### PR TITLE
Hotfix - Register table builder singletons

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Registered missing table builders as singletons.
+
 ## 0.1.0-rc.3
 
 ### Changed

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -104,7 +104,11 @@ use Lunar\Hub\Menu\OrderActionsMenu;
 use Lunar\Hub\Menu\SettingsMenu;
 use Lunar\Hub\Menu\SidebarMenu;
 use Lunar\Hub\Menu\SlotRegistry;
+use Lunar\Hub\Tables\Builders\CustomersTableBuilder;
 use Lunar\Hub\Tables\Builders\OrdersTableBuilder;
+use Lunar\Hub\Tables\Builders\ProductsTableBuilder;
+use Lunar\Hub\Tables\Builders\ProductTypesTableBuilder;
+use Lunar\Hub\Tables\Builders\ProductVariantsTableBuilder;
 use Lunar\Hub\Tables\Orders;
 use Lunar\Models\Product;
 
@@ -145,9 +149,19 @@ class AdminHubServiceProvider extends ServiceProvider
             return new ActivityLogManifest();
         });
 
-        $this->app->singleton(OrdersTableBuilder::class, function ($app) {
-            return new OrdersTableBuilder;
-        });
+        $tableBuilders = [
+            CustomersTableBuilder::class,
+            OrdersTableBuilder::class,
+            ProductsTableBuilder::class,
+            ProductTypesTableBuilder::class,
+            ProductVariantsTableBuilder::class,
+        ];
+
+        foreach ($tableBuilders as $tableBuilder) {
+            $this->app->singleton($tableBuilder, function ($app) use ($tableBuilder) {
+                return new $tableBuilder;
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Table builder classes need to be singletons to allow for customisation, some were missing so this PR looks to fix that.
