### PR TITLE
[0.2] Hotfix - Fix media upload, file missing exception

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Livewire\TemporaryUploadedFile;
 use Spatie\Activitylog\Facades\LogBatch;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Livewire\FileUploadConfiguration;
 
 trait HasImages
 {
@@ -253,16 +254,12 @@ trait HasImages
                         ->substr(0, 128)
                         ->append('.', $file->getClientOriginalExtension());
 
-                    $mediaLibaryDisk = config('media-library.disk_name');
-                    $mediaLibaryDriverConfig = Storage::disk($mediaLibaryDisk)->getConfig();
-                    $mediaLibaryDriver = $mediaLibaryDriverConfig['driver'];
-
-                    if ($mediaLibaryDriver == 'local') {
-                        $media = $owner->addMedia($file->getRealPath())
+                    if (FileUploadConfiguration::isUsingS3()) {
+                        $media = $owner->addMediaFromDisk($file->getRealPath())
                             ->usingFileName($filename)
                             ->toMediaCollection('images');
                     } else {
-                        $media = $owner->addMediaFromDisk($file->getRealPath())
+                        $media = $owner->addMedia($file->getRealPath())
                             ->usingFileName($filename)
                             ->toMediaCollection('images');
                     }


### PR DESCRIPTION
Currently we check the spatie media library config to determine how we handle the temporary file uploaded by Livewire. This is wrong as the filesystem used by Spatie media library and what Livewire uses could be different.

The idea of the original change was to check if we are not using the local system and if not, attempt to resolve the temp file on `s3` or similar. Livewire fortunately has a handy helper to determine this, which is what this PR looks to introduce.

As a side effect this should also close #851 