### PR TITLE
Fix blade directive

### DIFF
--- a/utils/livewire-tables/resources/views/columns/badge.blade.php
+++ b/utils/livewire-tables/resources/views/columns/badge.blade.php
@@ -1,9 +1,9 @@
 <div>
     <span @class([
         'lt-text-xs lt-inline-block lt-py-1 lt-px-2 lt-rounded',
-        'lt-text-green-600 lt-bg-green-50' => !@empty($success),
-        'lt-text-yellow-600 lt-bg-yellow-50' => !@empty($warning),
-        'lt-text-red-600 lt-bg-red-50' => !@empty($danger),
+        'lt-text-green-600 lt-bg-green-50' => !empty($success),
+        'lt-text-yellow-600 lt-bg-yellow-50' => !empty($warning),
+        'lt-text-red-600 lt-bg-red-50' => !empty($danger),
     ])>
         {{ $value }}
     </span>

--- a/utils/livewire-tables/resources/views/columns/badge.blade.php
+++ b/utils/livewire-tables/resources/views/columns/badge.blade.php
@@ -2,9 +2,7 @@
     <span @class([
         'lt-text-xs lt-inline-block lt-py-1 lt-px-2 lt-rounded',
         'lt-text-green-600 lt-bg-green-50' => !@empty($success),
-        'lt-text-yellow-600 lt-bg-yellow-50' => !@empty(
-            $warning
-        ),
+        'lt-text-yellow-600 lt-bg-yellow-50' => !@empty($warning),
         'lt-text-red-600 lt-bg-red-50' => !@empty($danger),
     ])>
         {{ $value }}


### PR DESCRIPTION
This syntax seems to be broken on Laravel `9.47` and up:

```diff
<div>
    <span @class([
        'lt-text-xs lt-inline-block lt-py-1 lt-px-2 lt-rounded',
        'lt-text-green-600 lt-bg-green-50' => !@empty($success),
-        'lt-text-yellow-600 lt-bg-yellow-50' => !@empty(
-            $warning
-        ),
        'lt-text-red-600 lt-bg-red-50' => !@empty($danger),
    ])>
        {{ $value }}
    </span>
</div>

```
In my project, the error is thrown when opening the products page in the hub.

Looks like this issue in Laravel was introduced here: https://github.com/laravel/framework/pull/45490

Setting the `laravel/framework` version to `9.46.0` fixes the issue in my project.