### PR TITLE
Update Cart.php (Fix lines exceptions when product variant is deleted)

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -159,7 +159,7 @@ class Cart extends BaseModel
      */
     public function lines()
     {
-        return $this->hasMany(CartLine::class, 'cart_id', 'id');
+        return $this->hasMany(CartLine::class, 'cart_id', 'id')->whereHas('purchasable');
     }
 
     /**


### PR DESCRIPTION
When you fetch a cart  and cart items (lines) but the lines are deleted, it throws error when you try to get the variant price or any property of of the deleted variant.

I had an incident whereby i added an item to cart few days a go, but then the shop deleted the that particular variant a few days later which drew my attention to that exception.
So i suggest that the **lines**  relationship in Cart.php should be constrained with only the ones that have real variant (purchasable).
- Changelog entries (core)
