### PR TITLE
fix: use `::make` to create models in Hub for new resources

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Products/ProductCreate.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductCreate.php
@@ -16,7 +16,7 @@ class ProductCreate extends AbstractProduct
      */
     public function mount()
     {
-        $this->product = new Product([
+        $this->product = Product::make([
             'status' => 'draft',
             'product_type_id' => ProductType::first()->id,
         ]);


### PR DESCRIPTION
Draft PR that fixes #877.

I am not 100% sure I understand the entirety of the functionality that allows us to use custom models for Products, Customers, Orders, etc, but based on the comment of [benjaminhull on stackoverflow](https://stackoverflow.com/questions/32193613/can-you-create-a-new-model-instance-without-saving-it-to-the-database#comment132528449_53452394), if we replace the way we are creating new models using the constructor of model classes with `::make()`, the `newInstance` method in the trait `HasModelExtending` is called and the correct model is returned.

If someone provides a list of all "swappable" models I can go through the entire hub and replace `new Model([... attributes...])` with `Model::make([...attributes...])`.