### PR TITLE
change default payment type

### DIFF
--- a/docs/src/lunar/payments.md
+++ b/docs/src/lunar/payments.md
@@ -18,7 +18,7 @@ All configuration for payments is located in `config/lunar/payments.php`. Here y
 <?php
 
 return [
-    'default' => env('PAYMENTS_TYPE', 'offline'),
+    'default' => env('PAYMENTS_TYPE', 'cash-in-hand'),
 
     'types' => [
         'cash-in-hand' => [

--- a/packages/admin/src/Views/Components/Orders/Status.php
+++ b/packages/admin/src/Views/Components/Orders/Status.php
@@ -42,7 +42,7 @@ class Status extends Component
 
         $match = $statuses[$status] ?? null;
 
-        $this->label = $match['label'] ?? $status;
+        $this->label = $match['label'] ?? 'N/A';
         $this->color = $match['color'] ?? '#7C7C7C';
         $this->status = $record?->status ?: $status;
     }

--- a/packages/admin/src/Views/Components/Orders/Status.php
+++ b/packages/admin/src/Views/Components/Orders/Status.php
@@ -42,7 +42,7 @@ class Status extends Component
 
         $match = $statuses[$status] ?? null;
 
-        $this->label = $match['label'] ?? 'N/A';
+        $this->label = $match['label'] ?? $status ?? 'N/A';
         $this->color = $match['color'] ?? '#7C7C7C';
         $this->status = $record?->status ?: $status;
     }

--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -31,6 +31,12 @@ return [
             'mailers' => [],
             'notifications' => [],
         ],
+        'payment-offline' => [
+            'label' => 'Payment Offline',
+            'color' => '#0A81D7',
+            'mailers' => [],
+            'notifications' => [],
+        ],
         'payment-received' => [
             'label' => 'Payment Received',
             'color' => '#6a67ce',

--- a/packages/core/config/payments.php
+++ b/packages/core/config/payments.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'default' => env('PAYMENTS_TYPE', 'offline'),
+    'default' => env('PAYMENTS_TYPE', 'cash-in-hand'),
 
     'types' => [
         'cash-in-hand' => [


### PR DESCRIPTION
- currently default payment type config is set to `env('PAYMENTS_TYPE', 'offline')`, which is wrong as `offline` payment **type** is not provided, the provided is **offline driver**
- added `payment-offline` status for order
- order status component to show label as 'N/A' when status label is null
