### PR TITLE
Add Brand ID to Fillable on Product

### DIFF
--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -101,6 +101,7 @@ class Product extends BaseModel implements SpatieHasMedia
         'attribute_data',
         'product_type_id',
         'status',
+        'brand_id',
     ];
 
     /**


### PR DESCRIPTION
Brand ID currently isn't fillable so it cannot be used for eloquent queries.

This changes that, so that Products can be created and assigned Brand ID
