### PR TITLE
Fix passing options to Quill editor

### DIFF
--- a/packages/admin/resources/views/components/input/richtext.blade.php
+++ b/packages/admin/resources/views/components/input/richtext.blade.php
@@ -3,7 +3,7 @@
     x-data="{
         value: @entangle($attributes->wire('model')),
         init() {
-          {{ $instanceId }} = new Quill($refs.editor, {{ json_encode($options) }})
+          {{ $instanceId }} = new Quill($refs.editor, {!! str_replace('"', "'", json_encode($options)) !!})
 
           {{ $instanceId }}.on('text-change', () => {
             $dispatch('quill-input', {{ $instanceId }}.root.innerHTML)


### PR DESCRIPTION
This previously wasnt working as the json string was being html encoded, but the quotes also need replaced to be alpine-friendly.