### PR TITLE
Hotfix - Properly handle adding media when disk is not local

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -218,10 +218,10 @@ trait HasImages
                         $image['filename']
                     );
                     
-                    $media_libary_disk = config("media-library.disk_name");
+                    $media_libary_disk = config('media-library.disk_name');
                     $media_libary_driver = Storage::disk($media_libary_disk)->getConfig()['driver'];
 
-                    if($media_libary_driver == "local") {
+                    if ($media_libary_driver == 'local') {
                         $media = $owner->addMedia($file->getRealPath())
                                     ->toMediaCollection('images');
                     } else {

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -219,14 +219,15 @@ trait HasImages
                     );
                     
                     $media_libary_disk = config('media-library.disk_name');
-                    $media_libary_driver = Storage::disk($media_libary_disk)->getConfig()['driver'];
+                    $media_libary_driver_config = Storage::disk($media_libary_disk)->getConfig();
+                    $media_libary_driver = $media_libary_driver_config['driver'];
 
                     if ($media_libary_driver == 'local') {
                         $media = $owner->addMedia($file->getRealPath())
-                                    ->toMediaCollection('images');
+                            ->toMediaCollection('images');
                     } else {
                         $media = $owner->addMediaFromDisk($file->getRealPath())
-                                    ->toMediaCollection('images');
+                            ->toMediaCollection('images');
                     }
 
                     activity()

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -218,11 +218,11 @@ trait HasImages
                         $image['filename']
                     );
                     
-                    $media_libary_disk = config('media-library.disk_name');
-                    $media_libary_driver_config = Storage::disk($media_libary_disk)->getConfig();
-                    $media_libary_driver = $media_libary_driver_config['driver'];
+                    $mediaLibaryDisk = config('media-library.disk_name');
+                    $mediaLibaryDriverConfig = Storage::disk($mediaLibaryDisk)->getConfig();
+                    $mediaLibaryDriver = $mediaLibaryDriverConfig['driver'];
 
-                    if ($media_libary_driver == 'local') {
+                    if ($mediaLibaryDriver == 'local') {
                         $media = $owner->addMedia($file->getRealPath())
                             ->toMediaCollection('images');
                     } else {

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -217,7 +217,7 @@ trait HasImages
                     $file = TemporaryUploadedFile::createFromLivewire(
                         $image['filename']
                     );
-                    
+
                     $mediaLibaryDisk = config('media-library.disk_name');
                     $mediaLibaryDriverConfig = Storage::disk($mediaLibaryDisk)->getConfig();
                     $mediaLibaryDriver = $mediaLibaryDriverConfig['driver'];

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -216,8 +216,17 @@ trait HasImages
                     $file = TemporaryUploadedFile::createFromLivewire(
                         $image['filename']
                     );
-                    $media = $owner->addMedia($file->getRealPath())
-                        ->toMediaCollection('images');
+                    
+                    $media_libary_disk = config("media-library.disk_name");
+                    $media_libary_driver = Storage::disk($media_libary_disk)->getConfig()['driver'];
+
+                    if($media_libary_driver == "local") {
+                        $media = $owner->addMedia($file->getRealPath())
+                                    ->toMediaCollection('images');
+                    } else {
+                        $media = $owner->addMediaFromDisk($file->getRealPath())
+                                    ->toMediaCollection('images');
+                    }
 
                     activity()
                     ->performedOn($owner)

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -4,6 +4,7 @@ namespace Lunar\Hub\Http\Livewire\Traits;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Livewire\TemporaryUploadedFile;
 use Spatie\Activitylog\Facades\LogBatch;


### PR DESCRIPTION
In order to obtain the media from a remote location,addMediaFromDisk has to be used.addMedia only works when the file is stored on the server. You can set a default media disk for Spatie Media Library, so I used that config and then determined if it was local or not, so the image can be found and added properly.