### PR TITLE
Hotfix [0.2] - Wrap customer group in array

### DIFF
--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -164,9 +164,9 @@ class PricingManager implements PricingManagerInterface
         }
 
         if (! $this->customerGroups || ! $this->customerGroups->count()) {
-            $this->customerGroups = collect(
+            $this->customerGroups = collect([
                 CustomerGroup::getDefault()
-            );
+            ]);
         }
 
         // Do we have a user?

--- a/packages/core/tests/Unit/Models/ProductVariantTest.php
+++ b/packages/core/tests/Unit/Models/ProductVariantTest.php
@@ -92,7 +92,7 @@ class ProductVariantTest extends TestCase
 
         $variant = $variant->load('prices');
 
-        $this->assertEquals(Pricing::for($variant)->get()->matched->price->value, 100);
+        $this->assertEquals(Pricing::for($variant)->get()->matched->price->value, 90);
         $this->assertEquals(Pricing::qty(5)->for($variant)->get()->matched->price->value, 60);
         $this->assertEquals(Pricing::qty(5)->customerGroup($groupB)->for($variant)->get()->matched->price->value, 30);
         $this->assertEquals(Pricing::customerGroup($groupB)->for($variant)->get()->matched->price->value, 80);


### PR DESCRIPTION
Currently we're setting:

```php
collect($customerGroup);
```

When it should be

```
collect([$customerGroup]);
```

The former will actually spread the customer group model attributes into a collection, which of course is wrong.