### PR TITLE
Allow to override Lunar table component namespace

### DIFF
--- a/packages/admin/config/system.php
+++ b/packages/admin/config/system.php
@@ -1,5 +1,8 @@
 <?php
 
 return [
+    'components_namespace' => [
+        'tables' => 'Lunar\\Hub\\Http\\Livewire\\Components',
+    ],
     'path' => 'hub',
 ];

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -22,7 +22,6 @@ use Lunar\Hub\Http\Livewire\Components\Authentication\PasswordReset;
 use Lunar\Hub\Http\Livewire\Components\Avatar;
 use Lunar\Hub\Http\Livewire\Components\Brands\BrandShow;
 use Lunar\Hub\Http\Livewire\Components\Brands\BrandsIndex;
-use Lunar\Hub\Http\Livewire\Components\Brands\BrandsTable;
 use Lunar\Hub\Http\Livewire\Components\Collections\CollectionGroupShow;
 use Lunar\Hub\Http\Livewire\Components\Collections\CollectionGroupsIndex;
 use Lunar\Hub\Http\Livewire\Components\Collections\CollectionShow;
@@ -32,13 +31,11 @@ use Lunar\Hub\Http\Livewire\Components\CollectionSearch;
 use Lunar\Hub\Http\Livewire\Components\CurrentStaffName;
 use Lunar\Hub\Http\Livewire\Components\Customers\CustomerShow;
 use Lunar\Hub\Http\Livewire\Components\Customers\CustomersIndex;
-use Lunar\Hub\Http\Livewire\Components\Customers\CustomersTable;
 use Lunar\Hub\Http\Livewire\Components\Orders\EmailNotification;
 use Lunar\Hub\Http\Livewire\Components\Orders\OrderCapture;
 use Lunar\Hub\Http\Livewire\Components\Orders\OrderRefund;
 use Lunar\Hub\Http\Livewire\Components\Orders\OrderShow;
 use Lunar\Hub\Http\Livewire\Components\Orders\OrdersIndex;
-use Lunar\Hub\Http\Livewire\Components\Orders\OrdersTable;
 use Lunar\Hub\Http\Livewire\Components\Orders\OrderStatus;
 use Lunar\Hub\Http\Livewire\Components\ProductOptions\OptionManager;
 use Lunar\Hub\Http\Livewire\Components\ProductOptions\OptionValueCreateModal;
@@ -51,9 +48,6 @@ use Lunar\Hub\Http\Livewire\Components\Products\ProductsIndex;
 use Lunar\Hub\Http\Livewire\Components\Products\ProductTypes\ProductTypeCreate;
 use Lunar\Hub\Http\Livewire\Components\Products\ProductTypes\ProductTypeShow;
 use Lunar\Hub\Http\Livewire\Components\Products\ProductTypes\ProductTypesIndex;
-use Lunar\Hub\Http\Livewire\Components\Products\Tables\ProductsTable;
-use Lunar\Hub\Http\Livewire\Components\Products\Tables\ProductTypesTable;
-use Lunar\Hub\Http\Livewire\Components\Products\Tables\ProductVariantsTable;
 use Lunar\Hub\Http\Livewire\Components\Products\Variants\Editing\Inventory;
 use Lunar\Hub\Http\Livewire\Components\Products\Variants\VariantShow;
 use Lunar\Hub\Http\Livewire\Components\Products\Variants\VariantSideMenu;
@@ -78,15 +72,6 @@ use Lunar\Hub\Http\Livewire\Components\Settings\Languages\LanguagesIndex;
 use Lunar\Hub\Http\Livewire\Components\Settings\Staff\StaffCreate;
 use Lunar\Hub\Http\Livewire\Components\Settings\Staff\StaffIndex;
 use Lunar\Hub\Http\Livewire\Components\Settings\Staff\StaffShow;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\ActivityLogTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\AddonsTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\AttributesTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\ChannelsTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\CurrenciesTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\LanguagesTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\StaffTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\TagsTable;
-use Lunar\Hub\Http\Livewire\Components\Settings\Tables\TaxZonesTable;
 use Lunar\Hub\Http\Livewire\Components\Settings\Tags\TagShow;
 use Lunar\Hub\Http\Livewire\Components\Settings\Tags\TagsIndex;
 use Lunar\Hub\Http\Livewire\Components\Settings\Taxes\TaxClassesIndex;
@@ -102,7 +87,6 @@ use Lunar\Hub\Menu\MenuRegistry;
 use Lunar\Hub\Menu\OrderActionsMenu;
 use Lunar\Hub\Menu\SettingsMenu;
 use Lunar\Hub\Menu\SidebarMenu;
-use Lunar\Hub\Menu\SlotRegistry;
 use Lunar\Hub\Tables\Builders\CustomersTableBuilder;
 use Lunar\Hub\Tables\Builders\OrdersTableBuilder;
 use Lunar\Hub\Tables\Builders\ProductsTableBuilder;
@@ -252,6 +236,9 @@ class AdminHubServiceProvider extends ServiceProvider
 
         // Blade Components
         Blade::componentNamespace('Lunar\\Hub\\Views\\Components', 'hub');
+
+        // Livewire Table Components
+        $this->registerLivewireTableComponents();
     }
 
     /**
@@ -292,14 +279,11 @@ class AdminHubServiceProvider extends ServiceProvider
         Livewire::component('hub.components.orders.status', OrderStatus::class);
         Livewire::component('hub.components.tables.actions.update-status', UpdateStatus::class);
         Livewire::component('hub.components.orders.emil-notification', EmailNotification::class);
-
-        Livewire::component('hub.components.orders.table', OrdersTable::class);
     }
 
     protected function registerCustomerComponents()
     {
         Livewire::component('hub.components.customers.index', CustomersIndex::class);
-        Livewire::component('hub.components.customers.table', CustomersTable::class);
         Livewire::component('hub.components.customers.show', CustomerShow::class);
     }
 
@@ -311,14 +295,12 @@ class AdminHubServiceProvider extends ServiceProvider
     protected function registerProductComponents()
     {
         Livewire::component('hub.components.products.index', ProductsIndex::class);
-        Livewire::component('hub.components.products.table', ProductsTable::class);
         Livewire::component('hub.components.products.show', ProductShow::class);
         Livewire::component('hub.components.products.create', ProductCreate::class);
 
         Livewire::component('hub.components.products.product-types.index', ProductTypesIndex::class);
         Livewire::component('hub.components.products.product-types.show', ProductTypeShow::class);
         Livewire::component('hub.components.products.product-types.create', ProductTypeCreate::class);
-        Livewire::component('hub.components.products.product-types.table', ProductTypesTable::class);
 
         Livewire::component('hub.components.products.editing.customer-groups', CustomerGroups::class);
 
@@ -327,7 +309,6 @@ class AdminHubServiceProvider extends ServiceProvider
 
         Livewire::component('hub.components.products.variants.side-menu', VariantSideMenu::class);
         Livewire::component('hub.components.products.variants.show', VariantShow::class);
-        Livewire::component('hub.components.products.variants.table', ProductVariantsTable::class);
         Livewire::component('hub.components.products.variants.editing.inventory', Inventory::class);
 
         Livewire::component('hub.components.product-options.option-manager', OptionManager::class);
@@ -342,7 +323,6 @@ class AdminHubServiceProvider extends ServiceProvider
     protected function registerBrandComponents()
     {
         Livewire::component('hub.components.brands.index', BrandsIndex::class);
-        Livewire::component('hub.components.brands.table', BrandsTable::class);
         Livewire::component('hub.components.brands.show', BrandShow::class);
     }
 
@@ -379,56 +359,94 @@ class AdminHubServiceProvider extends ServiceProvider
     {
         // Activity Log
         Livewire::component('hub.components.settings.activity-log.index', ActivityLogIndex::class);
-        Livewire::component('hub.components.settings.activity-log.table', ActivityLogTable::class);
 
         // Attributes
         Livewire::component('hub.components.settings.attributes.index', AttributesIndex::class);
         Livewire::component('hub.components.settings.attributes.show', AttributeShow::class);
         Livewire::component('hub.components.settings.attributes.attribute-group-edit', AttributeGroupEdit::class);
         Livewire::component('hub.components.settings.attributes.attribute-edit', AttributeEdit::class);
-        Livewire::component('hub.components.settings.attributes.table', AttributesTable::class);
 
         // Channels
         Livewire::component('hub.components.settings.channels.index', ChannelsIndex::class);
-        Livewire::component('hub.components.settings.channels.table', ChannelsTable::class);
         Livewire::component('hub.components.settings.channels.show', ChannelShow::class);
         Livewire::component('hub.components.settings.channels.create', ChannelCreate::class);
 
         // Users
         Livewire::component('hub.components.settings.staff.index', StaffIndex::class);
-        Livewire::component('hub.components.settings.staff.table', StaffTable::class);
         Livewire::component('hub.components.settings.staff.show', StaffShow::class);
         Livewire::component('hub.components.settings.staff.create', StaffCreate::class);
 
         // Languages
         Livewire::component('hub.components.settings.languages.index', LanguagesIndex::class);
-        Livewire::component('hub.components.settings.languages.table', LanguagesTable::class);
         Livewire::component('hub.components.settings.languages.create', LanguageCreate::class);
         Livewire::component('hub.components.settings.languages.show', LanguageShow::class);
 
         // Tags
         Livewire::component('hub.components.settings.tags.index', TagsIndex::class);
-        Livewire::component('hub.components.settings.tags.table', TagsTable::class);
         Livewire::component('hub.components.settings.tags.show', TagShow::class);
 
         // Currencies
         Livewire::component('hub.components.settings.currencies.index', CurrenciesIndex::class);
-        Livewire::component('hub.components.settings.currencies.table', CurrenciesTable::class);
         Livewire::component('hub.components.settings.currencies.show', CurrencyShow::class);
         Livewire::component('hub.components.settings.currencies.create', CurrencyCreate::class);
 
         // Addons
         Livewire::component('hub.components.settings.addons.index', AddonsIndex::class);
-        Livewire::component('hub.components.settings.addons.table', AddonsTable::class);
         Livewire::component('hub.components.settings.addons.show', AddonShow::class);
 
         // Taxes
         Livewire::component('hub.components.settings.taxes.tax-zones.index', TaxZonesIndex::class);
         Livewire::component('hub.components.settings.taxes.tax-zones.show', TaxZoneShow::class);
         Livewire::component('hub.components.settings.taxes.tax-zones.create', TaxZoneCreate::class);
-        Livewire::component('hub.components.settings.taxes.tax-zones.table', TaxZonesTable::class);
-
         Livewire::component('hub.components.settings.taxes.tax-classes.index', TaxClassesIndex::class);
+    }
+
+    /**
+     * Register the table components
+     *
+     * @return void
+     */
+    protected function registerLivewireTableComponents(): void
+    {
+        collect([
+            /** @see \Lunar\Hub\Http\Livewire\Components\Orders\OrdersTable */
+            'hub.components.orders.table' => 'Orders\OrdersTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Customers\CustomersTable */
+            'hub.components.customers.table' => 'Customers\CustomersTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Products\Tables\ProductsTable */
+            'hub.components.products.table' => 'Products\Tables\ProductsTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Products\Tables\ProductTypesTable */
+            'hub.components.products.product-types.table' => 'Products\Tables\ProductTypesTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Products\Tables\ProductVariantsTable */
+            'hub.components.products.variants.table' => 'Products\Tables\ProductVariantsTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Brands\BrandsTable */
+            'hub.components.brands.table' => 'Brands\BrandsTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\ActivityLogTable */
+            'hub.components.settings.activity-log.table' => 'Settings\Tables\ActivityLogTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\AttributesTable */
+            'hub.components.settings.attributes.table' => 'Settings\Tables\AttributesTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\ChannelsTable */
+            'hub.components.settings.channels.table' => 'Settings\Tables\ChannelsTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\StaffTable */
+            'hub.components.settings.staff.table' => 'Settings\Tables\StaffTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\LanguagesTable */
+            'hub.components.settings.languages.table' => 'Settings\Tables\LanguagesTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\TagsTable */
+            'hub.components.settings.tags.table' => 'Settings\Tables\TagsTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\CurrenciesTable */
+            'hub.components.settings.currencies.table' => 'Settings\Tables\CurrenciesTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\AddonsTable */
+            'hub.components.settings.addons.table' => 'Settings\Tables\AddonsTable',
+            /** @see \Lunar\Hub\Http\Livewire\Components\Settings\Tables\TaxZonesTable */
+            'hub.components.settings.taxes.tax-zones.table' => 'Settings\Tables\TaxZonesTable',
+        ])->each(function ($viewClass, $alias) {
+            $namespace = config('lunar-hub.system.components_namespace.tables', 'Lunar\\Hub\\Http\\Livewire\\Components');
+            $component = $namespace.'\\'.$viewClass;
+            if (! class_exists($component)) {
+                $component = 'Lunar\\Hub\\Http\\Livewire\\Components\\'.$viewClass;
+            }
+            Livewire::component($alias, $component);
+        });
     }
 
     /**


### PR DESCRIPTION
Now I am sure this PR will most likely get rejected 👀
However I feel as the aim for Lunar is to be extendable as possible, we should have this option for developers to switch out the table components namespace via the system config. Any table components which have not been overridden will simply fallback to the default Lunar implementation.

With my own use-case (filament tables package)
Before the Lunar update we had already implemented filament tables across the hub and did a lot of work to provide custom filters and actions for our client. Also recently taken advantage of the new table grid listing feature and soon to work on the new batch editing.

Now although I can appreciate the amount of work involved especially from your @alecritson creating the new tables components from scratch. Personally I will be continuing with Filament tables when using the hub as I feel Lunar's tables will struggle to keep up with the same features especially with the v3 coming up soon. 

Of course what I am suggesting here can simply be achieved without this PR if a developer was to override the AdminHubServiceProvider. The idea is to allow the developer to choose how they want to implement the tables features. 
My suggestion is not only based on filament, it would work with any Livewire table library implementation.