### PR TITLE
Hotfix - Add fixes for migrating old GetCandy brands

### DIFF
--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Lunar\Models\Brand;
+use Lunar\Models\Language;
 use Lunar\Models\Product;
 
 class EnsureBrandsAreUpgraded
@@ -17,7 +18,7 @@ class EnsureBrandsAreUpgraded
         $hasBrandsTable = Schema::hasTable("{$prefix}brands");
         $hasProductsTable = Schema::hasTable("{$prefix}products");
 
-        if ($hasBrandsTable || ! $hasProductsTable) {
+        if ($hasBrandsTable || ! $hasProductsTable || ! Language::count()) {
             return;
         }
 

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Lunar\FieldTypes\Text;
 use Lunar\Models\Brand;
+use Lunar\Models\Language;
 use Lunar\Models\Product;
 use Lunar\Models\ProductType;
 use Lunar\Tests\TestCase;
@@ -23,6 +24,10 @@ class EnsureBrandsAreUpgradedTest extends TestCase
     public function can_run()
     {
         Storage::fake('local');
+
+        Language::factory()->create([
+            'default' => true,
+        ]);
 
         $prefix = config('lunar.database.table_prefix');
         Schema::dropIfExists("{$prefix}brands");


### PR DESCRIPTION
When running the migration command from GetCandy to Lunar, the brand changes weren't present in the last version for GetCandy, meaning the database copying simply won't work.

There was also an issue where the state update class for brands was trying to generate URLs during this process when it didn't have the data it needed.

This PR looks to address those issues.