### PR TITLE
[0.2] Add clearOptions() method to ShippingManifest

### DIFF
--- a/packages/core/src/Base/ShippingManifest.php
+++ b/packages/core/src/Base/ShippingManifest.php
@@ -44,6 +44,16 @@ class ShippingManifest implements ShippingManifestInterface
     /**
      * {@inheritDoc}
      */
+    public function clearOptions()
+    {
+        $this->options = collect();
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getOptions(Cart $cart): Collection
     {
         app(Pipeline::class)

--- a/packages/core/src/Base/ShippingManifestInterface.php
+++ b/packages/core/src/Base/ShippingManifestInterface.php
@@ -17,6 +17,13 @@ interface ShippingManifestInterface
     public function addOption(ShippingOption $shippingOption);
 
     /**
+     * Remove all shipping options
+     *
+     * @return self
+     */
+    public function clearOptions();
+
+    /**
      * Return available options for a given cart.
      *
      * @param  \Lunar\Models\Cart  $cart

--- a/packages/core/tests/Unit/Base/ShippingManifestTest.php
+++ b/packages/core/tests/Unit/Base/ShippingManifestTest.php
@@ -115,4 +115,26 @@ class ShippingManifestTest extends TestCase
 
         $this->assertCount(1, ShippingManifest::getOptions($this->cart));
     }
+
+    /** @test */
+    public function can_clear_options()
+    {
+        $taxClass = TaxClass::factory()->create();
+
+        ShippingManifest::addOption(
+            new ShippingOption(
+                name: 'Basic Delivery',
+                description: 'Basic Delivery',
+                identifier: 'BASDEL',
+                price: new Price(500, $this->cart->currency, 1),
+                taxClass: $taxClass
+            )
+        );
+
+        $this->assertCount(1, ShippingManifest::getOptions($this->cart));
+
+        ShippingManifest::clearOptions();
+
+        $this->assertCount(0, ShippingManifest::getOptions($this->cart));
+    }
 }


### PR DESCRIPTION
Sometimes, it can be necessary to remove ShippingOptions which were added during the same request cycle. This PR adds a method to clear all options, so you can be sure to start from a blank slate.