### PR TITLE
Hotfix - livewire tables wire:key naming conflict

### DIFF
--- a/utils/livewire-tables/resources/views/index.blade.php
+++ b/utils/livewire-tables/resources/views/index.blade.php
@@ -247,7 +247,7 @@
                                     @endif
 
                                     @foreach ($this->columns as $column)
-                                        <x-l-tables::cell wire:key="loading_column_{{ $column->field }}">
+                                        <x-l-tables::cell wire:key="loading_column_{{ $column->field }}_{{ $id }}">
                                             <div class="lt-animate-pulse">
                                                 <div class="lt-h-4 lt-bg-gray-200 lt-rounded-full"></div>
                                             </div>
@@ -281,7 +281,7 @@
 
                                     @foreach ($this->columns as $column)
                                         <x-l-tables::cell :sort="true"
-                                                        wire:key="column_{{ $column->field }}">
+                                                        wire:key="column_{{ $column->field }}_{{ $row->id }}">
                                             @if ($column->isLivewire())
                                                 <livewire:is :component="$column->getLivewire()" />
                                             @elseif($column->isViewComponent())


### PR DESCRIPTION
fixed #673 