### PR TITLE
Add correct params to TransactionObserver

### DIFF
--- a/packages/core/src/Observers/TransactionObserver.php
+++ b/packages/core/src/Observers/TransactionObserver.php
@@ -7,9 +7,9 @@ use Lunar\Models\Transaction;
 class TransactionObserver
 {
     /**
-     * Handle the OrderLine "updated" event.
+     * Handle the Transaction "created" event.
      *
-     * @param  \Lunar\Models\OrderLine  $orderLine
+     * @param  \Lunar\Models\Transaction  $orderLine
      * @return void
      */
     public function created(Transaction $transaction)


### PR DESCRIPTION
I noticed the params in the comment of TransactionObserver are incorrect, which will cause issues for some IDEs.