### PR TITLE
Hotfix - Add check for Sqlite before adding full text index

### DIFF
--- a/utils/scout-database-engine/database/migrations/2022_08_30_000000_create_search_index_table.php
+++ b/utils/scout-database-engine/database/migrations/2022_08_30_000000_create_search_index_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -21,7 +22,9 @@ return new class extends Migration
             $table->text('content');
             $table->timestamps();
 
-            $table->fullText('content');
+            if (DB::getDriverName() !== 'sqlite') {
+                $table->fullText('content');
+            }
         });
     }
 


### PR DESCRIPTION
SQLite doesn't support fulltext indexes, since we're auto registering migrations, any tests in a Laravel app will be blocked when they try and run.