### PR TITLE
Docs -  Add customer_id to fields list

### DIFF
--- a/docs/src/lunar/orders.md
+++ b/docs/src/lunar/orders.md
@@ -14,6 +14,7 @@ Lunar\Models\Order
 |:-|:-|
 |id||
 |user_id|If this is not a guest order, this will have the users id|
+|customer_id|Can be `null`, stores customer|
 |channel_id|Which channel this was purchased through|
 |status|A status that makes sense to you as the store owner|
 |reference|Your stores own reference


### PR DESCRIPTION
Add `customer_id` to the fields list for Orders documentation
