### PR TITLE
Change of UI on discount limitations to use popover

### DIFF
--- a/packages/admin/resources/lang/en/components.php
+++ b/packages/admin/resources/lang/en/components.php
@@ -76,6 +76,20 @@ return [
     'attribute-edit.save_attribute_btn' => 'Save Attribute',
 
     /**
+     * Brand search.
+     */
+    'brand-search.btn' => 'Add Brands',
+    'brand-search.first_tab' => 'Search brands',
+    'brand-search.second_tab' => 'Selected brands',
+    'brand-search.max_results_exceeded' => 'Showing the first :max of :total brands. Try being more specific in your search.',
+    'brand-search.exists_in_collection' => 'Already associated',
+    'brand-search.no_results' => 'No results found.',
+    'brand-search.pre_search_message' => 'Search for brands by attribute.',
+    'brand-search.select_empty' => 'When you select brands, they will appear here.',
+    'brand-search.title' => 'Search for brands',
+    'brand-search.commit_btn' => 'Select Brands',
+
+    /**
      * Collection search.
      */
     'collection-search.btn' => 'Add Collections',

--- a/packages/admin/resources/lang/en/partials.php
+++ b/packages/admin/resources/lang/en/partials.php
@@ -83,6 +83,14 @@ return [
     'image-manager.select_images' => 'Select images',
     'image-manager.select_images_btn' => 'Select images',
     /**
+     * Discounts
+     */
+    'discounts.limitations.heading' => 'Limitations',
+    'discounts.limitations.by_collection' => 'Limit by collection',
+    'discounts.limitations.by_brand' => 'Limit by brand',
+    'discounts.limitations.view_brand' => 'View Brand',
+
+    /**
      * Product Collections.
      */
     'products.collections.heading' => 'Collections',

--- a/packages/admin/resources/views/livewire/components/brand-search.blade.php
+++ b/packages/admin/resources/views/livewire/components/brand-search.blade.php
@@ -1,0 +1,115 @@
+<div>
+    <x-hub::button type="button"
+                   wire:click.prevent="$set('showBrowser', true)">
+        {{ __('adminhub::components.brand-search.btn') }}
+    </x-hub::button>
+
+    <x-hub::slideover :title="__('adminhub::components.brand-search.title')"
+                      wire:model="showBrowser">
+        <div class="space-y-4"
+             x-data="{ tab: 'search' }">
+            <div>
+                <nav class="flex space-x-4"
+                     aria-label="Tabs">
+                    <button x-on:click.prevent="tab = 'search'"
+                            class="px-3 py-2 text-sm font-medium rounded-md"
+                            :class="{
+                                'bg-indigo-100 text-indigo-700': tab == 'search',
+                                'text-gray-500 hover:text-gray-700': tab != 'search'
+                            }">
+                        {{ __('adminhub::components.brand-search.first_tab') }}
+                    </button>
+
+                    <button class="px-3 py-2 text-sm font-medium rounded-md"
+                            @click.prevent="tab = 'selected'"
+                            :class="{
+                                'bg-indigo-100 text-indigo-700': tab == 'selected',
+                                'text-gray-500 hover:text-gray-700': tab != 'selected'
+                            }">
+                        {{ __('adminhub::components.brand-search.second_tab') }}
+
+                        ({{ $this->selectedModels->count() }})
+                    </button>
+                </nav>
+            </div>
+
+            <div x-show="tab == 'search'">
+                <x-hub::input.text wire:model.debounce.300ms="searchTerm" />
+
+                @if ($this->searchTerm)
+                    @if ($this->results->total() > $maxResults)
+                        <span class="block p-3 my-2 text-xs text-blue-600 rounded bg-blue-50">
+                            {{ __('adminhub::components.brand-search.max_results_exceeded', [
+                                'max' => $maxResults,
+                                'total' => $this->results->total(),
+                            ]) }}
+                        </span>
+                    @endif
+                    <div class="mt-4 space-y-1">
+                        @forelse($this->results as $brand)
+                            <div @class([
+                                'flex w-full items-center justify-between rounded shadow-sm text-left border px-2 py-2 text-sm',
+                                'opacity-25' => $this->existingIds->contains($brand->id),
+                            ])>
+                                <div class="truncate max-w-64">
+                                    {{ $brand->name }}
+                                </div>
+
+                                @if (!$this->existingIds->contains($brand->id))
+                                    @if (collect($this->selected)->contains($brand->id))
+                                        <button class="px-2 py-1 text-xs text-red-700 border border-red-200 rounded shadow-sm hover:bg-red-50"
+                                                wire:click.prevent="removeBrand('{{ $brand->id }}')">
+                                            {{ __('adminhub::global.deselect') }}
+                                        </button>
+                                    @else
+                                        <button class="px-2 py-1 text-xs text-blue-700 border border-blue-200 rounded shadow-sm hover:bg-blue-50"
+                                                wire:click.prevent="selectBrand('{{ $brand->id }}')">
+                                            {{ __('adminhub::global.select') }}
+                                        </button>
+                                    @endif
+                                @else
+                                    <span class="text-xs">
+                                        {{ __('adminhub::components.brand-search.exists_in_collection') }}
+                                    </span>
+                                @endif
+                            </div>
+                        @empty
+                            {{ __('adminhub::components.brand-search.no_results') }}
+                        @endforelse
+                    </div>
+                @else
+                    <div class="px-3 py-2 mt-4 text-sm text-gray-500 bg-gray-100 rounded">
+                        {{ __('adminhub::components.brand-search.pre_search_message') }}
+                    </div>
+                @endif
+            </div>
+
+            <div x-show="tab == 'selected'"
+                 class="space-y-2">
+                @forelse($this->selectedModels as $brand)
+                    <div class="flex items-center justify-between w-full px-2 py-2 text-sm text-left border rounded shadow-sm "
+                         wire:key="selected_{{ $brand->id }}">
+                        <div class="truncate max-w-64">
+                            {{ $brand->name }}
+                        </div>
+
+                        <button class="px-2 py-1 text-xs text-red-700 border border-red-200 rounded shadow-sm hover:bg-red-50"
+                                wire:click.prevent="removeBrand('{{ $brand->id }}')">
+                            {{ __('adminhub::global.deselect') }}
+                        </button>
+                    </div>
+                @empty
+                    <div class="px-3 py-2 mt-4 text-sm text-gray-500 bg-gray-100 rounded">
+                        {{ __('adminhub::components.brand-search.select_empty') }}
+                    </div>
+                @endforelse
+            </div>
+        </div>
+
+        <x-slot name="footer">
+            <x-hub::button wire:click.prevent="triggerSelect">
+                {{ __('adminhub::components.brand-search.commit_btn') }}
+            </x-hub::button>
+        </x-slot>
+    </x-hub::slideover>
+</div>

--- a/packages/admin/resources/views/partials/forms/discount/limitations.blade.php
+++ b/packages/admin/resources/views/partials/forms/discount/limitations.blade.php
@@ -1,38 +1,141 @@
-<div class="overflow-hidden shadow sm:rounded-md">
-    <div class="flex-col px-4 py-5 space-y-4 bg-white sm:p-6">
+<div class="shadow sm:rounded-md">
+    <div class="flex-col px-4 py-5 space-y-4 bg-white sm:p-6 sm:rounded-md">
         <header>
             <h3 class="text-lg font-medium leading-6 text-gray-900">
-                Limitations
+                {{ __('adminhub::partials.discounts.limitations.heading') }}
             </h3>
         </header>
 
         <div class="space-y-4">
-
-
-            <x-hub::input.group
-                label="Limit by collection"
-                for="brands"
-            >
-
-            @livewire('hub.components.collections.collection-tree-select', [
-                'selectedCollections' => $selectedCollections,
-            ])
-
-            </x-hub::input.group>
-
-            <x-hub::input.group
-                label="Limit by brand"
-                for="brands"
-            >
-              <div class="rounded border h-full overflow-y-scroll max-h-96 p-2 bg-gray-50 space-y-2">
-                @foreach($this->brands as $brand)
-                    <label class="flex items-center space-x-2  bg-white py-2 rounded shadow text-sm px-3 cursor-pointer hover:bg-gray-50" wire:key="av_brand_{{ $brand->id }}">
-                      <input type="checkbox" wire:model="selectedBrands" value="{{ $brand->id }}">
-                      <div>{{ $brand->name }}</div>
-                    </label>
+        
+            <header class="flex items-center justify-between">
+                <h4 class="text-md font-medium text-gray-700">
+                    {{ __('adminhub::partials.discounts.limitations.by_collection') }}
+                </h4>
+    
+                @livewire('hub.components.collection-search', [
+                    'existing' => $selectedCollections->pluck('id'),
+                ])
+            </header>   
+            
+            <div class="space-y-2">
+                @foreach ($selectedCollections as $index => $collection)
+                    <div wire:key="collection_{{ $index }}">
+                        <div class="flex items-center px-4 py-2 text-sm border rounded">
+                            @if ($collection['thumbnail'])
+                                <span class="flex-shrink-0 block w-12 mr-4">
+                                    <img src="{{ $collection['thumbnail'] }}"
+                                         class="rounded">
+                                </span>
+                            @endif
+    
+                            <div class="flex grow">
+                                <div class="grow flex gap-1.5 flex-wrap items-center">
+                                    <strong class="rounded px-1.5 py-0.5 bg-blue-50 text-xs text-blue-600">
+                                        {{ $collection['group_name'] }}
+                                    </strong>
+    
+                                    @if (count($collection['breadcrumb']))
+                                        <span class="text-gray-500 flex gap-1.5 items-center">
+                                            <span class="font-medium">
+                                                {{ collect($collection['breadcrumb'])->first() }}
+                                            </span>
+    
+                                            <x-hub::icon ref="chevron-right"
+                                                         class="w-4 h-4"
+                                                         style="solid" />
+                                        </span>
+                                    @endif
+    
+                                    @if (count($collection['breadcrumb']) > 1)
+                                        <span class="text-gray-500 flex gap-1.5 items-center"
+                                              title="{{ collect($collection['breadcrumb'])->implode(' > ') }}">
+                                            <span class="font-medium cursor-help">
+                                                ...
+                                            </span>
+    
+                                            <x-hub::icon ref="chevron-right"
+                                                         class="w-4 h-4"
+                                                         style="solid" />
+                                        </span>
+                                    @endif
+    
+                                    <strong class="text-gray-700 truncate max-w-[40ch]"
+                                            title="{{ $collection['name'] }}">
+                                        {{ $collection['name'] }}
+                                    </strong>
+                                </div>
+    
+                                <div class="flex items-center">
+                                    <x-hub::dropdown minimal>
+                                        <x-slot name="options">
+                                            <x-hub::dropdown.link class="flex items-center justify-between px-4 py-2 text-sm text-gray-700 border-b hover:bg-gray-50"
+                                                                  :href="route('hub.collections.show', [
+                                                                      'group' => $collection['group_id'],
+                                                                      'collection' => $collection['id'],
+                                                                  ])">
+                                                {{ __('adminhub::partials.products.collections.view_collection') }}
+                                            </x-hub::dropdown.link>
+    
+                                            <x-hub::dropdown.button wire:click.prevent="removeCollection({{ $index }})"
+                                                                    class="flex items-center justify-between px-4 py-2 text-sm text-red-600 hover:bg-gray-50">
+                                                {{ __('adminhub::global.remove') }}
+                                            </x-hub::dropdown.button>
+                                        </x-slot>
+                                    </x-hub::dropdown>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 @endforeach
-              </div>
-            </x-hub::input.group>
+            </div>
+            
+            <header class="flex items-center justify-between border-t pt-4">
+                <h4 class="text-md font-medium text-gray-700">
+                    {{ __('adminhub::partials.discounts.limitations.by_brand') }}
+                </h4>
+    
+                @livewire('hub.components.brand-search', [
+                    'existing' => $selectedBrands->pluck('id'),
+                ])
+            </header>   
+            
+            <div class="space-y-2">
+                @foreach ($selectedBrands as $index => $brand)
+                    <div wire:key="collection_{{ $index }}">
+                        <div class="flex items-center px-4 py-2 text-sm border rounded">
+    
+                            <div class="flex grow">
+                                <div class="grow flex gap-1.5 flex-wrap items-center">
+                                    <strong class="text-gray-700 truncate max-w-[40ch]"
+                                            title="{{ $brand['name'] }}">
+                                        {{ $brand['name'] }}
+                                    </strong>
+                                </div>
+    
+                                <div class="flex items-center">
+                                    <x-hub::dropdown minimal>
+                                        <x-slot name="options">
+                                            <x-hub::dropdown.link class="flex items-center justify-between px-4 py-2 text-sm text-gray-700 border-b hover:bg-gray-50"
+                                                                  :href="route('hub.brands.show', [
+                                                                      'brand' => $brand['id'],
+                                                                  ])">
+                                                {{ __('adminhub::partials.discounts.limitations.view_brand') }}
+                                            </x-hub::dropdown.link>
+    
+                                            <x-hub::dropdown.button wire:click.prevent="removeBrand({{ $index }})"
+                                                                    class="flex items-center justify-between px-4 py-2 text-sm text-red-600 hover:bg-gray-50">
+                                                {{ __('adminhub::global.remove') }}
+                                            </x-hub::dropdown.button>
+                                        </x-slot>
+                                    </x-hub::dropdown>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+            
         </div>
     </div>
 </div>

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -23,6 +23,7 @@ use Lunar\Hub\Http\Livewire\Components\Avatar;
 use Lunar\Hub\Http\Livewire\Components\Brands\BrandShow;
 use Lunar\Hub\Http\Livewire\Components\Brands\BrandsIndex;
 use Lunar\Hub\Http\Livewire\Components\Brands\BrandsTable;
+use Lunar\Hub\Http\Livewire\Components\BrandSearch;
 use Lunar\Hub\Http\Livewire\Components\Collections\CollectionGroupShow;
 use Lunar\Hub\Http\Livewire\Components\Collections\CollectionGroupsIndex;
 use Lunar\Hub\Http\Livewire\Components\Collections\CollectionShow;
@@ -283,6 +284,7 @@ class AdminHubServiceProvider extends ServiceProvider
         Livewire::component('hub.components.activity-log-feed', ActivityLogFeed::class);
         Livewire::component('hub.components.product-search', ProductSearch::class);
         Livewire::component('hub.components.collection-search', CollectionSearch::class);
+        Livewire::component('hub.components.brand-search', BrandSearch::class);
         Livewire::component('hub.components.account', Account::class);
         Livewire::component('hub.components.avatar', Avatar::class);
         Livewire::component('hub.components.current-staff-name', CurrentStaffName::class);

--- a/packages/admin/src/Http/Livewire/Components/BrandSearch.php
+++ b/packages/admin/src/Http/Livewire/Components/BrandSearch.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Lunar\Hub\Http\Livewire\Components;
+
+use Illuminate\Support\Collection;
+use Livewire\Component;
+use Lunar\Models\Brand;
+
+class BrandSearch extends Component
+{
+    /**
+     * Should the browser be visible?
+     *
+     * @var bool
+     */
+    public bool $showBrowser = false;
+
+    /**
+     * The search term.
+     *
+     * @var string
+     */
+    public $searchTerm = null;
+
+    /**
+     * Max results we want to show.
+     *
+     * @var int
+     */
+    public $maxResults = 50;
+
+    /**
+     * Any existing brands to exclude from selecting.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    public Collection $existing;
+
+    /**
+     * The currently selected brands.
+     *
+     * @var array
+     */
+    public array $selected = [];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rules()
+    {
+        return [
+            'searchTerm' => 'required|string|max:255',
+        ];
+    }
+
+    /**
+     * Return the selected collections.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getSelectedModelsProperty()
+    {
+        return Brand::whereIn('id', $this->selected)->get();
+    }
+
+    /**
+     * Return the existing collection ids.
+     *
+     * @return array
+     */
+    public function getExistingIdsProperty()
+    {
+        return $this->existing->pluck('id');
+    }
+
+    /**
+     * Listener for when show browser is updated.
+     *
+     * @return void
+     */
+    public function updatedShowBrowser()
+    {
+        $this->selected = [];
+        $this->searchTerm = null;
+    }
+
+    /**
+     * Add the brand to the selected array.
+     *
+     * @param  string|int  $id
+     * @return void
+     */
+    public function selectBrand($id)
+    {
+        $this->selected[] = $id;
+    }
+
+    /**
+     * Remove a brand from the selected brands.
+     *
+     * @param  string|int  $id
+     * @return void
+     */
+    public function removeBrand($id)
+    {
+        $index = collect($this->selected)->search($id);
+        unset($this->selected[$index]);
+        $this->selected = collect($this->selected)->values();
+    }
+
+    /**
+     * Returns the computed search results.
+     *
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function getResultsProperty()
+    {
+        if (! $this->searchTerm) {
+            return null;
+        }
+
+        return Brand::query()->where('name', 'like', '%'.$this->searchTerm.'%')->paginate($this->maxResults);
+
+        //return Brand::search($this->searchTerm)->paginate($this->maxResults);
+    }
+
+    public function triggerSelect()
+    {
+        $this->emit('brandSearch.selected', $this->selected);
+
+        $this->showBrowser = false;
+    }
+
+    /**
+     * Render the livewire component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('adminhub::livewire.components.brand-search')
+            ->layout('adminhub::layouts.base');
+    }
+}

--- a/packages/admin/src/Http/Livewire/Components/BrandSearch.php
+++ b/packages/admin/src/Http/Livewire/Components/BrandSearch.php
@@ -119,9 +119,7 @@ class BrandSearch extends Component
             return null;
         }
 
-        return Brand::query()->where('name', 'like', '%'.$this->searchTerm.'%')->paginate($this->maxResults);
-
-        //return Brand::search($this->searchTerm)->paginate($this->maxResults);
+        return Brand::search($this->searchTerm)->paginate($this->maxResults);
     }
 
     public function triggerSelect()

--- a/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
@@ -108,9 +108,9 @@ abstract class AbstractDiscount extends Component
     {
         $this->currency = Currency::getDefault();
 
-        $this->selectedBrands = $this->discount->brands->map(fn ($brand) => $this->mapBrandToArray($brand));
-        $this->selectedCollections = $this->discount->collections->map(fn ($collection) => $this->mapCollectionToArray($collection));
-
+        $this->selectedBrands = $this->discount->brands->map(fn ($brand) => $this->mapBrandToArray($brand)) ?? collect();
+        $this->selectedCollections = $this->discount->collections->map(fn ($collection) => $this->mapCollectionToArray($collection)) ?? collect();
+        
         $this->selectedConditions = $this->discount->purchasableConditions()
             ->wherePurchasableType(Product::class)
             ->pluck('purchasable_id')->values()->toArray();

--- a/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
@@ -32,16 +32,19 @@ abstract class AbstractDiscount extends Component
      */
     public Discount $discount;
 
-    public Collection $collections;
-
     /**
      * The brands to restrict the coupon for.
      *
      * @var array
      */
-    public array $selectedBrands = [];
+    public Collection $selectedBrands;
 
-    public array $selectedCollections = [];
+    /**
+     * The collections to restrict the coupon for.
+     *
+     * @var array
+     */
+    public Collection $selectedCollections;
 
     /**
      * The selected conditions
@@ -97,14 +100,16 @@ abstract class AbstractDiscount extends Component
         'discount.conditions' => 'syncConditions',
         'discount.rewards' => 'syncRewards',
         'discount.purchasables' => 'syncPurchasables',
-        'collectionTreeSelect.updated' => 'selectCollections',
+        'brandSearch.selected' => 'selectBrands',
+        'collectionSearch.selected' => 'selectCollections',
     ];
 
     public function mount()
     {
         $this->currency = Currency::getDefault();
-        $this->selectedBrands = $this->discount->brands->pluck('id')->toArray();
-        $this->selectedCollections = $this->discount->collections->pluck('id')->toArray();
+
+        $this->selectedBrands = $this->discount->brands->map(fn ($brand) => $this->mapBrandToArray($brand));
+        $this->selectedCollections = $this->discount->collections->map(fn ($collection) => $this->mapCollectionToArray($collection));
 
         $this->selectedConditions = $this->discount->purchasableConditions()
             ->wherePurchasableType(Product::class)
@@ -183,6 +188,21 @@ abstract class AbstractDiscount extends Component
     }
 
     /**
+     * Select brands given an array of IDs
+     *
+     * @param  array  $ids
+     * @return void
+     */
+    public function selectBrands(array $ids)
+    {
+        $selectedBrands = Brand::findMany($ids)->map(fn ($brand) => $this->mapBrandToArray($brand));
+
+        $this->selectedBrands = $this->selectedBrands->count()
+            ? $this->selectedBrands->merge($selectedBrands)
+            : $selectedBrands;
+    }
+
+    /**
      * Select collections given an array of IDs
      *
      * @param  array  $ids
@@ -190,7 +210,11 @@ abstract class AbstractDiscount extends Component
      */
     public function selectCollections(array $ids)
     {
-        $this->selectedCollections = $ids;
+        $selectedCollections = ModelsCollection::findMany($ids)->map(fn ($collection) => $this->mapCollectionToArray($collection));
+
+        $this->selectedCollections = $this->selectedCollections->count()
+            ? $this->selectedCollections->merge($selectedCollections)
+            : $selectedCollections;
     }
 
     public function syncRewards(array $ids)
@@ -234,6 +258,17 @@ abstract class AbstractDiscount extends Component
     }
 
     /**
+     * Remove the brand by it's index.
+     *
+     * @param  int|string  $index
+     * @return void
+     */
+    public function removeBrand($index)
+    {
+        $this->selectedBrands->forget($index);
+    }
+
+    /**
      * Remove the collection by it's index.
      *
      * @param  int|string  $index
@@ -241,27 +276,7 @@ abstract class AbstractDiscount extends Component
      */
     public function removeCollection($index)
     {
-        $this->collections->forget($index);
-    }
-
-    /**
-     * Return a list of available countries.
-     *
-     * @return Collection
-     */
-    public function getBrandsProperty()
-    {
-        return Brand::orderBy('name')->get();
-    }
-
-    /**
-     * Return the category tree.
-     *
-     * @return Collection
-     */
-    public function getCollectionTreeProperty()
-    {
-        return ModelsCollection::get()->toTree();
+        $this->selectedCollections->forget($index);
     }
 
     /**
@@ -289,7 +304,7 @@ abstract class AbstractDiscount extends Component
             $this->discount->save();
 
             $this->discount->brands()->sync(
-                $this->selectedBrands
+                $this->selectedBrands->pluck('id')
             );
 
             $channels = collect($this->availability['channels'])->mapWithKeys(function ($channel) {
@@ -318,7 +333,7 @@ abstract class AbstractDiscount extends Component
             $this->discount->channels()->sync($channels);
 
             $this->discount->collections()->sync(
-                $this->selectedCollections
+                $this->selectedCollections->pluck('id')->toArray()
             );
         });
 
@@ -384,5 +399,36 @@ abstract class AbstractDiscount extends Component
     {
         return view('adminhub::livewire.components.discounts.show')
             ->layout('adminhub::layouts.app');
+    }
+
+    /**
+     * Return the data we need from a brand
+     *
+     * @return array
+     */
+    private function mapBrandToArray($brand)
+    {
+        return [
+            'id' => $brand->id,
+            'name' => $brand->name,
+        ];
+    }
+
+    /**
+     * Return the data we need from a collection
+     *
+     * @return array
+     */
+    private function mapCollectionToArray($collection)
+    {
+        return [
+            'id' => $collection->id,
+            'group_id' => $collection->collection_group_id,
+            'group_name' => $collection->group->name,
+            'name' => $collection->translateAttribute('name'),
+            'thumbnail' => optional($collection->thumbnail)->getUrl(),
+            'position' => optional($collection->pivot)->position,
+            'breadcrumb' => $collection->breadcrumb,
+        ];
     }
 }

--- a/packages/admin/src/Http/Livewire/Components/Discounts/DiscountCreate.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/DiscountCreate.php
@@ -30,6 +30,9 @@ class DiscountCreate extends AbstractDiscount
 
         $this->currency = Currency::getDefault();
         $this->syncAvailability();
+        
+        $this->selectedBrands = collect();
+        $this->selectedCollections = collect();
     }
 
     /**

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -64,6 +64,19 @@ class Brand extends BaseModel implements SpatieHasMedia
     }
 
     /**
+     * Return our base (core) attributes we want searchable.
+     *
+     * @return array
+     */
+    public function getSearchableAttributes()
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+
+    /**
      * Return the product relationship.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany


### PR DESCRIPTION
This PR changes the discount limitations UI to use pop-overs/slide-outs for collection and brand selection, rather than the tree and list components currently in place.

As part of this PR a new brand search component has been introduced.