### PR TITLE
[0.2] Feat - Delay loading Collection products when large amounts

### DIFF
--- a/packages/admin/resources/views/livewire/components/collections/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/collections/show.blade.php
@@ -101,7 +101,14 @@
                             </x-hub::input.group>
                         </div>
                     @endif
-
+                    @if(!$products->count() && $this->productCount >= 100)
+                        <div wire:loading.remove wire:target="loadProducts">
+                            <x-hub::button theme="gray" type="button" wire:click="loadProducts">Load {{ $this->productCount }} products</x-hub::button>
+                        </div>
+                        <div wire:loading wire:target="loadProducts">
+                            <x-hub::loading-indicator class="w-4" />
+                        </div>
+                    @else
                     <div wire:sort
                          sort.options='{ group: "products", method: "sortProducts" }'
                          class="space-y-2">
@@ -135,7 +142,7 @@
                                         @if (strpos($collection->sort, 'base_price') !== false)
                                             {{ $product['base_price'] }}
                                         @elseif(strpos($collection->sort, 'sku') !== false)
-                                            <div class="truncate">{{ $product['sku'] }}</div>
+                                             <div class="truncate">{{ $product['sku'] }}</div>
                                         @endif
                                     </div>
                                 </div>
@@ -154,6 +161,7 @@
                             </x-hub::alert>
                         @endforelse
                     </div>
+                    @endif
                 </div>
             </div>
 

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
@@ -65,10 +65,25 @@ class CollectionShow extends Component
      */
     public function mount()
     {
+        $this->products = collect();
+
+        if (!$this->productCount >= 100) {
+            $this->loadProducts();
+        }
+
+        $this->syncAvailability();
+    }
+
+    public function getProductCountProperty()
+    {
+        return $this->collection->products()->count();
+    }
+
+    public function loadProducts()
+    {
         $this->products = $this->mapProducts(
             $this->collection->load('products.variants.basePrices.currency')->products
         );
-        $this->syncAvailability();
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
@@ -67,7 +67,7 @@ class CollectionShow extends Component
     {
         $this->products = collect();
 
-        if (!$this->productCount >= 100) {
+        if ($this->productCount <= 100) {
             $this->loadProducts();
         }
 


### PR DESCRIPTION
Currently when viewing a collection, if there are a lot of products associated the load times are astronomical. I think this needs to be looked at in greater detail in another release such as `0.3` but in the interim I think delaying loading the products until the user chooses to (unless under 100 products) will at least prevent the page from timing out.