### PR TITLE
Add ability to remove a shipping modifier

### DIFF
--- a/packages/core/src/Base/ShippingModifiers.php
+++ b/packages/core/src/Base/ShippingModifiers.php
@@ -41,4 +41,15 @@ class ShippingModifiers
     {
         $this->modifiers->push($modifier);
     }
+    
+    /**
+     * Remove a shipping modifier.
+     *
+     * @param $modifier Class reference to the modifier.
+     * @return void
+     */
+    public function remove($modifier)
+    {
+        $this->modifiers->forget($modifier);
+    }
 }

--- a/packages/core/src/Base/ShippingModifiers.php
+++ b/packages/core/src/Base/ShippingModifiers.php
@@ -41,7 +41,7 @@ class ShippingModifiers
     {
         $this->modifiers->push($modifier);
     }
-    
+
     /**
      * Remove a shipping modifier.
      *


### PR DESCRIPTION
Similar to the change previously merged to allow cart line and cart modifiers to be removed, this allows shipping modifiers to be removed.

Again the same use case - we have an external service creating orders so we dont want processing to be run on those.