### PR TITLE
Add paid status to orders config

### DIFF
--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -42,5 +42,11 @@ return [
             'mailers' => [],
             'notifications' => [],
         ],
+        'paid' => [
+            'label' => 'Paid',
+            'color' => '#16A34A'
+            'mailers' => [],
+            'notifications' => [],
+        ],
     ],
 ];


### PR DESCRIPTION
The demo-store package sets the status for orders to 'paid' once payment has been captured. When this happens, the Orders page in the hub breaks with a vanilla lunar install, as the 'paid' status does not exist in the default 'statuses' config entry in the orders.php config file. Adding this default entry here will avoid this from happening for new users trying out the demo-store.