### PR TITLE
Add slots to customer show

### DIFF
--- a/packages/admin/resources/views/livewire/components/customers/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/customers/show.blade.php
@@ -9,6 +9,15 @@
         <div class="xl:w-1/3">
             <div class="bg-white rounded shadow">
                 <div class="p-4 space-y-4">
+                
+                    @foreach ($this->getSlotsByPosition('top') as $slot)
+                        <div id="{{ $slot->handle }}">
+                            <div>
+                                @livewire($slot->component, ['slotModel' => $customer], key('top-slot-' . $slot->handle))
+                            </div>
+                        </div>
+                    @endforeach                
+                
                     <div class="grid grid-cols-3 gap-4">
                         <div>
                             <x-hub::input.group for="title"
@@ -68,6 +77,14 @@
                         @include('adminhub::partials.attributes', ['inline' => true])
                     </div>
                 </div>
+                
+                @foreach ($this->getSlotsByPosition('bottom') as $slot)
+                    <div id="{{ $slot->handle }}">
+                        <div>
+                            @livewire($slot->component, ['slotModel' => $customer], key('top-slot-' . $slot->handle))
+                        </div>
+                    </div>
+                @endforeach  
 
                 <div class="p-4 text-right rounded-b bg-gray-50">
                     <x-hub::button type="button"

--- a/packages/admin/src/Http/Livewire/Components/Customers/CustomerShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Customers/CustomerShow.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Password;
 use Livewire\Component;
 use Livewire\WithPagination;
 use Lunar\DataTypes\Price;
+use Lunar\Hub\Http\Livewire\Traits\HasSlots;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Hub\Http\Livewire\Traits\WithAttributes;
 use Lunar\Hub\Http\Livewire\Traits\WithCountries;
@@ -24,6 +25,7 @@ use Lunar\Models\State;
 
 class CustomerShow extends Component
 {
+    use HasSlots;
     use Notifies;
     use WithAttributes;
     use WithPagination;
@@ -181,6 +183,13 @@ class CustomerShow extends Component
     {
         return Attribute::whereAttributeType(Customer::class)->orderBy('position')->get();
     }
+    
+    protected function getListeners()
+    {
+        return array_merge([],
+            $this->getHasSlotsListeners()
+        );
+    }
 
     /**
      * Save the customer record.
@@ -198,6 +207,8 @@ class CustomerShow extends Component
         $this->customer->attribute_data = $this->prepareAttributeData();
 
         $this->customer->save();
+        
+        $this->updateSlots();
 
         $this->notify(
             __('adminhub::notifications.customer.updated')
@@ -543,5 +554,25 @@ class CustomerShow extends Component
     {
         return view('adminhub::livewire.components.customers.show')
             ->layout('adminhub::layouts.base');
+    }
+    
+    /*
+     * Returns the model which has slots associated.
+     *
+     * @return \Lunar\Models\Customer
+     */
+    protected function getSlotModel()
+    {
+        return $this->customer;
+    }
+
+    /**
+     * Returns the contexts for any slots.
+     *
+     * @return array
+     */
+    protected function getSlotContexts()
+    {
+        return ['customer.show'];
     }
 }

--- a/packages/admin/src/Http/Livewire/Components/Customers/CustomerShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Customers/CustomerShow.php
@@ -183,7 +183,7 @@ class CustomerShow extends Component
     {
         return Attribute::whereAttributeType(Customer::class)->orderBy('position')->get();
     }
-    
+
     protected function getListeners()
     {
         return array_merge([],
@@ -207,7 +207,7 @@ class CustomerShow extends Component
         $this->customer->attribute_data = $this->prepareAttributeData();
 
         $this->customer->save();
-        
+
         $this->updateSlots();
 
         $this->notify(
@@ -555,7 +555,7 @@ class CustomerShow extends Component
         return view('adminhub::livewire.components.customers.show')
             ->layout('adminhub::layouts.base');
     }
-    
+
     /*
      * Returns the model which has slots associated.
      *


### PR DESCRIPTION
This PR brings slots to the customer show view (with context `customer.show`).
As a future iteration - it would be amazing to make the tabs on the page slot-able