### PR TITLE
Feature/extend Lunar Migrate Command

### DIFF
--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -139,6 +139,11 @@ We have created a command for this purpose to try make the switch as easy as pos
 php artisan lunar:migrate:getcandy
 ```
 
+#### Instructions for Custom Application (Optional)
+We realise that developers may have added their own fields to a number of the `getcandy_` tables.
+In order for your upgrade to include the custom fields. Please move any migration files which previously extended GetCandy over to `database/migrations/upgrade`
+Next step you will need to change the migration namespace from `GetCandy\Base\Migration` to `Lunar\Base\Migration`
+
 #### What this command will do
 
 - Remove any previous GetCandy migrations from the `migrations` table.
@@ -146,6 +151,9 @@ php artisan lunar:migrate:getcandy
 - Copy across the data from the old `getcandy_` tables into the new `lunar_` tables.
 - Update any polymorphic `GetCandy` classes to the `Lunar` namespace.
 - Update field types in `attribute_data` to the `Lunar` namespace.
+- Remove previous GetCandy migrations located in `database/migrations/upgrade` from the migrations table.
+- Run the upgrade migrations again with the lunar_ prefix, updating the new tables.
+- By default, this command will remove the `getcandy_` tables once checking the data has been transferred.
 
 
 #### What this command will not do
@@ -155,4 +163,4 @@ php artisan lunar:migrate:getcandy
 ---
 
 The intention of this is to provide a non-destructive way to migrate the data. Once the command has been run
-your `getcandy_` tables should remain intact, so you are free to check the data and remove when ready.
+your `getcandy_` tables will be removed only once checking data integrity across the old and new tables. You can opt out of this by passing `--cleanup=false`. 


### PR DESCRIPTION
Please describe your Pull Request as best as possible, explaining what it provides and why it is of value, referencing any related Issues.

Try to include the following in your Pull Request, where applicable...

- Documentation updates
- Automated tests
- Changelog entries (core and hub)

@alecritson Your current command works very well when there are no modifications made to getcandy tables.
However when developers have customisations across multiple tables the command fails when trying to add the additional columns and data over to lunar tables.

This PR solves this issue by allowing the developer to prepare their upgrade migrations which will then be processed once the lunar tables have been created but before copying over the data.

I think we should remove the old getcandy details once we have confirmed each table has the same number of records.
By default I have set cleanup to true, however you can opt out by setting `--cleanup=false`

Docs have been updated to reflect all these changes.