### PR TITLE
fix route name

### DIFF
--- a/packages/admin/resources/views/livewire/components/products/product-types/index.blade.php
+++ b/packages/admin/resources/views/livewire/components/products/product-types/index.blade.php
@@ -6,7 +6,7 @@
 
         <div class="text-right">
             <x-hub::button tag="a"
-                           href="{{ route('hub.product-type.create') }}">
+                           href="{{ route('hub.product-types.create') }}">
                 {{ __('adminhub::catalogue.product-types.index.create_btn') }}
             </x-hub::button>
         </div>
@@ -14,57 +14,6 @@
 
     <div>
         @livewire('hub.components.products.product-types.table')
-        {{-- <x-hub::table>
-            <x-slot name="toolbar">
-                <div class="p-4">
-                    <x-hub::input.text wire:model="search"
-                                       placeholder="Search by attribute or SKU"
-                                       class="py-2" />
-                </div>
-            </x-slot>
-
-            <x-slot name="head">
-                <x-hub::table.heading>
-                    {{ __('adminhub::global.name') }}
-                </x-hub::table.heading>
-
-                <x-hub::table.heading>
-                    {{ __('adminhub::global.no_of_products') }}
-                </x-hub::table.heading>
-
-                <x-hub::table.heading>
-                    {{ __('adminhub::global.no_of_attributes') }}
-                </x-hub::table.heading>
-
-                <x-hub::table.heading></x-hub::table.heading>
-            </x-slot>
-
-            <x-slot name="body">
-                @forelse($productTypes as $type)
-                    <x-hub::table.row>
-                        <x-hub::table.cell>
-                            {{ $type->name }}
-                        </x-hub::table.cell>
-
-                        <x-hub::table.cell>
-                            {{ $type->products_count }}
-                        </x-hub::table.cell>
-
-                        <x-hub::table.cell>
-                            {{ $type->mapped_attributes_count }}
-                        </x-hub::table.cell>
-
-                        <x-hub::table.cell>
-                            <a href="{{ route('hub.product-type.show', $type->id) }}"
-                               class="text-indigo-500 hover:underline">
-                                Edit
-                            </a>
-                        </x-hub::table.cell>
-                    </x-hub::table.row>
-                @empty
-                @endforelse
-            </x-slot>
-        </x-hub::table> --}}
     </div>
 
 </div>

--- a/packages/admin/routes/includes/product-types.php
+++ b/packages/admin/routes/includes/product-types.php
@@ -9,6 +9,6 @@ Route::group([
     'middleware' => 'can:catalogue:manage-products',
 ], function () {
     Route::get('/', ProductTypeIndex::class)->name('hub.product-types.index');
-    Route::get('create', ProductTypeCreate::class)->name('hub.product-type.create');
-    Route::get('{productType}', ProductTypeShow::class)->name('hub.product-type.show');
+    Route::get('create', ProductTypeCreate::class)->name('hub.product-types.create');
+    Route::get('{productType}', ProductTypeShow::class)->name('hub.product-types.show');
 });

--- a/packages/admin/src/Http/Livewire/Components/Products/Tables/ProductTypesTable.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/Tables/ProductTypesTable.php
@@ -44,7 +44,7 @@ class ProductTypesTable extends Table
             TextColumn::make('name')->heading(
                 __('adminhub::tables.headings.name')
             )->url(function ($record) {
-                return route('hub.product-type.show', $record->id);
+                return route('hub.product-types.show', $record->id);
             }),
             TextColumn::make('product_count', function ($record) {
                 return $record->products_count;

--- a/packages/admin/src/Menu/MenuGroup.php
+++ b/packages/admin/src/Menu/MenuGroup.php
@@ -17,7 +17,7 @@ class MenuGroup extends MenuSlot
     /**
      * The display name of the menu group.
      *
-     * @var string
+     * @var string | array
      */
     public $handle;
 
@@ -53,6 +53,8 @@ class MenuGroup extends MenuSlot
      */
     public function isActive($path)
     {
-        return Str::startsWith($path, $this->handle);
+        return (bool) collect($this->handle)->first(function ($handle) use ($path) {
+            return Str::startsWith($path, $handle);
+        });
     }
 }

--- a/packages/admin/src/Menu/MenuLink.php
+++ b/packages/admin/src/Menu/MenuLink.php
@@ -31,7 +31,7 @@ class MenuLink implements MenuItem
     /**
      * The handle for the menu link.
      *
-     * @var string
+     * @var string | array
      */
     public $handle;
 
@@ -65,7 +65,7 @@ class MenuLink implements MenuItem
     /**
      * Setter for the handle property.
      *
-     * @param  string  $handle
+     * @param  string | array  $handle
      * @return static
      */
     public function handle($handle)
@@ -146,6 +146,8 @@ class MenuLink implements MenuItem
      */
     public function isActive($path)
     {
-        return Str::startsWith($path, $this->handle);
+        return (bool) collect($this->handle)->first(function ($handle) use ($path) {
+            return Str::startsWith($path, $handle);
+        });
     }
 }

--- a/packages/admin/src/Menu/SidebarMenu.php
+++ b/packages/admin/src/Menu/SidebarMenu.php
@@ -65,7 +65,10 @@ class SidebarMenu
         $catalogueGroup
             ->section('hub.collections')
             ->name(__('adminhub::menu.sidebar.collections'))
-            ->handle('hub.collection-groups')
+            ->handle([
+                'hub.collection-groups',
+                'hub.collections',
+            ])
             ->route('hub.collection-groups.index')
             ->icon('collection');
 

--- a/packages/admin/tests/Unit/Menu/MenuLinkTest.php
+++ b/packages/admin/tests/Unit/Menu/MenuLinkTest.php
@@ -76,4 +76,21 @@ class MenuLinkTest extends TestCase
         $this->assertTrue($menuLink->isActive('foo'));
         $this->assertTrue($menuLink->isActive('foo/bar'));
     }
+
+    /** @test */
+    public function active_state_is_correct_based_on_given_array_path()
+    {
+        $menuLink = new MenuLink();
+
+        $menuLink->handle([
+            'foo',
+            'second-foo',
+        ]);
+
+        $this->assertFalse($menuLink->isActive('hub/bar'));
+        $this->assertTrue($menuLink->isActive('foo'));
+        $this->assertTrue($menuLink->isActive('foo/bar'));
+        $this->assertTrue($menuLink->isActive('second-foo'));
+        $this->assertTrue($menuLink->isActive('second-foo/bar'));
+    }
 }

--- a/packages/admin/tests/Unit/Menu/MenuRegistrarTest.php
+++ b/packages/admin/tests/Unit/Menu/MenuRegistrarTest.php
@@ -9,7 +9,7 @@ use Lunar\Hub\Tests\TestCase;
 /**
  * @group hub.menu
  */
-class MenuRegistryTest extends TestCase
+class MenuRegistrarTest extends TestCase
 {
     /** @test */
     public function can_fetch_class_from_container()


### PR DESCRIPTION
1. enhance menu handle to support `array` 
  - collection page not showing active menu state

 **before**
![image](https://user-images.githubusercontent.com/67364036/219706979-83ac66ec-0de4-4066-af56-51a732d6beb1.png)

**after**
![image](https://user-images.githubusercontent.com/67364036/219707330-7763b5f9-3114-4be4-922d-37b30e345c06.png)




2. change product type route name

**before:**
![image](https://user-images.githubusercontent.com/67364036/219683242-0e2be062-80a8-4331-bd6d-27ca9d1948c4.png)

**after:**
![image](https://user-images.githubusercontent.com/67364036/219682915-44405986-6813-4c1a-b394-077645b77e61.png)

