### PR TITLE
Discount breakdown

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -127,6 +127,7 @@ module.exports = {
           '/extending/shipping',
           '/extending/tables',
           '/extending/taxation',
+          '/extending/validations',
         ]
       }
     ],

--- a/packages/core/src/Base/ValueObjects/Cart/DiscountBreakdowValue.php
+++ b/packages/core/src/Base/ValueObjects/Cart/DiscountBreakdowValue.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lunar\Base\ValueObjects\Cart;
+
+use Illuminate\Support\Collection;
+use Lunar\DataTypes\Price;
+use Lunar\Models\Discount;
+
+class DiscountBreakdownValue
+{
+    public function __construct(
+        public Price $price,
+        public Collection $lines,
+        public Discount $discount,
+    ) {
+        //
+    }
+}

--- a/packages/core/src/Base/ValueObjects/Cart/DiscountBreakdown.php
+++ b/packages/core/src/Base/ValueObjects/Cart/DiscountBreakdown.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lunar\Base\ValueObjects\Cart;
+
+use Illuminate\Support\Collection;
+
+class DiscountBreakdown
+{
+    public function __construct(
+        public ?Collection $discounts = null
+    ) {
+        $this->discounts = $discounts ?: collect();
+    }
+
+    /**
+     * Add a discount breakdown.
+     *
+     * @param  DiscountBreakdownValue  $discountBreakdownValue
+     * @return void
+     */
+    public function addDiscount(DiscountBreakdownValue $discountBreakdownValue)
+    {
+        $this->discounts->push($discountBreakdownValue);
+    }
+}

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -122,7 +122,7 @@ class BuyXGetY
             }
             
             $affectedLines->push((object) [
-                'line' => $cartLine,
+                'line' => $rewardLine,
                 'quantity' => $qtyToAllocate,
             ]);
             

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -22,6 +22,7 @@ use Lunar\Base\Purchasable;
 use Lunar\Base\Traits\CachesProperties;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\LogsActivity;
+use Lunar\Base\ValueObjects\Cart\DiscountBreakdown;
 use Lunar\Base\ValueObjects\Cart\FreeItem;
 use Lunar\Base\ValueObjects\Cart\Promotion;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
@@ -62,6 +63,7 @@ class Cart extends BaseModel
         'shippingTotal',
         'taxTotal',
         'discountTotal',
+        'discountBreakdown',
         'total',
         'taxBreakdown',
         'promotions',
@@ -98,6 +100,13 @@ class Cart extends BaseModel
      * @var null|Price
      */
     public ?Price $discountTotal = null;
+    
+    /**
+     * All the discount breakdowns for the cart.
+     *
+     * @var null|Collection<DiscountBreakdown>
+     */
+    public ?Collection $discountBreakdown = null;
 
     /**
      * The cart total.


### PR DESCRIPTION
This PR adds the concept of `discount breakdowns` to the cart, similar to tax breakdowns.

When a discount is added to the cart, it allows you to see what items were affected by that discount, and what the price of the individual discount is. This allows developers to add later pipelines to the cart that perform (for example) tax apportioning.