### PR TITLE
Hotfix - Unable to use table bulk action component

### DIFF
--- a/utils/livewire-tables/resources/views/actions/bulk.blade.php
+++ b/utils/livewire-tables/resources/views/actions/bulk.blade.php
@@ -9,7 +9,7 @@
 
     <x-l-tables::support.modal wire:model="showModal">
         <div>
-            @livewire('hub.components.tables.actions.update-status', [
+            @livewire($livewire, [
                 'ids' => $selectedIds,
             ])
         </div>

--- a/utils/livewire-tables/resources/views/index.blade.php
+++ b/utils/livewire-tables/resources/views/index.blade.php
@@ -165,6 +165,7 @@
                                     @foreach ($this->bulkActions as $action)
                                         @livewire($action->getName(), [
                                             'label' => $action->label,
+                                            'livewire' => $action->getLivewire(),
                                         ])
                                     @endforeach
                                 </div>

--- a/utils/livewire-tables/src/Components/Concerns/HasLivewireComponent.php
+++ b/utils/livewire-tables/src/Components/Concerns/HasLivewireComponent.php
@@ -9,7 +9,7 @@ trait HasLivewireComponent
      *
      * @var string
      */
-    protected $livewire = null;
+    public $livewire = null;
 
     /**
      * Set the livewire component to render.


### PR DESCRIPTION
Documents mentioned that we can choose a component for the table bulk action, however, that does not work because the component is hard-coded to use the update status action. This request fixes that and properly allows for the component mentioned when adding the bulk action to a table to be used.
