### PR TITLE
[0.1] Hotfix - Handle missing status from table column

### DIFF
--- a/packages/admin/src/Views/Components/Orders/Status.php
+++ b/packages/admin/src/Views/Components/Orders/Status.php
@@ -40,7 +40,7 @@ class Status extends Component
 
         $statuses = config('lunar.orders.statuses');
 
-        $match = $statuses[$record?->status ?: $status] ?? null;
+        $match = $statuses[$status] ?? null;
 
         $this->label = $match['label'] ?? $status;
         $this->color = $match['color'] ?? '#7C7C7C';

--- a/packages/admin/src/Views/Components/Orders/Status.php
+++ b/packages/admin/src/Views/Components/Orders/Status.php
@@ -34,6 +34,10 @@ class Status extends Component
      */
     public function __construct($record = null, $status = null)
     {
+        if ($record && ! $status) {
+            $status = $record->status;
+        }
+
         $statuses = config('lunar.orders.statuses');
 
         $match = $statuses[$record?->status ?: $status] ?? null;


### PR DESCRIPTION
Currently, if the status is not passed to the Status column component it will throw an error if it can't find it in the config.

Closes #697