### PR TITLE
[0.2] Hotfix - Discount issues

### DIFF
--- a/packages/core/src/DiscountTypes/Discount.php
+++ b/packages/core/src/DiscountTypes/Discount.php
@@ -33,7 +33,7 @@ class Discount extends AbstractDiscountType
         $cartCoupon = strtoupper($cart->coupon_code ?? null);
         $conditionCoupon = strtoupper($this->discount->coupon ?? null);
 
-        $passes = !$cartCoupon || ($cartCoupon === $conditionCoupon);
+        $passes = !$conditionCoupon || ($cartCoupon === $conditionCoupon);
 
         $minSpend = $data['min_prices'][$cart->currency->code] ?? null;
 

--- a/packages/core/src/DiscountTypes/Discount.php
+++ b/packages/core/src/DiscountTypes/Discount.php
@@ -67,7 +67,7 @@ class Discount extends AbstractDiscountType
     {
         $currency = $cart->currency;
 
-        $value = ($values[$currency->code] ?? 0) * 100;
+        $value = ($values[$currency->code] ?? 0) * $cart->currency->factor;
 
         $lines = $this->getEligibleLines($cart);
 
@@ -146,7 +146,7 @@ class Discount extends AbstractDiscountType
 
         foreach ($lines as $line) {
             $subTotal = $line->subTotal->value;
-            $amount = (int) round($subTotal * ($value / 100));
+            $amount = (int) round($subTotal * ($value / $cart->currency->factor));
 
             $line->discountTotal = new Price(
                 $amount,


### PR DESCRIPTION
Theres overlap with PR #841 here but I wanted to push up as conversation on it seems to have stalled.

This fixes up a few issues I've found on discounts:

1. Cache getEligibleLines to avoid re-running queries and logic
2. Handle there not being a condition coupon, which per the UI indicates the discount should be added automatically
3. Applies currency factoring

One thing I've noticed in testing is that percentage discounts don't apply a cart level discount value (`cartDiscountAmount`) in the way fixed discounts do. Is this intentional?