### PR TITLE
[0.2] Hotfix: retrieve correct collection group for collection tree after action

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
@@ -79,10 +79,10 @@ class CollectionTree extends Component
             $objectIdPositions = array_flip($ids);
 
             $models = Collection::withCount('children')
-            ->findMany($ids)
-            ->sortBy(function ($model) use ($objectIdPositions) {
-                return $objectIdPositions[$model->getKey()];
-            })->values();
+                ->findMany($ids)
+                ->sortBy(function ($model) use ($objectIdPositions) {
+                    return $objectIdPositions[$model->getKey()];
+                })->values();
 
             Collection::rebuildSubtree(
                 $models->first()->parent,
@@ -151,7 +151,7 @@ class CollectionTree extends Component
     {
         $parentId = collect($this->nodes)->first()['parent_id'];
         $this->nodes = $this->mapCollections(
-            Collection::whereParentId($parentId)->withCount('children')->defaultOrder()->get()
+            Collection::whereParentId($parentId)->inGroup($this->owner->id)->withCount('children')->defaultOrder()->get()
         );
     }
 
@@ -168,7 +168,7 @@ class CollectionTree extends Component
 
         if ($parentMatched) {
             $this->nodes = $this->mapCollections(
-                Collection::whereParentId($parentId)->withCount('children')->defaultOrder()->get()
+                Collection::whereParentId($parentId)->inGroup($this->owner->id)->withCount('children')->defaultOrder()->get()
             );
         }
 
@@ -177,7 +177,7 @@ class CollectionTree extends Component
 
         if ($nodeMatched) {
             $this->nodes = $this->mapCollections(
-                Collection::whereParentId($nodeMatched['parent_id'])->withCount('children')->defaultOrder()->get()
+                Collection::whereParentId($nodeMatched['parent_id'])->inGroup($this->owner->id)->withCount('children')->defaultOrder()->get()
             );
         }
     }


### PR DESCRIPTION
**issue:**
when deleting or moving a collection into sub-collection or to root, the tree doesn't update with correct collection group

**steps:**
- have more than 1 collection group
- ensure all collection groups have collection
- delete/move a collection
- nodes will show collection from all collection groups