### PR TITLE
Fix/brand table search

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Brands/BrandsTable.php
+++ b/packages/admin/src/Http/Livewire/Components/Brands/BrandsTable.php
@@ -15,6 +15,11 @@ class BrandsTable extends LunarTable
     /**
      * {@inheritDoc}
      */
+    public bool $searchable = true;
+
+    /**
+     * {@inheritDoc}
+     */
     public bool $filterable = false;
 
     /**
@@ -43,6 +48,10 @@ class BrandsTable extends LunarTable
     public function getData()
     {
         return Brand::with(['thumbnail'])
+            ->when($this->query, function ($query) {
+                $this->resetPage();
+                $query->whereIn('id', Brand::search($this->query)->keys());
+            })
             ->withCount(['products'])
             ->orderBy('name')
             ->paginate($this->perPage);

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -4,12 +4,11 @@ namespace Lunar\Hub\Http\Livewire\Traits;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Livewire\FileUploadConfiguration;
 use Livewire\TemporaryUploadedFile;
 use Spatie\Activitylog\Facades\LogBatch;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Livewire\FileUploadConfiguration;
 
 trait HasImages
 {

--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -55,7 +55,7 @@ trait WithAttributes
     /**
      * Parse the attributes into the correct collection format.
      *
-     * @param \Illuminate\Support\Collection $attributes
+     * @param  \Illuminate\Support\Collection  $attributes
      * @return \Illuminate\Support\Collection
      */
     protected function parseAttributes(Collection $attributes, $existingData, $key = 'attributeMapping')
@@ -64,7 +64,7 @@ trait WithAttributes
             return ! class_exists($attribute->type);
         })->mapWithKeys(function ($attribute) use ($key, $existingData) {
             $data = $existingData ?
-                $existingData->first(fn($value, $handle) => $handle == $attribute->handle)
+                $existingData->first(fn ($value, $handle) => $handle == $attribute->handle)
                 : null;
 
             $value = $data ? $data->getValue() : null;
@@ -73,7 +73,7 @@ trait WithAttributes
                 $value = $this->prepareTranslatedText($value);
             }
 
-            $reference = 'a_' . $attribute->id;
+            $reference = 'a_'.$attribute->id;
 
             return [
                 $reference => [
@@ -91,7 +91,7 @@ trait WithAttributes
                     'view' => app()->make($attribute->type)->getView(),
                     'validation' => $attribute->validation_rules,
                     'data' => $value,
-                ]
+                ],
             ];
         });
     }
@@ -105,7 +105,7 @@ trait WithAttributes
             ->get()->map(function ($group) {
                 return [
                     'model' => $group,
-                    'fields' => $this->attributeMapping->filter(fn($att) => $att['group_id'] == $group->id),
+                    'fields' => $this->attributeMapping->filter(fn ($att) => $att['group_id'] == $group->id),
                 ];
             });
     }
@@ -138,7 +138,7 @@ trait WithAttributes
     /**
      * Map translated values into field types.
      *
-     * @param array $data
+     * @param  array  $data
      * @return \Lunar\FieldTypes\TranslatedText
      */
     protected function mapTranslatedText($data)
@@ -154,7 +154,7 @@ trait WithAttributes
     /**
      * Prepare translated text field for Livewire modeling.
      *
-     * @param string|array $value
+     * @param  string|array  $value
      * @return array
      */
     protected function prepareTranslatedText($value)
@@ -204,9 +204,9 @@ trait WithAttributes
                     }
                     $rules["{$attribute['signature']}.{$language->code}"] = $validationRules;
                 }
+
                 continue;
             }
-
 
             if ($isRequired) {
                 $validation = array_merge($validation, ['required']);
@@ -214,13 +214,14 @@ trait WithAttributes
 
             if ($attribute['type'] == Number::class) {
                 $validation = array_merge($validation, [
-                    'numeric' . ($attribute['configuration']['min'] ? '|min:' . $attribute['configuration']['min'] : ''),
-                    'numeric' . ($attribute['configuration']['max'] ? '|max:' . $attribute['configuration']['max'] : ''),
+                    'numeric'.($attribute['configuration']['min'] ? '|min:'.$attribute['configuration']['min'] : ''),
+                    'numeric'.($attribute['configuration']['max'] ? '|max:'.$attribute['configuration']['max'] : ''),
                 ]);
             }
 
             $rules[$field] = implode('|', $validation);
         }
+
         return $rules;
     }
 
@@ -250,7 +251,7 @@ trait WithAttributes
     /**
      * Handle attributes updated event.
      *
-     * @param array $event
+     * @param  array  $event
      * @return void
      */
     public function updatedAttributes($event)

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -148,7 +148,7 @@ class ProductCreateTest extends TestCase
                     'thumbnail' => null,
                     'breadcrumb' => ['Foo', 'Bar'],
                     'position' => 1,
-                ]
+                ],
             ]))
             ->call('save')
             ->assertHasNoErrors();
@@ -215,7 +215,7 @@ class ProductCreateTest extends TestCase
                 "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'required',
             ])
             ->assertHasNoErrors([
-                "attributeMapping.a_{$attribute->id}.data.fr" => 'required'
+                "attributeMapping.a_{$attribute->id}.data.fr" => 'required',
             ]);
     }
 
@@ -232,7 +232,7 @@ class ProductCreateTest extends TestCase
         $attribute = Attribute::factory()->create([
             'type' => TranslatedText::class,
             'required' => false,
-            'validation_rules' => 'string,max:9'
+            'validation_rules' => 'string,max:9',
         ]);
 
         $productType = ProductType::all()->first();
@@ -247,7 +247,7 @@ class ProductCreateTest extends TestCase
                 "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'required',
             ])
             ->assertHasErrors([
-                "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'max'
+                "attributeMapping.a_{$attribute->id}.data.{$language->code}" => 'max',
             ]);
     }
 
@@ -279,7 +279,7 @@ class ProductCreateTest extends TestCase
             ->set("attributeMapping.a_{$attribute->id}.data", 'some value')
             ->call('save')
             ->assertHasNoErrors([
-                "attributeMapping.a_{$attribute->id}.data" => 'required'
+                "attributeMapping.a_{$attribute->id}.data" => 'required',
             ]);
     }
 
@@ -294,7 +294,7 @@ class ProductCreateTest extends TestCase
         $attribute = Attribute::factory()->create([
             'type' => Text::class,
             'required' => false,
-            'validation_rules' => 'numeric'
+            'validation_rules' => 'numeric',
         ]);
 
         $productType = ProductType::all()->first();

--- a/packages/core/config/search.php
+++ b/packages/core/config/search.php
@@ -18,6 +18,7 @@ return [
         \Lunar\Models\ProductOption::class,
         \Lunar\Models\Order::class,
         \Lunar\Models\Customer::class,
+        \Lunar\Models\Brand::class,
         // Below you can add your own models for indexing
     ],
     /*

--- a/utils/livewire-tables/resources/views/index.blade.php
+++ b/utils/livewire-tables/resources/views/index.blade.php
@@ -99,7 +99,7 @@
                             </div>
                         @endif
 
-                        @if ($this->hasSearchApplied)
+                        @if ($this->canSaveSearches && $this->hasSearchApplied)
                             <x-l-tables::button x-on:click="savingSearch = true">
                                 Save Search
                             </x-l-tables::button>


### PR DESCRIPTION
- enable Brand table search
- fix `save search` button do not show if its not enabled
- add `Brand` to search config

currently when applying search on table doesn't reset the page pagination, this causes issue when applying search in X page returns no result, due to pagination offset. should this be handled by table builder or manually