### PR TITLE
Update EnsureBrandsAreUpgraded.php

### DIFF
--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -13,7 +13,7 @@ class EnsureBrandsAreUpgraded
 {
     public function prepare()
     {
-        if (! $this->canRun()) {
+        if (! $this->canRun() || ! $this->shouldRun()) {
             return;
         }
 

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -13,12 +13,7 @@ class EnsureBrandsAreUpgraded
 {
     public function prepare()
     {
-        $prefix = config('lunar.database.table_prefix');
-
-        $hasBrandsTable = Schema::hasTable("{$prefix}brands");
-        $hasProductsTable = Schema::hasTable("{$prefix}products");
-
-        if ($hasBrandsTable || ! $hasProductsTable || ! Language::count()) {
+        if (! $this->canRun()) {
             return;
         }
 
@@ -75,7 +70,10 @@ class EnsureBrandsAreUpgraded
     {
         $prefix = config('lunar.database.table_prefix');
 
-        return Schema::hasTable("{$prefix}brands");
+        $hasBrandsTable = Schema::hasTable("{$prefix}brands");
+        $hasProductsTable = Schema::hasTable("{$prefix}products");
+
+        return $hasBrandsTable && $hasProductsTable && Language::count();
     }
 
     protected function shouldRun()

--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -13,7 +13,7 @@ class EnsureBrandsAreUpgraded
 {
     public function prepare()
     {
-        if (! $this->canRun() || ! $this->shouldRun()) {
+        if (! $this->canPrepare()) {
             return;
         }
 
@@ -64,6 +64,16 @@ class EnsureBrandsAreUpgraded
         }
 
         Storage::disk('local')->delete('tmp/state/legacy_brands.json');
+    }
+
+    protected function canPrepare()
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        $hasBrandsTable = Schema::hasTable("{$prefix}brands");
+        $hasProductsTable = Schema::hasTable("{$prefix}products");
+
+        return ! $hasBrandsTable && $hasProductsTable && Language::count();
     }
 
     protected function canRun()


### PR DESCRIPTION
Adding `Language::count()` check to `canRun()` to ensure this waits to run until after the data has been moved over to the `lunar_` prefix tables. Removing duplicated code by making use of `canRun()` in `prepare()`.

As the presence of a language wasn't being checked as part of the `run()` function's `canRun`/`shouldRun` checks, it was still able to proceed and hit the `Brand::firstOrCreate` line without a default language being available.