### PR TITLE
[0.1] Hotfix - Hide error icon on interactive

### DIFF
--- a/packages/admin/resources/views/components/input/group.blade.php
+++ b/packages/admin/resources/views/components/input/group.blade.php
@@ -3,7 +3,9 @@
            class="flex items-center text-sm font-medium text-gray-700">
         <span class="block">{{ $labelPrefix ?? null }}</span>
 
-        <span class="block">{{ $label }}>
+        <span class="block">
+            {{ $label }}
+
             @if ($required)
                 <sup class="text-xs text-red-600">&#42;</sup>
             @endif
@@ -12,14 +14,6 @@
 
     <div class="relative mt-1">
         {{ $slot }}
-
-        @if ($error && $errorIcon)
-            <div
-                 class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none peer-focus:hidden peer-hover:hidden">
-                <x-hub::icon ref="exclamation-circle"
-                             class="w-5 h-5 text-red-500" />
-            </div>
-        @endif
     </div>
 
     @if ($instructions)
@@ -27,7 +21,14 @@
     @endif
 
     @if ($error)
-        <p class="mt-2 text-sm text-red-600">{{ $error }}</p>
+        <div class="flex items-center gap-1 mt-2">
+            @if ($errorIcon)
+                <x-hub::icon ref="exclamation-circle"
+                             class="w-5 h-5 text-red-500" />
+            @endif
+
+            <p class="text-sm text-red-600">{{ $error }}</p>
+        </div>
     @endif
 
     @if (count($errors))

--- a/packages/admin/resources/views/components/input/group.blade.php
+++ b/packages/admin/resources/views/components/input/group.blade.php
@@ -1,36 +1,46 @@
 <div>
-  <label for="{{ $for }}" class="flex items-center text-sm font-medium text-gray-700">
-    <span class="block">{{ $labelPrefix ?? null }}</span>
-    <span class="block">{{ $label }}@if($required)<sup class="text-xs text-red-600">&#42;</sup>@endif</span>
-  </label>
-  <div class="relative mt-1">
-    {{ $slot }}
-    @if($error && $errorIcon)
-      <div class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-        <!-- Heroicon name: solid/exclamation-circle -->
-        <svg class="w-5 h-5 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-        </svg>
-      </div>
-    @endif
-  </div>
-  @if($instructions)
-    <p class="mt-2 text-sm text-gray-500">{{ $instructions }}</p>
-  @endif
-  @if($error)
-    <p class="mt-2 text-sm text-red-600">{{ $error }}</p>
-  @endif
-  @if(count($errors))
-    <div class="space-y-1">
-      @foreach($errors as $error)
-        @if(is_array($error))
-          @foreach($error as $text)
-            <p class="text-sm text-red-600">{{ $text }}</p>
-          @endforeach
-        @else
-          <p class="text-sm text-red-600">{{ $error }}</p>
+    <label for="{{ $for }}"
+           class="flex items-center text-sm font-medium text-gray-700">
+        <span class="block">{{ $labelPrefix ?? null }}</span>
+
+        <span class="block">{{ $label }}>
+            @if ($required)
+                <sup class="text-xs text-red-600">&#42;</sup>
+            @endif
+        </span>
+    </label>
+
+    <div class="relative mt-1">
+        {{ $slot }}
+
+        @if ($error && $errorIcon)
+            <div
+                 class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none peer-focus:hidden peer-hover:hidden">
+                <x-hub::icon ref="exclamation-circle"
+                             class="w-5 h-5 text-red-500" />
+            </div>
         @endif
-      @endforeach
     </div>
-  @endif
+
+    @if ($instructions)
+        <p class="mt-2 text-sm text-gray-500">{{ $instructions }}</p>
+    @endif
+
+    @if ($error)
+        <p class="mt-2 text-sm text-red-600">{{ $error }}</p>
+    @endif
+
+    @if (count($errors))
+        <div class="space-y-1">
+            @foreach ($errors as $error)
+                @if (is_array($error))
+                    @foreach ($error as $text)
+                        <p class="text-sm text-red-600">{{ $text }}</p>
+                    @endforeach
+                @else
+                    <p class="text-sm text-red-600">{{ $error }}</p>
+                @endif
+            @endforeach
+        </div>
+    @endif
 </div>

--- a/packages/admin/resources/views/components/input/text.blade.php
+++ b/packages/admin/resources/views/components/input/text.blade.php
@@ -1,9 +1,8 @@
-<input
-  {{ $attributes->merge([
-    'type' => 'text',
-    'class' => 'form-input block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed',
-  ])->class([
-    'border-red-400' => !!$error,
-  ]) }}
-  maxlength="255"
->
+<input {{ $attributes->merge([
+        'type' => 'text',
+        'class' =>
+            'form-input block w-full border-gray-300 rounded-md peer shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed',
+    ])->class([
+        'border-red-400' => !!$error,
+    ]) }}
+       maxlength="255">

--- a/packages/admin/resources/views/components/input/text.blade.php
+++ b/packages/admin/resources/views/components/input/text.blade.php
@@ -1,7 +1,7 @@
 <input {{ $attributes->merge([
         'type' => 'text',
         'class' =>
-            'form-input block w-full border-gray-300 rounded-md peer shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed',
+            'form-input block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed',
     ])->class([
         'border-red-400' => !!$error,
     ]) }}


### PR DESCRIPTION
This PR fixes the error icon overlapping the `type="number"` input spinners.

Another approach would be to remove the spinners but that doesn't feel right in an admin system.