### PR TITLE
Hotfix - Fix up state upgrading

### DIFF
--- a/docs/src/lunar/products.md
+++ b/docs/src/lunar/products.md
@@ -14,7 +14,7 @@ Products also belong to a `ProductType` and aside from the attributes, which you
 Lunar\Models\Product::create([
     'product_type_id' => $productTypeId,
     'status' => 'published',
-    'brand' => 'Foo',
+    'brand_id' => $brandId,
     'attribute_data' => [
         'name' => new TranslatedText(collect([
             'en' => new Text('FooBar'),
@@ -601,7 +601,7 @@ This example assumes we already have Attributes set up for name and description 
 Lunar\Models\Product::create([
     'product_type_id' => $productType->id,
     'status' => 'published',
-    'brand' => 'Dr. Martens',
+    'brand_id' => $brandId,
     'sku' => 'DRBOOT',
     'attribute_data' => [
         'name' => new TranslatedText(collect([

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -98,12 +98,10 @@ class ProductCreateTest extends TestCase
 
         $productB = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'PROB',
         ]);
 
         $productC = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'PROC',
         ]);
 
         $brand = Brand::factory()->create();

--- a/packages/admin/tests/Unit/Http/Livewire/Traits/HasPricesTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Traits/HasPricesTest.php
@@ -56,7 +56,6 @@ class HasPricesTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([

--- a/packages/admin/tests/Unit/Http/Livewire/Traits/WithLanguagesTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Traits/WithLanguagesTest.php
@@ -56,7 +56,6 @@ class WithLanguagesTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([

--- a/packages/core/database/factories/ProductFactory.php
+++ b/packages/core/database/factories/ProductFactory.php
@@ -4,6 +4,7 @@ namespace Lunar\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Lunar\FieldTypes\Text;
+use Lunar\Models\Brand;
 use Lunar\Models\Product;
 use Lunar\Models\ProductType;
 
@@ -16,7 +17,7 @@ class ProductFactory extends Factory
         return [
             'product_type_id' => ProductType::factory(),
             'status'          => 'published',
-            'brand'           => $this->faker->company,
+            'brand_id'        => Brand::factory()->create()->id,
             'attribute_data'  => collect([
                 'name'        => new Text($this->faker->name),
                 'description' => new Text($this->faker->sentence),

--- a/packages/core/database/migrations/2022_08_09_100002_add_brand_id_to_products_table.php
+++ b/packages/core/database/migrations/2022_08_09_100002_add_brand_id_to_products_table.php
@@ -13,11 +13,16 @@ class AddBrandIdToProductsTable extends Migration
                   ->nullable()
                   ->constrained($this->prefix.'brands');
         });
+
+        Schema::table($this->prefix.'products', function (Blueprint $table) {
+            $table->dropColumn('brand');
+        });
     }
 
     public function down()
     {
         Schema::table($this->prefix.'products', function ($table) {
+            $table->dropForeign(['brand_id']);
             $table->dropColumn('brand_id');
         });
     }

--- a/packages/core/database/state/ConvertProductTypeAttributesToProducts.php
+++ b/packages/core/database/state/ConvertProductTypeAttributesToProducts.php
@@ -9,6 +9,11 @@ use Lunar\Models\ProductType;
 
 class ConvertProductTypeAttributesToProducts
 {
+    public function prepare()
+    {
+        //
+    }
+
     public function run()
     {
         $prefix = config('lunar.database.table_prefix');

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -36,7 +36,7 @@ class EnsureBrandsAreUpgraded
             $brands[$brand][] = $productId;
         }
 
-        Storage::disk('local')->put('legacy_brands.json', json_encode($brands));
+        Storage::put('tmp/state/legacy_brands.json', json_encode($brands));
     }
 
     public function run()
@@ -45,10 +45,12 @@ class EnsureBrandsAreUpgraded
             return;
         }
 
-        $brands = Storage::disk('local')->get('legacy_brands.json');
+        $brands = Storage::get('tmp/state/legacy_brands.json');
 
         if ($brands) {
             $brands = json_decode($brands);
+
+            dd($brands, 1);
 
             foreach ($brands as $brandName => $productIds) {
                 $brand = Brand::firstOrCreate([

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Database\State;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Lunar\Models\Brand;
@@ -45,12 +46,16 @@ class EnsureBrandsAreUpgraded
             return;
         }
 
-        $brands = Storage::get('tmp/state/legacy_brands.json');
+        $brands = null;
+
+        try {
+            $brands = Storage::get('tmp/state/legacy_brands.json');
+        } catch (FileNotFoundException $e) {
+            // $brands = null;
+        }
 
         if ($brands) {
             $brands = json_decode($brands);
-
-            dd($brands, 1);
 
             foreach ($brands as $brandName => $productIds) {
                 $brand = Brand::firstOrCreate([

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -36,7 +36,7 @@ class EnsureBrandsAreUpgraded
             $brands[$brand][] = $productId;
         }
 
-        Storage::put('legacy_brands.json', json_encode($brands));
+        Storage::disk('local')->put('legacy_brands.json', json_encode($brands));
     }
 
     public function run()
@@ -45,7 +45,7 @@ class EnsureBrandsAreUpgraded
             return;
         }
 
-        $brands = Storage::get('legacy_brands.json');
+        $brands = Storage::disk('local')->get('legacy_brands.json');
 
         if ($brands) {
             $brands = json_decode($brands);
@@ -61,7 +61,7 @@ class EnsureBrandsAreUpgraded
             }
         }
 
-        Storage::delete('legacy_brands.json');
+        Storage::disk('local')->delete('legacy_brands.json');
     }
 
     protected function canRun()

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -36,7 +36,7 @@ class EnsureBrandsAreUpgraded
             $brands[$brand][] = $productId;
         }
 
-        Storage::put('tmp/state/legacy_brands.json', json_encode($brands));
+        Storage::put('legacy_brands.json', json_encode($brands));
     }
 
     public function run()
@@ -45,7 +45,7 @@ class EnsureBrandsAreUpgraded
             return;
         }
 
-        $brands = Storage::get('tmp/state/legacy_brands.json');
+        $brands = Storage::get('legacy_brands.json');
 
         if ($brands) {
             $brands = json_decode($brands);
@@ -61,7 +61,7 @@ class EnsureBrandsAreUpgraded
             }
         }
 
-        Storage::delete('tmp/state/legacy_brands.json');
+        Storage::delete('legacy_brands.json');
     }
 
     protected function canRun()

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -51,7 +51,6 @@ class EnsureBrandsAreUpgraded
         try {
             $brands = Storage::get('tmp/state/legacy_brands.json');
         } catch (FileNotFoundException $e) {
-            // $brands = null;
         }
 
         if ($brands) {
@@ -68,7 +67,7 @@ class EnsureBrandsAreUpgraded
             }
         }
 
-        Storage::disk('local')->delete('legacy_brands.json');
+        Storage::disk('local')->delete('tmp/state/legacy_brands.json');
     }
 
     protected function canRun()

--- a/packages/core/database/state/EnsureDefaultTaxClassExists.php
+++ b/packages/core/database/state/EnsureDefaultTaxClassExists.php
@@ -7,6 +7,11 @@ use Lunar\Models\TaxClass;
 
 class EnsureDefaultTaxClassExists
 {
+    public function prepare()
+    {
+        //
+    }
+
     public function run()
     {
         if (! $this->canRun() || ! $this->shouldRun()) {

--- a/packages/core/database/state/EnsureMediaCollectionsAreRenamed.php
+++ b/packages/core/database/state/EnsureMediaCollectionsAreRenamed.php
@@ -3,12 +3,18 @@
 namespace Lunar\Database\State;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Lunar\Models\Brand;
 use Lunar\Models\Collection;
 use Lunar\Models\Product;
 
 class EnsureMediaCollectionsAreRenamed
 {
+    public function prepare()
+    {
+        //
+    }
+
     public function run()
     {
         if (! $this->shouldRun()) {
@@ -20,7 +26,7 @@ class EnsureMediaCollectionsAreRenamed
 
     protected function shouldRun()
     {
-        return $this->getOutdatedMediaQuery()->count();
+        return Schema::hasTable('media') && $this->getOutdatedMediaQuery()->count();
     }
 
     /**

--- a/packages/core/database/state/EnsureUserOrdersHaveACustomer.php
+++ b/packages/core/database/state/EnsureUserOrdersHaveACustomer.php
@@ -8,6 +8,11 @@ use Lunar\Models\Order;
 
 class EnsureUserOrdersHaveACustomer
 {
+    public function prepare()
+    {
+        //
+    }
+
     public function run()
     {
         if (! $this->canRun()) {

--- a/packages/core/phpunit.xml
+++ b/packages/core/phpunit.xml
@@ -25,6 +25,9 @@
     <testsuite name="Feature">
       <directory suffix="Test.php">./tests/Feature</directory>
     </testsuite>
+    <testsuite name="Database">
+      <directory suffix="Test.php">./tests/Database</directory>
+    </testsuite>
   </testsuites>
   <php>
     <env name="DB_CONNECTION" value="testing"/>

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -5,7 +5,6 @@ namespace Lunar\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
-use Lunar\Base\Traits\HasChannels;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
 use Lunar\Base\Traits\HasUrls;
@@ -18,7 +17,6 @@ class Brand extends BaseModel implements SpatieHasMedia
 {
     use HasFactory,
         HasMedia,
-        HasChannels,
         HasUrls,
         Searchable,
         LogsActivity,

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -22,9 +22,7 @@ class EnsureBrandsAreUpgradedTest extends TestCase
     /** @test */
     public function can_run()
     {
-        Storage::fake();
-
-
+        Storage::fake('app');
 
         $prefix = config('lunar.database.table_prefix');
         Schema::dropIfExists("{$prefix}brands");
@@ -71,15 +69,6 @@ class EnsureBrandsAreUpgradedTest extends TestCase
             ]),
         ]);
 
-        Storage::put('tmp/state/legacy_brands.json', json_encode([
-            'Brand A' => [
-                $pa->id,
-                $pb->id,
-            ],
-            'Brand B' => [
-                $pc->id,
-            ],
-        ]));
 
         $this->assertDatabaseHas((new Product)->getTable(), [
             'brand' => 'Brand A',

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -5,6 +5,7 @@ namespace Lunar\Tests\Database\State;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 use Lunar\FieldTypes\Text;
 use Lunar\Models\Brand;
 use Lunar\Models\Product;
@@ -21,6 +22,10 @@ class EnsureBrandsAreUpgradedTest extends TestCase
     /** @test */
     public function can_run()
     {
+        Storage::fake();
+
+
+
         $prefix = config('lunar.database.table_prefix');
         Schema::dropIfExists("{$prefix}brands");
 
@@ -39,7 +44,7 @@ class EnsureBrandsAreUpgradedTest extends TestCase
 
         $productType = ProductType::factory()->create();
 
-        Product::forceCreate([
+        $pa = Product::forceCreate([
             'brand' => 'Brand A',
             'product_type_id' => $productType->id,
             'status'          => 'published',
@@ -48,7 +53,7 @@ class EnsureBrandsAreUpgradedTest extends TestCase
             ]),
         ]);
 
-        Product::forceCreate([
+        $pb = Product::forceCreate([
             'brand' => 'Brand A',
             'product_type_id' => $productType->id,
             'status'          => 'published',
@@ -57,7 +62,7 @@ class EnsureBrandsAreUpgradedTest extends TestCase
             ]),
         ]);
 
-        Product::forceCreate([
+        $pc = Product::forceCreate([
             'brand' => 'Brand B',
             'product_type_id' => $productType->id,
             'status'          => 'published',
@@ -65,6 +70,16 @@ class EnsureBrandsAreUpgradedTest extends TestCase
                 'name'        => new Text('Product C'),
             ]),
         ]);
+
+        Storage::put('tmp/state/legacy_brands.json', json_encode([
+            'Brand A' => [
+                $pa->id,
+                $pb->id,
+            ],
+            'Brand B' => [
+                $pc->id,
+            ],
+        ]));
 
         $this->assertDatabaseHas((new Product)->getTable(), [
             'brand' => 'Brand A',

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -22,7 +22,7 @@ class EnsureBrandsAreUpgradedTest extends TestCase
     /** @test */
     public function can_run()
     {
-        Storage::fake('app');
+        Storage::fake('local');
 
         $prefix = config('lunar.database.table_prefix');
         Schema::dropIfExists("{$prefix}brands");

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -69,7 +69,6 @@ class EnsureBrandsAreUpgradedTest extends TestCase
             ]),
         ]);
 
-
         $this->assertDatabaseHas((new Product)->getTable(), [
             'brand' => 'Brand A',
         ]);

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Lunar\Tests\Database\State;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Lunar\FieldTypes\Text;
+use Lunar\Models\Brand;
+use Lunar\Models\Product;
+use Lunar\Models\ProductType;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group database.state
+ */
+class EnsureBrandsAreUpgradedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_run()
+    {
+        $prefix = config('lunar.database.table_prefix');
+        Schema::dropIfExists("{$prefix}brands");
+
+        Schema::table("{$prefix}products", function ($table) {
+            $table->dropColumn('brand_id');
+        });
+
+        Schema::table("{$prefix}products", function ($table) {
+            $table->string('brand')->nullable();
+        });
+
+        DB::table('migrations')->whereIn('migration', [
+            '2022_08_09_100001_create_brands_table',
+            '2022_08_09_100002_add_brand_id_to_products_table',
+        ])->delete();
+
+        $productType = ProductType::factory()->create();
+
+        Product::forceCreate([
+            'brand' => 'Brand A',
+            'product_type_id' => $productType->id,
+            'status'          => 'published',
+            'attribute_data'  => collect([
+                'name'        => new Text('Product A'),
+            ]),
+        ]);
+
+        Product::forceCreate([
+            'brand' => 'Brand A',
+            'product_type_id' => $productType->id,
+            'status'          => 'published',
+            'attribute_data'  => collect([
+                'name'        => new Text('Product B'),
+            ]),
+        ]);
+
+        Product::forceCreate([
+            'brand' => 'Brand B',
+            'product_type_id' => $productType->id,
+            'status'          => 'published',
+            'attribute_data'  => collect([
+                'name'        => new Text('Product C'),
+            ]),
+        ]);
+
+        $this->assertDatabaseHas((new Product)->getTable(), [
+            'brand' => 'Brand A',
+        ]);
+
+        $this->artisan('migrate');
+
+        $this->assertDatabaseHas((new Brand)->getTable(), [
+            'name' => 'Brand A',
+        ]);
+
+        $this->assertDatabaseHas((new Brand)->getTable(), [
+            'name' => 'Brand B',
+        ]);
+
+        $brandA = Brand::whereName('Brand A')->first();
+        $brandB = Brand::whereName('Brand B')->first();
+
+        $this->assertCount(2, Product::whereBrandId($brandA->id)->get());
+        $this->assertCount(1, Product::whereBrandId($brandB->id)->get());
+    }
+}

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -38,7 +38,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         // perform environment setup
-        $app->useStoragePath(realpath(__DIR__.'/../../storage/tmp/state/legacy_brands.json'));
+        // $app->useStoragePath(realpath(__DIR__.'/../../storage/tmp/state/legacy_brands.json'));
+
+        // dd($app['config']);
     }
 
     /**

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -38,7 +38,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         // perform environment setup
-        // $app->useStoragePath(realpath(__DIR__.'/../../storage/tmp/state/legacy_brands.json'));
+        $app->useStoragePath(realpath(__DIR__.'/../../storage'));
 
         // dd($app['config']);
     }

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -37,7 +37,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function getEnvironmentSetUp($app)
     {
-        dd($app['config']);
         // perform environment setup
     }
 

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -38,7 +38,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         // perform environment setup
-        $app->useStoragePath(realpath(__DIR__.'/../../storage'));
+        $app->useStoragePath(realpath(__DIR__.'/../../storage/tmp/state/legacy_brands.json'));
     }
 
     /**

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -38,6 +38,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         // perform environment setup
+        $app->useStoragePath(realpath(__DIR__.'/../../storage'));
     }
 
     /**

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -37,10 +37,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function getEnvironmentSetUp($app)
     {
+        dd($app['config']);
         // perform environment setup
-        $app->useStoragePath(realpath(__DIR__.'/../../storage'));
-
-        // dd($app['config']);
     }
 
     /**

--- a/packages/core/tests/Unit/Managers/PricingManagerTest.php
+++ b/packages/core/tests/Unit/Managers/PricingManagerTest.php
@@ -42,7 +42,6 @@ class PricingManagerTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([
@@ -95,7 +94,6 @@ class PricingManagerTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([
@@ -131,7 +129,6 @@ class PricingManagerTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([
@@ -184,7 +181,6 @@ class PricingManagerTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([
@@ -281,7 +277,6 @@ class PricingManagerTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([
@@ -333,7 +328,6 @@ class PricingManagerTest extends TestCase
 
         $product = Product::factory()->create([
             'status' => 'published',
-            'brand'  => 'BAR',
         ]);
 
         $variant = ProductVariant::factory()->create([

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -5,6 +5,7 @@ namespace Lunar\Tests\Unit\Models;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Lunar\Models\Brand;
 use Lunar\Models\Channel;
 use Lunar\Models\Collection;
 use Lunar\Models\CustomerGroup;
@@ -72,7 +73,11 @@ class ProductTest extends TestCase
     {
         $channel = Channel::factory()->create();
 
-        $product = Product::factory()->create();
+        $brand = Brand::factory()->create();
+
+        $product = Product::factory()->create([
+            'brand_id' => $brand->id,
+        ]);
 
         $publishDate = now()->addDays(1);
 


### PR DESCRIPTION
There are some issues currently when running state up dates that have resulting in some schema updates being added to the state management classes that run after migrations have happened.

Schema updates should only happen in migrations otherwise they can be missed and as a result won't run. An example of this was for the brand update, on a fresh install the `brand` column on products wasn't being removed.

The PR looks to make some tweaks to the way the state is managed. 


### Additional `prepare` method required on state classes

This method will be triggered before any outstanding migrations are run, this will give developers the chance to grab any data and store it against the class before the `run` method is triggered.

For example:

```php
<?php

namespace Lunar\Database\State;

use Lunar\Models\Product;

class DoSomethingToTheDatabaseData
{
	/**
	 * The legacy brands to import.
	 *
	 * @var array
	 */
	protected $legacyBrands = [];

	public function prepare()
	{
		$this->data = Product::get();
	}

	public function run()
	{
		foreach ($this->data as $row) {
			// Do something...
		}
	}
}
```