### PR TITLE
fixed the minSpend condition on Discount Feature

### DIFF
--- a/packages/core/src/DiscountTypes/Discount.php
+++ b/packages/core/src/DiscountTypes/Discount.php
@@ -37,7 +37,7 @@ class Discount extends AbstractDiscountType
 
         $lines = $this->getEligibleLines($cart);
 
-        if (! $passes || ($minSpend && $minSpend < $lines->sum('subTotal.value'))) {
+        if (! $passes || ($minSpend && $minSpend >= $lines->sum('subTotal.value'))) {
             return $cart;
         }
 


### PR DESCRIPTION
there is an issue with the coupon code **'Minimum cart amount'** if i set Minimum cart amount = 10$ && if I have cart subtotal = 100$ then this condition will not work and the coupon will not get applied.

`if (! $passes || ($minSpend && $minSpend < $lines->sum('subTotal.value'))) {
            return $cart;
        }` 
 it should be 
 
 `if (! $passes || ($minSpend && $minSpend >= $lines->sum('subTotal.value'))) {
            return $cart;
        }`       