### PR TITLE
Hotfix - Remove inert on trap

### DIFF
--- a/packages/admin/resources/views/components/modal.blade.php
+++ b/packages/admin/resources/views/components/modal.blade.php
@@ -36,7 +36,7 @@ switch ($maxWidth ?? '2xl') {
 
     <div x-cloak
          x-show="show"
-         x-trap.inert.noscroll="show"
+         x-trap.noscroll="show"
          x-on:click.away="show = false"
          x-init="$watch('show', (isShown) => isShown && $focus.first())"
          x-transition

--- a/packages/admin/resources/views/components/slideover-simple.blade.php
+++ b/packages/admin/resources/views/components/slideover-simple.blade.php
@@ -8,7 +8,7 @@
 
     <div class="fixed inset-0 z-40 flex"
          x-show="{{ $target }}"
-         x-trap.inert.noscroll="{{ $target }}"
+         x-trap.noscroll="{{ $target }}"
          x-on:click.away="{{ $target }} = false"
          x-cloak
          x-transition:enter="transition ease-out duration-300"

--- a/packages/admin/resources/views/components/slideover.blade.php
+++ b/packages/admin/resources/views/components/slideover.blade.php
@@ -23,7 +23,7 @@
 
         <div class="fixed inset-y-0 right-0 flex max-w-full pl-10">
             <div x-show="show"
-                 x-trap.inert.noscroll="show"
+                 x-trap.noscroll="show"
                  x-on:click.away="show = false"
                  x-cloak
                  x-init="$watch('show', (isShown) => isShown && $focus.first())"


### PR DESCRIPTION
The modifier `inert` applies `aria-hidden` to all elements outside of the modal, it's recommended but not necessary.

I believe this to be the culprit, it's much faster without it.