### PR TITLE
[0.1] Feat - Add user_emails to customer search attributes

### DIFF
--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -107,6 +107,8 @@ class Customer extends BaseModel
 
         $data['addresses'] = $this->addresses->toArray();
 
+        $data['user_emails'] = $this->users->pluck('email')->toArray();
+
         return $data;
     }
 


### PR DESCRIPTION
Add user emails to the customer search so that customers can be found by the email addresses of the user(s) associated with them.

Fixes: https://github.com/lunarphp/lunar/issues/663