### PR TITLE
Hotfix - Unable to generate media conversions in production

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -265,7 +265,10 @@ trait HasImages
      */
     public function regenerateConversions($id)
     {
-        Artisan::call('media-library:regenerate --ids='.$id);
+        Artisan::call('media-library:regenerate', [
+            '--ids' => $id,
+            '--force' => true,
+        ]);
         $this->notify(
             __('adminhub::partials.image-manager.remake_transforms.notify.success')
         );


### PR DESCRIPTION
In production, Spatie media library will prompt when regenerating media conversions, since we're doing this behind the scenes it'll error. This PR cleans up the command call and passes `--force` as their docs suggest.