### PR TITLE
Hotfix - Fix language code duplication on tests

### DIFF
--- a/packages/core/database/factories/LanguageFactory.php
+++ b/packages/core/database/factories/LanguageFactory.php
@@ -3,7 +3,6 @@
 namespace Lunar\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 use Lunar\Models\Language;
 
 class LanguageFactory extends Factory
@@ -13,7 +12,7 @@ class LanguageFactory extends Factory
     public function definition(): array
     {
         return [
-            'code'    => Str::random(4),
+            'code'    => $this->faker->unique()->languageCode,
             'name'    => $this->faker->name(),
             'default' => true,
         ];

--- a/packages/core/database/factories/LanguageFactory.php
+++ b/packages/core/database/factories/LanguageFactory.php
@@ -13,7 +13,7 @@ class LanguageFactory extends Factory
     public function definition(): array
     {
         return [
-            'code'    => Str::random(2),
+            'code'    => Str::random(4),
             'name'    => $this->faker->name(),
             'default' => true,
         ];


### PR DESCRIPTION
Sometimes when the tests run they will fail due to a duplicated language code, seems that `Str::random(2)` was a bit too short.

This PR will make use of `$this->faker->unique()->languageCode`