### PR TITLE
Fix minutes in orders table date formats

### DIFF
--- a/packages/admin/src/Tables/Builders/OrdersTableBuilder.php
+++ b/packages/admin/src/Tables/Builders/OrdersTableBuilder.php
@@ -47,7 +47,7 @@ class OrdersTableBuilder extends TableBuilder
                 return $record->total->formatted;
             }),
             TextColumn::make('date')->value(function ($record) {
-                return $record->placed_at?->format('Y/m/d @ H:ma');
+                return $record->placed_at?->format('Y/m/d @ H:ia');
             }),
         ]);
 


### PR DESCRIPTION
Orders table date format is wrong - it was showing month instead of minutes
