### PR TITLE
[0.2] Hotfix - Fix product/collection syncing

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
@@ -51,6 +51,13 @@ class CollectionShow extends Component
      */
     public \Illuminate\Support\Collection $products;
 
+    /**
+     * Whether products have been loaded.
+     *
+     * @var bool
+     */
+    public bool $productsLoaded = false;
+
     protected function getListeners()
     {
         return array_merge([
@@ -83,6 +90,8 @@ class CollectionShow extends Component
         $this->products = $this->mapProducts(
             $this->collection->load('products.variants.basePrices.currency')->products
         );
+
+        $this->productsLoaded = true;
     }
 
     /**
@@ -293,7 +302,7 @@ class CollectionShow extends Component
         });
 
         DB::transaction(function () {
-            if ($this->productCount <= 30) {
+            if ($this->productsLoaded) {
                 $this->collection->products()->sync(
                     $this->products->mapWithKeys(function ($product, $index) {
                         return [


### PR DESCRIPTION
When saving a collection a check on the product count is done before attempting to sync the collection products, just in case we haven't loaded in the products (due to size) and we don't want to detach all the collections.

This logic is wrong however because if you have over the threshold, even if you load in the products, it'll never save the associations.

This check now adds a `productsLoaded` boolean which is used instead.