### PR TITLE
Fix validation of attributes of type TranslatedText

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -55,7 +55,7 @@ trait WithAttributes
     /**
      * Parse the attributes into the correct collection format.
      *
-     * @param  \Illuminate\Support\Collection  $attributes
+     * @param \Illuminate\Support\Collection $attributes
      * @return \Illuminate\Support\Collection
      */
     protected function parseAttributes(Collection $attributes, $existingData, $key = 'attributeMapping')
@@ -64,7 +64,7 @@ trait WithAttributes
             return ! class_exists($attribute->type);
         })->mapWithKeys(function ($attribute) use ($key, $existingData) {
             $data = $existingData ?
-                $existingData->first(fn ($value, $handle) => $handle == $attribute->handle)
+                $existingData->first(fn($value, $handle) => $handle == $attribute->handle)
                 : null;
 
             $value = $data ? $data->getValue() : null;
@@ -73,24 +73,26 @@ trait WithAttributes
                 $value = $this->prepareTranslatedText($value);
             }
 
-            $reference = 'a_'.$attribute->id;
+            $reference = 'a_' . $attribute->id;
 
-            return [$reference => [
-                'name' => $attribute->translate('name'),
-                'group' => $attribute->attributeGroup->translate('name'),
-                'group_id' => $attribute->attributeGroup->id,
-                'group_handle' => $attribute->attributeGroup->handle,
-                'group_position' => $attribute->attributeGroup->position,
-                'id' => $attribute->handle,
-                'signature' => "{$key}.{$reference}.data",
-                'type' => $attribute->type,
-                'handle' => $attribute->handle,
-                'configuration' => $attribute->configuration,
-                'required' => $attribute->required,
-                'view' => app()->make($attribute->type)->getView(),
-                'validation' => $attribute->validation_rules,
-                'data' => $value,
-            ]];
+            return [
+                $reference => [
+                    'name' => $attribute->translate('name'),
+                    'group' => $attribute->attributeGroup->translate('name'),
+                    'group_id' => $attribute->attributeGroup->id,
+                    'group_handle' => $attribute->attributeGroup->handle,
+                    'group_position' => $attribute->attributeGroup->position,
+                    'id' => $attribute->handle,
+                    'signature' => "{$key}.{$reference}.data",
+                    'type' => $attribute->type,
+                    'handle' => $attribute->handle,
+                    'configuration' => $attribute->configuration,
+                    'required' => $attribute->required,
+                    'view' => app()->make($attribute->type)->getView(),
+                    'validation' => $attribute->validation_rules,
+                    'data' => $value,
+                ]
+            ];
         });
     }
 
@@ -103,7 +105,7 @@ trait WithAttributes
             ->get()->map(function ($group) {
                 return [
                     'model' => $group,
-                    'fields' => $this->attributeMapping->filter(fn ($att) => $att['group_id'] == $group->id),
+                    'fields' => $this->attributeMapping->filter(fn($att) => $att['group_id'] == $group->id),
                 ];
             });
     }
@@ -136,7 +138,7 @@ trait WithAttributes
     /**
      * Map translated values into field types.
      *
-     * @param  array  $data
+     * @param array $data
      * @return \Lunar\FieldTypes\TranslatedText
      */
     protected function mapTranslatedText($data)
@@ -152,7 +154,7 @@ trait WithAttributes
     /**
      * Prepare translated text field for Livewire modeling.
      *
-     * @param  string|array  $value
+     * @param string|array $value
      * @return array
      */
     protected function prepareTranslatedText($value)
@@ -192,13 +194,15 @@ trait WithAttributes
             $isRequired = ($attribute['required'] ?? false) || ($attribute['system'] ?? false);
 
             // TranslatedText values are in an array, apply rules to each item of the array
-            // and make the default language's value required if necessary
             if ($attribute['type'] == TranslatedText::class) {
                 foreach ($this->languages as $language) {
+                    // all rules set when attribute was created (resets on each iteration)
+                    $validationRules = $validation;
                     if ($language->default && $isRequired) {
-                        $validation = array_merge($validation, ['required']);
+                        // append required for the default language
+                        $validationRules = array_merge($validationRules, ['required']);
                     }
-                    $rules["{$attribute['signature']}.{$language->code}"] = $validation;
+                    $rules["{$attribute['signature']}.{$language->code}"] = $validationRules;
                 }
                 continue;
             }
@@ -217,7 +221,6 @@ trait WithAttributes
 
             $rules[$field] = implode('|', $validation);
         }
-
         return $rules;
     }
 
@@ -247,7 +250,7 @@ trait WithAttributes
     /**
      * Handle attributes updated event.
      *
-     * @param  array  $event
+     * @param array $event
      * @return void
      */
     public function updatedAttributes($event)

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -4,9 +4,13 @@ namespace Lunar\Hub\Tests\Unit\Http\Livewire\Components\Products;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
+use Lunar\FieldTypes\Number;
+use Lunar\FieldTypes\Text;
+use Lunar\FieldTypes\TranslatedText;
 use Lunar\Hub\Http\Livewire\Components\Products\ProductCreate;
 use Lunar\Hub\Models\Staff;
 use Lunar\Hub\Tests\TestCase;
+use Lunar\Models\Attribute;
 use Lunar\Models\Brand;
 use Lunar\Models\Collection;
 use Lunar\Models\Currency;
@@ -52,7 +56,7 @@ class ProductCreateTest extends TestCase
         ProductType::factory()->create();
     }
 
-    /** @test  */
+    /** @test */
     public function component_mounts_correctly()
     {
         $staff = Staff::factory()->create([
@@ -135,15 +139,17 @@ class ProductCreateTest extends TestCase
                     'name' => $productC->translateAttribute('name'),
                     'type' => 'cross-sell',
                 ],
-            ]))->set('collections', collect([[
-                'id' => $collection->id,
-                'name' => $collection->translateAttribute('name'),
-                'group_id' => $collection->collection_group_id,
-                'group_name' => $collection->group->name,
-                'thumbnail' => null,
-                'breadcrumb' => ['Foo', 'Bar'],
-                'position' => 1,
-            ]]))
+            ]))->set('collections', collect([
+                [
+                    'id' => $collection->id,
+                    'name' => $collection->translateAttribute('name'),
+                    'group_id' => $collection->collection_group_id,
+                    'group_name' => $collection->group->name,
+                    'thumbnail' => null,
+                    'breadcrumb' => ['Foo', 'Bar'],
+                    'position' => 1,
+                ]
+            ]))
             ->call('save')
             ->assertHasNoErrors();
 
@@ -180,5 +186,216 @@ class ProductCreateTest extends TestCase
             'element_type' => Product::class,
             'element_id' => $component->get('product.id'),
         ]);
+    }
+
+    /** @test */
+    public function validates_required_translated_text_attribute()
+    {
+        // value for attribute in default language MUST be REQUIRED
+        // value for attribute in additional languages are optional
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $language = Language::getDefault();
+
+        $attribute = Attribute::factory()->create([
+            'type' => TranslatedText::class,
+            'required' => true,
+        ]);
+
+        $productType = ProductType::all()->first();
+
+        $productType->mappedAttributes()->attach($attribute);
+
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->call('save')
+            ->assertHasErrors([
+                "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'required',
+            ])
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data.fr" => 'required'
+            ]);
+    }
+
+    /** @test */
+    public function validates_optional_translated_text_attribute()
+    {
+        // optional attribute must only apply user set validation rules
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $language = Language::getDefault();
+
+        $attribute = Attribute::factory()->create([
+            'type' => TranslatedText::class,
+            'required' => false,
+            'validation_rules' => 'string,max:9'
+        ]);
+
+        $productType = ProductType::all()->first();
+
+        $productType->mappedAttributes()->attach($attribute);
+
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data.{$language->code}", 'more than ten letters')
+            ->call('save')
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'required',
+            ])
+            ->assertHasErrors([
+                "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'max'
+            ]);
+    }
+
+    /** @test */
+    public function validates_required_text_attribute()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $attribute = Attribute::factory()->create([
+            'type' => Text::class,
+            'required' => true,
+        ]);
+
+        $productType = ProductType::all()->first();
+
+        $productType->mappedAttributes()->attach($attribute);
+
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->call('save')
+            ->assertHasErrors([
+                "attributeMapping.a_{$attribute->id}.data" => 'required',
+            ]);
+
+        Livewire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data", 'some value')
+            ->call('save')
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data" => 'required'
+            ]);
+    }
+
+    /** @test */
+    public function validates_optional_text_attribute()
+    {
+        // with additional rules
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $attribute = Attribute::factory()->create([
+            'type' => Text::class,
+            'required' => false,
+            'validation_rules' => 'numeric'
+        ]);
+
+        $productType = ProductType::all()->first();
+
+        $productType->mappedAttributes()->attach($attribute);
+
+        // it is not required for realsies
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->call('save')
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data" => 'required',
+            ]);
+
+        // fail the additional validation rules
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data", 'text not a number')
+            ->call('save')
+            ->assertHasErrors([
+                "attributeMapping.a_{$attribute->id}.data" => 'numeric',
+            ]);
+
+        // pass the validation
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data", '42')
+            ->call('save')
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data",
+            ]);
+    }
+
+    /** @test */
+    public function validates_required_number_attribute()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $attribute = Attribute::factory()->create([
+            'type' => Number::class,
+            'required' => true,
+            'configuration' => ['min' => 2, 'max' => 5],
+        ]);
+
+        $productType = ProductType::all()->first();
+
+        $productType->mappedAttributes()->attach($attribute);
+
+        // fail the required rule
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->call('save')
+            ->assertHasErrors([
+                "attributeMapping.a_{$attribute->id}.data" => 'required',
+            ]);
+
+        // pass the required rule
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data", 3)
+            ->call('save')
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data" => 'required',
+            ]);
+    }
+
+    /** @test */
+    public function validates_optional_number_attribute()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $attribute = Attribute::factory()->create([
+            'type' => Number::class,
+            'required' => true,
+            'configuration' => ['min' => 2, 'max' => 5],
+        ]);
+
+        $productType = ProductType::all()->first();
+
+        $productType->mappedAttributes()->attach($attribute);
+
+        // fail the configuration rules
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data", 10)
+            ->call('save')
+            ->assertHasErrors([
+                "attributeMapping.a_{$attribute->id}.data",
+            ]);
+
+        // pass the configuration rules
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set("attributeMapping.a_{$attribute->id}.data", 3)
+            ->call('save')
+            ->assertHasNoErrors([
+                "attributeMapping.a_{$attribute->id}.data",
+            ]);
     }
 }

--- a/packages/core/src/DiscountTypes/Discount.php
+++ b/packages/core/src/DiscountTypes/Discount.php
@@ -118,7 +118,7 @@ class Discount extends AbstractDiscountType
 
         if ($productIds->count()) {
             $lines = $lines->reject(function ($line) use ($productIds) {
-                return ! $productIds->contains(get_class($line->purchasable->product).'::'.$line->purchasable->id);
+                return ! $productIds->contains(get_class($line->purchasable->product).'::'.$line->purchasable->product->id);
             });
         }
 


### PR DESCRIPTION
Applying additional validation rules (specified when adding/updating an attribute) to attributes of type `TranslatedText` is wrong. It is applying the rule to the field that is [a collection of items](https://github.com/lunarphp/lunar/blob/main/packages/core/src/FieldTypes/TranslatedText.php#L59). So if the rule `string` was added to the attribute it would validate the collection/array of items against it and **always** fail.

**Note**: If you're testing it and your attribute has the `RichText` feature enabled and is also required, the js plugin used for [WYSIWYG adds `<p><br></p>`](https://github.com/quilljs/quill/issues/1235) as content even when all the text is deleted and it looks like the required rule isn't working. 

