### PR TITLE
Use static::class when checking model search engine mapping

### DIFF
--- a/packages/core/src/Base/Traits/Searchable.php
+++ b/packages/core/src/Base/Traits/Searchable.php
@@ -151,9 +151,9 @@ trait Searchable
     {
         $engines = config('lunar.search.engine_map', []);
 
-        if (isset($engines[self::class])) {
+        if (isset($engines[static::class])) {
             return app(EngineManager::class)->engine(
-                $engines[self::class]
+                $engines[static::class]
             );
         }
 


### PR DESCRIPTION
Fixes #744 
