### PR TITLE
[0.2] Fix/discount by product

### DIFF
--- a/packages/core/database/factories/CartFactory.php
+++ b/packages/core/database/factories/CartFactory.php
@@ -18,7 +18,6 @@ class CartFactory extends Factory
             'merged_id' => null,
             'currency_id' => Currency::factory(),
             'channel_id' => Channel::factory(),
-            'coupon_code' => $this->faker->boolean ? $this->faker->word : null,
             'completed_at' => null,
             'meta' => [],
         ];

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -65,7 +65,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $cartCoupon = strtoupper($cart->coupon_code ?? null);
         $conditionCoupon = strtoupper($this->discount->coupon ?? null);
 
-        $validCoupon = $conditionCoupon ? ($cartCoupon === $conditionCoupon) : true;
+        $validCoupon = $cartCoupon && $conditionCoupon ? ($cartCoupon === $conditionCoupon) : true;
 
         $minSpend = $data['min_prices'][$cart->currency->code] ?? null;
         $minSpend = (int) bcmul($minSpend, $cart->currency->factor);

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -65,7 +65,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $cartCoupon = strtoupper($cart->coupon_code ?? null);
         $conditionCoupon = strtoupper($this->discount->coupon ?? null);
 
-        $validCoupon = $cartCoupon && $conditionCoupon ? ($cartCoupon === $conditionCoupon) : true;
+        $validCoupon = $cartCoupon ? ($cartCoupon === $conditionCoupon) : blank($conditionCoupon);
 
         $minSpend = $data['min_prices'][$cart->currency->code] ?? null;
         $minSpend = (int) bcmul($minSpend, $cart->currency->factor);

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -2,7 +2,9 @@
 
 namespace Lunar\DiscountTypes;
 
+use Illuminate\Support\Collection;
 use Lunar\Base\DiscountTypeInterface;
+use Lunar\Models\Cart;
 use Lunar\Models\Discount;
 
 abstract class AbstractDiscountType implements DiscountTypeInterface
@@ -37,5 +39,42 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $this->discount->uses = $this->discount->uses + 1;
 
         return $this;
+    }
+
+    /**
+     * Return the eligible lines for the discount.
+     *
+     * @param  Cart  $cart
+     * @return Illuminate\Support\Collection
+     */
+    protected function getEligibleLines(Cart $cart): Collection
+    {
+        return $cart->lines;
+    }
+
+    /**
+     * Check if discount's conditions met.
+     *
+     * @param  Cart  $cart
+     * @return bool
+     */
+    protected function checkDiscountConditions(Cart $cart): bool
+    {
+        $data = $this->discount->data;
+
+        $cartCoupon = strtoupper($cart->coupon_code ?? null);
+        $conditionCoupon = strtoupper($this->discount->coupon ?? null);
+
+        $validCoupon = $conditionCoupon ? ($cartCoupon === $conditionCoupon) : true;
+
+        $minSpend = $data['min_prices'][$cart->currency->code] ?? null;
+        $minSpend = (int) bcmul($minSpend, $cart->currency->factor);
+
+        $lines = $this->getEligibleLines($cart);
+        $validMinSpend = $minSpend ? $minSpend < $lines->sum('subTotal.value') : true;
+
+        $validMaxUses = $this->discount->max_uses ? $this->discount->uses < $this->discount->max_uses : true;
+
+        return $validCoupon && $validMinSpend && $validMaxUses;
     }
 }

--- a/packages/core/src/DiscountTypes/Discount.php
+++ b/packages/core/src/DiscountTypes/Discount.php
@@ -118,7 +118,7 @@ class Discount extends AbstractDiscountType
 
         if ($productIds->count()) {
             $lines = $lines->reject(function ($line) use ($productIds) {
-                return ! $productIds->contains(get_class($line->purchasable->product).'::'.$line->purchasable->id);
+                return !$productIds->contains(get_class($line->purchasable->product) . '::' . $line->purchasable->product->id);
             });
         }
 

--- a/packages/core/src/DiscountTypes/Discount.php
+++ b/packages/core/src/DiscountTypes/Discount.php
@@ -34,6 +34,7 @@ class Discount extends AbstractDiscountType
         $passes = $cartCoupon && ($cartCoupon === $conditionCoupon);
 
         $minSpend = $data['min_prices'][$cart->currency->code] ?? null;
+        $minSpend = (int) bcmul($minSpend, $cart->currency->factor);
 
         $lines = $this->getEligibleLines($cart);
 
@@ -65,7 +66,7 @@ class Discount extends AbstractDiscountType
     {
         $currency = $cart->currency;
 
-        $value = ($values[$currency->code] ?? 0) * 100;
+        $value = (int) bcmul($values[$currency->code] ?? 0, $currency->factor);
 
         $lines = $this->getEligibleLines($cart);
 

--- a/packages/core/tests/Unit/DiscountTypes/DiscountTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/DiscountTest.php
@@ -23,20 +23,33 @@ class DiscountTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Currency::factory()->create([
+            'code' => 'GBP',
+            'decimal_places' => 2,
+        ]);
+
+        Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        CustomerGroup::factory()->create([
+            'default' => true,
+        ]);
+    }
+
+
     /** @test */
     public function will_only_apply_to_lines_with_correct_brand()
     {
-        $customerGroup = CustomerGroup::factory()->create([
-            'default' => true,
-        ]);
+        $customerGroup = CustomerGroup::getDefault();
 
-        $channel = Channel::factory()->create([
-            'default' => true,
-        ]);
+        $channel = Channel::getDefault();
 
-        $currency = Currency::factory()->create([
-            'code' => 'GBP',
-        ]);
+        $currency = Currency::getDefault();
 
         $cart = Cart::factory()->create([
             'channel_id' => $channel->id,
@@ -130,17 +143,11 @@ class DiscountTest extends TestCase
     /** @test */
     public function will_only_apply_to_lines_with_correct_product()
     {
-        $customerGroup = CustomerGroup::factory()->create([
-            'default' => true,
-        ]);
+        $customerGroup = CustomerGroup::getDefault();
 
-        $channel = Channel::factory()->create([
-            'default' => true,
-        ]);
+        $channel = Channel::getDefault();
 
-        $currency = Currency::factory()->create([
-            'code' => 'GBP',
-        ]);
+        $currency = Currency::getDefault();
 
         $cart = Cart::factory()->create([
             'channel_id' => $channel->id,
@@ -238,17 +245,11 @@ class DiscountTest extends TestCase
      */
     public function can_apply_fixed_amount_discount()
     {
-        $currency = Currency::factory()->create([
-            'code' => 'GBP',
-        ]);
+        $currency = Currency::getDefault();
 
-        $customerGroup = CustomerGroup::factory()->create([
-            'default' => true,
-        ]);
+        $customerGroup = CustomerGroup::getDefault();
 
-        $channel = Channel::factory()->create([
-            'default' => true,
-        ]);
+        $channel = Channel::getDefault();
 
         $cart = Cart::factory()->create([
             'currency_id' => $currency->id,
@@ -279,7 +280,7 @@ class DiscountTest extends TestCase
             'data' => [
                 'fixed_value' => true,
                 'fixed_values' => [
-                    'GBP' => 10,
+                    'GBP' => 10.5,
                 ],
             ],
         ]);
@@ -300,8 +301,8 @@ class DiscountTest extends TestCase
 
         $cart = $cart->calculate();
 
-        $this->assertEquals(1000, $cart->discountTotal->value);
-        $this->assertEquals(1400, $cart->total->value);
+        $this->assertEquals(1050, $cart->discountTotal->value);
+        $this->assertEquals(1350, $cart->total->value);
         $this->assertEquals(400, $cart->taxTotal->value);
         $this->assertCount(1, $cart->discounts);
     }
@@ -309,17 +310,11 @@ class DiscountTest extends TestCase
     /** @test */
     public function can_apply_percentage_discount()
     {
-        $customerGroup = CustomerGroup::factory()->create([
-            'default' => true,
-        ]);
+        $customerGroup = CustomerGroup::getDefault();
 
-        $channel = Channel::factory()->create([
-            'default' => true,
-        ]);
+        $channel = Channel::getDefault();
 
-        $currency = Currency::factory()->create([
-            'code' => 'GBP',
-        ]);
+        $currency = Currency::getDefault();
 
         $cart = Cart::factory()->create([
             'channel_id' => $channel->id,
@@ -376,5 +371,526 @@ class DiscountTest extends TestCase
         $this->assertEquals(100, $cart->discountTotal->value);
         $this->assertEquals(200, $cart->taxTotal->value);
         $this->assertEquals(1100, $cart->total->value);
+    }
+
+
+    /**
+     * @test
+     */
+    public function can_apply_discount_without_coupon_code()
+    {
+        $currency = Currency::getDefault();
+
+        $customerGroup = CustomerGroup::getDefault();
+
+        $channel = Channel::getDefault();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $purchasableA = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id' => $purchasableA->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasableA),
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 2,
+        ]);
+
+        $discount = Discount::factory()->create([
+            'type' => DiscountTypesDiscount::class,
+            'name' => 'Test Coupon',
+            'data' => [
+                'fixed_value' => true,
+                'fixed_values' => [
+                    'GBP' => 10,
+                ],
+            ],
+        ]);
+
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+
+        $cart = $cart->calculate();
+
+        $this->assertEquals(1000, $cart->discountTotal->value);
+        $this->assertEquals(1400, $cart->total->value);
+        $this->assertEquals(400, $cart->taxTotal->value);
+        $this->assertCount(1, $cart->discounts);
+    }
+
+    /**
+     * @test
+     */
+    public function can_apply_discount_with_max_uses()
+    {
+        $currency = Currency::getDefault();
+
+        $customerGroup = CustomerGroup::getDefault();
+
+        $channel = Channel::getDefault();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $purchasableA = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id' => $purchasableA->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasableA),
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 2,
+        ]);
+
+        $discount = Discount::factory()->create([
+            'type' => DiscountTypesDiscount::class,
+            'name' => 'Test Coupon',
+            'uses' => 2,
+            'max_uses' => 10,
+            'data' => [
+                'fixed_value' => true,
+                'fixed_values' => [
+                    'GBP' => 10,
+                ],
+            ],
+        ]);
+
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+
+        $cart = $cart->calculate();
+
+        $this->assertEquals(1000, $cart->discountTotal->value);
+        $this->assertEquals(1400, $cart->total->value);
+        $this->assertEquals(400, $cart->taxTotal->value);
+        $this->assertCount(1, $cart->discounts);
+    }
+    /**
+     * @test
+     */
+    public function cannot_apply_discount_with_max_uses()
+    {
+        $currency = Currency::getDefault();
+
+        $customerGroup = CustomerGroup::getDefault();
+
+        $channel = Channel::getDefault();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $purchasableA = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id' => $purchasableA->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasableA),
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 2,
+        ]);
+
+        $discount = Discount::factory()->create([
+            'type' => DiscountTypesDiscount::class,
+            'name' => 'Test Coupon',
+            'uses' => 10,
+            'max_uses' => 10,
+            'data' => [
+                'fixed_value' => true,
+                'fixed_values' => [
+                    'GBP' => 10,
+                ],
+            ],
+        ]);
+
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+
+        $cart = $cart->calculate();
+
+        $this->assertEquals(0, $cart->discountTotal->value);
+        $this->assertEquals(2400, $cart->total->value);
+        $this->assertEquals(2000, $cart->subTotal->value);
+    }
+
+    /**
+     * @test
+     */
+    public function can_apply_discount_with_min_spend()
+    {
+        $currency = Currency::getDefault();
+
+        $customerGroup = CustomerGroup::getDefault();
+
+        $channel = Channel::getDefault();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $purchasableA = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id' => $purchasableA->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasableA),
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 20,
+        ]);
+
+        $discount = Discount::factory()->create([
+            'type' => DiscountTypesDiscount::class,
+            'name' => 'Test Coupon',
+            'uses' => 2,
+            'max_uses' => 10,
+            'data' => [
+                'fixed_value' => true,
+                'fixed_values' => [
+                    'GBP' => 10,
+                ],
+                "min_prices" => [
+                    'GBP' => 50,
+                ]
+            ],
+        ]);
+
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+
+        $cart = $cart->calculate();
+
+        $this->assertEquals(1000, $cart->discountTotal->value);
+        $this->assertEquals(20_000, $cart->subTotal->value);
+        $this->assertEquals(23_000, $cart->total->value);
+        $this->assertEquals(4000, $cart->taxTotal->value);
+        $this->assertCount(1, $cart->discounts);
+    }
+
+    /**
+     * @test
+     */
+    public function cannot_apply_discount_with_min_spend()
+    {
+        $currency = Currency::getDefault();
+
+        $customerGroup = CustomerGroup::getDefault();
+
+        $channel = Channel::getDefault();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $purchasableA = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id' => $purchasableA->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasableA),
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 2,
+        ]);
+
+        $discount = Discount::factory()->create([
+            'type' => DiscountTypesDiscount::class,
+            'name' => 'Test Coupon',
+            'uses' => 2,
+            'max_uses' => 10,
+            'data' => [
+                'fixed_value' => true,
+                'fixed_values' => [
+                    'GBP' => 10,
+                ],
+                "min_prices" => [
+                    'GBP' => 50,
+                ]
+            ],
+        ]);
+
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+
+        $cart = $cart->calculate();
+
+        $this->assertEquals(0, $cart->discountTotal->value);
+        $this->assertEquals(2000, $cart->subTotal->value);
+        $this->assertEquals(2400, $cart->total->value);
+        $this->assertEquals(400, $cart->taxTotal->value);
+        $this->assertNull($cart->discounts);
+    }
+
+    /**
+     * @test
+     */
+    public function can_apply_discount_with_conditions()
+    {
+        $currency = Currency::getDefault();
+
+        $customerGroup = CustomerGroup::getDefault();
+
+        $channel = Channel::getDefault();
+
+        $purchasableA = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id' => $purchasableA->id,
+        ]);
+
+        $scenarios = [
+            [
+                // no conditions
+                'test' => [
+                    'discount' => [
+                        'data' => [
+                            'fixed_value' => true,
+                            'fixed_values' => [
+                                'GBP' => 10,
+                            ],
+                        ],
+                    ]
+                ],
+                'expect' => [
+                    'discount' => 1000,
+                    'subTotal' => 20_000,
+                    'total' => 23_000,
+                    'taxTotal' => 4000,
+                    'discounts' => 1,
+                ],
+            ],
+            [
+                // coupon code
+                'test' => [
+                    'cart' => [
+                        'coupon_code' => 'OFF10'
+                    ],
+                    'discount' => [
+                        'coupon' => 'OFF10',
+                        'data' => [
+                            'fixed_value' => true,
+                            'fixed_values' => [
+                                'GBP' => 10,
+                            ],
+                        ],
+                    ]
+                ],
+                'expect' => [
+                    'discount' => 1000,
+                    'subTotal' => 20_000,
+                    'total' => 23_000,
+                    'taxTotal' => 4000,
+                    'discounts' => 1,
+                ],
+            ],
+            [
+                // coupon code + max uses
+                'test' => [
+                    'cart' => [
+                        'coupon_code' => 'OFF10'
+                    ],
+                    'discount' => [
+                        'coupon' => 'OFF10',
+                        'uses' => 2,
+                        'max_uses' => 10,
+                        'data' => [
+                            'fixed_value' => true,
+                            'fixed_values' => [
+                                'GBP' => 10,
+                            ],
+                        ],
+                    ]
+                ],
+                'expect' => [
+                    'discount' => 1000,
+                    'subTotal' => 20_000,
+                    'total' => 23_000,
+                    'taxTotal' => 4000,
+                    'discounts' => 1,
+                ],
+            ],
+            [
+                // coupon code + max uses + min prices
+                'test' => [
+                    'cart' => [
+                        'coupon_code' => 'OFF10'
+                    ],
+                    'discount' => [
+                        'coupon' => 'OFF10',
+                        'uses' => 2,
+                        'max_uses' => 10,
+                        'data' => [
+                            'fixed_value' => true,
+                            'fixed_values' => [
+                                'GBP' => 10,
+                            ],
+                            "min_prices" => [
+                                'GBP' => 50,
+                            ]
+                        ],
+                    ]
+                ],
+                'expect' => [
+                    'discount' => 1000,
+                    'subTotal' => 20_000,
+                    'total' => 23_000,
+                    'taxTotal' => 4000,
+                    'discounts' => 1,
+                ],
+            ],
+        ];
+
+        foreach ($scenarios as $scenario) {
+            $cart = Cart::factory()->create(
+                array_merge(
+                    [
+                        'currency_id' => $currency->id,
+                        'channel_id' => $channel->id,
+                    ],
+                    @$scenario['test']['cart'] ?? []
+                )
+            );
+
+            $cart->lines()->create([
+                'purchasable_type' => get_class($purchasableA),
+                'purchasable_id' => $purchasableA->id,
+                'quantity' => 20,
+            ]);
+
+            Discount::query()->delete();
+
+            $discount = Discount::factory()->create(array_merge(
+                [
+                    'type' => DiscountTypesDiscount::class,
+                    'name' => 'Test Coupon',
+                ],
+                $scenario['test']['discount']
+            ));
+
+            $discount->customerGroups()->sync([
+                $customerGroup->id => [
+                    'enabled' => true,
+                    'starts_at' => now(),
+                ],
+            ]);
+
+            $discount->channels()->sync([
+                $channel->id => [
+                    'enabled' => true,
+                    'starts_at' => now()->subHour(),
+                ],
+            ]);
+
+            $cart = $cart->calculate();
+
+            $expect = $scenario['expect'];
+
+            $this->assertEquals($expect['discount'], $cart->discountTotal->value);
+            $this->assertEquals($expect['subTotal'], $cart->subTotal->value);
+            $this->assertEquals($expect['total'], $cart->total->value);
+            $this->assertEquals($expect['taxTotal'], $cart->taxTotal->value);
+
+            if (is_null($expect['discounts'])) {
+                $this->assertNull($cart->discounts);
+            } else {
+                $this->assertCount($expect['discounts'], $cart->discounts);
+            }
+        }
     }
 }


### PR DESCRIPTION
issues:
1. discount's conditions checking
     - if cart has coupon but discount doesn't have coupon code won't apply, but discount without code should auto apply
     - minSpend not using correct precision
2. fixedValue discount using hardcoded precision `* 100`
3. small refactor and introduce `checkDiscountConditions` method to allow other discountType to extend