### PR TITLE
Hotfix [0.2] - Fix duplicate language code on tests

### DIFF
--- a/packages/admin/tests/Unit/Http/Livewire/Traits/HasPricesTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Traits/HasPricesTest.php
@@ -26,12 +26,10 @@ class HasPricesTest extends TestCase
 
         Language::factory()->create([
             'default' => true,
-            'code' => 'en',
         ]);
 
         Language::factory()->create([
             'default' => false,
-            'code' => 'fr',
         ]);
 
         Currency::factory()->create([


### PR DESCRIPTION
Currently there is a recurring issue where a test will fail due to duplicate language codes. This should solve it.