### PR TITLE
Buy X get Y: Ensure we dont add discounts for partial quantities

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -107,7 +107,11 @@ class BuyXGetY
 
             $remainder = $rewardLine->quantity % $remainingRewardQty;
 
-            $qtyToAllocate = ($remainingRewardQty - $remainder) / $rewardLine->quantity;
+            $qtyToAllocate = floor(($remainingRewardQty - $remainder) / $rewardLine->quantity);
+
+            if (! $qtyToAllocate) {
+                continue;
+            }
 
             $remainingRewardQty -= $qtyToAllocate;
 

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -107,7 +107,7 @@ class BuyXGetY
 
             $remainder = $rewardLine->quantity % $remainingRewardQty;
 
-            $qtyToAllocate = floor(($remainingRewardQty - $remainder) / $rewardLine->quantity);
+            $qtyToAllocate = (int) floor(($remainingRewardQty - $remainder) / $rewardLine->quantity);
 
             if (! $qtyToAllocate) {
                 continue;


### PR DESCRIPTION
When using a Buy X get Y discount i noticed if your quantity was more than 1 then it was possible to get `partial` discounts adding (e.g. 0.5), which would then throw an error on the price data type as it was getting a float rather than an int.

See config:

<img width="1102" alt="Screenshot 2023-02-17 at 15 57 23" src="https://user-images.githubusercontent.com/51899/219702809-951299fe-a57a-46ae-96d7-a17e53087edf.png">

This PR fixes it.