### PR TITLE
Increment discount uses as part of order creation

### DIFF
--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -126,7 +126,7 @@ class CreateOrder extends AbstractAction
 
             $cart->order()->associate($order);
             
-            $cart->discounts->each(function ($discount) {
+            $cart->discounts?->each(function ($discount) {
                 $discount->markAsUsed()->save();
             });
 

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -127,7 +127,7 @@ class CreateOrder extends AbstractAction
             $cart->order()->associate($order);
             
             $cart->discounts?->each(function ($discount) {
-                $discount->markAsUsed()->save();
+                $discount->markAsUsed()->discount->save();
             });
 
             $cart->save();

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -125,6 +125,10 @@ class CreateOrder extends AbstractAction
             $order->addresses()->createMany($addresses->toArray());
 
             $cart->order()->associate($order);
+            
+            $cart->discounts->each(function ($discount) {
+                $discount->markAsUsed()->save();
+            });
 
             $cart->save();
 

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -26,4 +26,16 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
 
         return $this;
     }
+    
+    /**
+     * Mark a discount as used
+     *
+     * @return self
+     */
+    public function markAsUsed(): self
+    {
+        $this->discount->uses = $this->discount->uses + 1; 
+
+        return $this;
+    }
 }

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -12,7 +12,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
      *
      * @var Discount
      */
-    protected Discount $discount;
+    public Discount $discount;
 
     /**
      * Set the data for the discount to user.

--- a/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
@@ -5,13 +5,16 @@ namespace Lunar\Tests\Unit\Actions\Carts;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\DataTypes\Price as PriceDataType;
 use Lunar\DataTypes\ShippingOption;
+use Lunar\DiscountTypes\Discount as DiscountTypesDiscount;
 use Lunar\Exceptions\Carts\CartException;
 use Lunar\Facades\ShippingManifest;
 use Lunar\Models\Cart;
 use Lunar\Models\CartAddress;
+use Lunar\Models\Channel;
 use Lunar\Models\Country;
 use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
+use Lunar\Models\Discount;
 use Lunar\Models\Order;
 use Lunar\Models\OrderAddress;
 use Lunar\Models\OrderLine;
@@ -278,5 +281,133 @@ class CreateOrderTest extends TestCase
             $taxRateAmount->percentage,
             $order->tax_breakdown->first()->percentage
         );
+    }
+    
+    /** @test  */
+    public function increments_discount_uses()
+    {
+        $customerGroup = CustomerGroup::factory()->create([
+            'default' => true,
+        ]);
+        
+        $channel = Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        $billing = CartAddress::factory()->make([
+            'type' => 'billing',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'BILL',
+        ]);
+
+        $shipping = CartAddress::factory()->make([
+            'type' => 'shipping',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'SHIPP',
+        ]);
+
+        $taxClass = TaxClass::factory()->create();
+
+        $currency = Currency::factory()->create([
+            'decimal_places' => 2,
+        ]);
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+            'coupon_code' => '10OFF',
+        ]);
+
+        $taxClass = TaxClass::factory()->create([
+            'name' => 'Foobar',
+        ]);
+
+        $taxClass->taxRateAmounts()->create(
+            TaxRateAmount::factory()->make([
+                'percentage' => 20,
+                'tax_class_id' => $taxClass->id,
+            ])->toArray()
+        );
+
+        $purchasable = ProductVariant::factory()->create([
+            'tax_class_id' => $taxClass->id,
+            'unit_quantity' => 1,
+        ]);
+
+        Price::factory()->create([
+            'price' => 1000,
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasable),
+            'priceable_id' => $purchasable->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasable),
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 1,
+        ]);
+
+        $cart->addresses()->createMany([
+            $billing->toArray(),
+            $shipping->toArray(),
+        ]);
+
+        $shippingOption = new ShippingOption(
+            name: 'Basic Delivery',
+            description: 'Basic Delivery',
+            identifier: 'BASDEL',
+            price: new PriceDataType(500, $cart->currency, 1),
+            taxClass: $taxClass
+        );
+
+        ShippingManifest::addOption($shippingOption);
+
+        $cart->shippingAddress->update([
+            'shipping_option' => $shippingOption->getIdentifier(),
+        ]);
+
+        $cart->shippingAddress->shippingOption = $shippingOption;
+        
+        $discount = Discount::factory()->create([
+            'type' => DiscountTypesDiscount::class,
+            'name' => 'Test Coupon',
+            'coupon' => '10OFF',
+            'data' => [
+                'fixed_value' => true,
+                'fixed_values' => [
+                    $currency->code => 1,
+                ],
+            ],
+        ]);
+
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+
+        $order = $cart->createOrder();
+
+        $cart = $cart->refresh();
+        
+        $discount = $discount->refresh();
+
+        $this->assertInstanceOf(Order::class, $cart->order);
+        $this->assertEquals(1, $discount->uses);
     }
 }


### PR DESCRIPTION
This PR adds incrementing the `uses` column of discounts as part of the order creation process. 

This is likely not the right approach, but is intended to kick start a conversation as to how is best to achieve this. 

Things that should be considered:
- Should discounts be associated with an order so that you can know which orders had which discount applied? (maybe as an order line)
- Should incrementing only be done once payment has been received, and if so how do we approach that.