### PR TITLE
Slightly improve UX for image manager

### DIFF
--- a/packages/admin/resources/lang/en/partials.php
+++ b/packages/admin/resources/lang/en/partials.php
@@ -75,6 +75,7 @@ return [
     'image-manager.save_btn' => 'Save image',
     'image-manager.edit_row_btn' => 'Edit',
     'image-manager.delete_row_btn' => 'Delete',
+    'image-manager.delete_primary' => 'You cannot delete the primary image.',
     'image-manager.delete_message' => 'This image will be deleted on save,',
     'image-manager.undo_btn' => 'undo',
     'image-manager.no_results' => 'No images exist for this product, add your first image above.',

--- a/packages/admin/resources/views/components/input/toggle.blade.php
+++ b/packages/admin/resources/views/components/input/toggle.blade.php
@@ -21,7 +21,7 @@
     class="{{ $on ? 'bg-green-500' : 'bg-gray-200' }} relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
     role="switch"
     aria-checked="false"
-    @if($disabled ?? true) disabled @endif
+    @disabled($disabled ?? true)
     x-on:click="toggle"
     :class="{
         'bg-green-500': checked == onValue,

--- a/packages/admin/resources/views/partials/image-manager.blade.php
+++ b/packages/admin/resources/views/partials/image-manager.blade.php
@@ -131,13 +131,15 @@
                                     </x-hub::tooltip>
                                 @endif
 
-                                <button type="button"
-                                        wire:click.prevent="removeImage('{{ $key }}')"
-                                        class="text-gray-400 hover:text-red-500 "
-                                        @if ($image['primary']) disabled @endif>
-                                    <x-hub::icon ref="trash"
-                                                 style="solid" />
-                                </button>
+                                <x-hub::tooltip :text="$image['primary'] ? __('adminhub::partials.image-manager.delete_primary') : __('adminhub::partials.image-manager.delete_row_btn')">
+                                    <button type="button"
+                                            wire:click.prevent="removeImage('{{ $key }}')"
+                                            class="text-gray-400 hover:text-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                                            @disabled($image['primary'])>
+                                        <x-hub::icon ref="trash"
+                                                     style="solid" />
+                                    </button>
+                                </x-hub::tooltip>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- Show a tooltip that a primary image can't be deleted
- Reduce opacity of delete button for primary image

Before:
![image](https://user-images.githubusercontent.com/20305359/209539146-8cb009c2-13a1-4e9c-8705-4c34264eda1e.png)


After:
![image](https://user-images.githubusercontent.com/20305359/209539091-ea66b4fe-1fbc-4870-9f61-c686117c8a58.png)
