### PR TITLE
fix: product page bottom bar not full width when side bar collapsed

### DIFF
--- a/packages/admin/resources/views/partials/products/editing/sections.blade.php
+++ b/packages/admin/resources/views/partials/products/editing/sections.blade.php
@@ -21,7 +21,7 @@
     </div>
 </div>
 
-<div class="fixed lg:w-[calc(100vw_-_16rem)] bottom-0 left-0 right-0 z-40 p-6 border-t border-gray-100 lg:left-auto bg-white/75">
+<div class="fixed w-full bottom-0 left-0 right-0 z-40 p-6 border-t border-gray-100 lg:left-auto bg-white/75">
     <form wire:submit.prevent="save">
         <div class="flex justify-end gap-6">
             @include('adminhub::partials.products.status-bar')


### PR DESCRIPTION
product page bottom bar not full width when side bar collapsed

before
![image](https://user-images.githubusercontent.com/67364036/212015898-ff8d7432-24da-4095-84b9-cf46a5c05765.png)

after
![image](https://user-images.githubusercontent.com/67364036/212035908-2f198ca0-e083-4371-a855-522e2b4ab8bb.png)
