### PR TITLE
fix blade directive issue causing error on products index page in hub

### DIFF
--- a/utils/livewire-tables/resources/views/columns/badge.blade.php
+++ b/utils/livewire-tables/resources/views/columns/badge.blade.php
@@ -1,13 +1,13 @@
 <div>
     <span @class([
         'lt-text-xs lt-inline-block lt-py-1 lt-px-2 lt-rounded',
-        'lt-text-blue-600 lt-bg-blue-50' => !@empty($info),
-        'lt-text-green-600 lt-bg-green-50' => !@empty($success),
-        'lt-text-blue-600 lt-bg-blue-50' => !@empty($info),
-        'lt-text-yellow-600 lt-bg-yellow-50' => !@empty(
+        'lt-text-blue-600 lt-bg-blue-50' => !empty($info),
+        'lt-text-green-600 lt-bg-green-50' => !empty($success),
+        'lt-text-blue-600 lt-bg-blue-50' => !empty($info),
+        'lt-text-yellow-600 lt-bg-yellow-50' => !empty(
             $warning
         ),
-        'lt-text-red-600 lt-bg-red-50' => !@empty($danger),
+        'lt-text-red-600 lt-bg-red-50' => !empty($danger),
     ])>
         {{ $value }}
     </span>


### PR DESCRIPTION
The `badge.blade.php` blade file was using the @empty blade directive without closing @endempty directives. This causes an error on the products index page in the admin hub. To resolve, I've switched to using the native php empty function instead.