### PR TITLE
Update package split and tagging to support multiple branches

### DIFF
--- a/.github/workflows/split_packages.yml
+++ b/.github/workflows/split_packages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - '0.*'
     tags:
       - '*'
 jobs:
@@ -15,6 +16,7 @@ jobs:
           'core'
         ]
     steps:
+
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
@@ -30,7 +32,7 @@ jobs:
           repository_name: '${{ matrix.package }}'
           user_name: "GitHub Action"
           user_email: "action@github.com"
-          branch: "main"
+          branch: ${GITHUB_REF#refs/heads/}
 
       - name: Tag ${{ matrix.package }}
         if: "startsWith(github.ref, 'refs/tags/')"
@@ -44,7 +46,7 @@ jobs:
           repository_name: '${{ matrix.package }}'
           user_name: "GitHub Action"
           user_email: "action@github.com"
-          branch: "main"
+          branch: ${GITHUB_REF#refs/heads/}
 
   split_utils:
     runs-on: ubuntu-latest
@@ -70,4 +72,18 @@ jobs:
           repository_name: '${{ matrix.package }}'
           user_name: "GitHub Action"
           user_email: "action@github.com"
-          branch: "main"
+          branch: ${GITHUB_REF#refs/heads/}
+
+      - name: Tag ${{ matrix.package }}
+        if: "startsWith(github.ref, 'refs/tags/')"
+        uses: symplify/github-action-monorepo-split@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        with:
+          tag: ${GITHUB_REF#refs/tags/}
+          package_directory: 'utils/${{ matrix.package }}'
+          repository_organization: 'lunarphp'
+          repository_name: '${{ matrix.package }}'
+          user_name: "GitHub Action"
+          user_email: "action@github.com"
+          branch: ${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
Currently when we tag a release or push to `main` it's restricted to that branch. Going forward we want to have multiple branches across versions to help with on going support.

This PR looks to update the package splitting and tagging to reference the branch it relates so, so in theory we should be able to create other branches such as `0.1` and create tags off those branches and they be split appropriately...