### PR TITLE
Fix tax breakdown on save

### DIFF
--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -63,7 +63,7 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function serialize($model, $key, $value, $attributes)
     {
-        return json_encode($value->map(function ($rate) {
+        return $value->map(function ($rate) {
             if ($rate->total instanceof Price) {
                 $rate->total = (object) [
                     'value' => $rate->total->value,
@@ -72,7 +72,6 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
                 ];
             }
             return $rate;
-        })
-        ->values());
+        })->toJson();
     }
 }

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -54,10 +54,13 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
     }
     
     /**
-    * Get the serialized representation of the value.
-    *
-    * @param  array<string, mixed>  $attributes
-    */
+     * Get the serialized representation of the value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  \Illuminate\Support\Collection  $value
+     * @param  array<string, mixed>  $attributes
+     */
     public function serialize($model, $key, $value, $attributes)
     {
         return json_encode($value->map(function ($rate) {

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -42,7 +42,12 @@ class TaxBreakdown implements CastsAttributes
     public function set($model, $key, $value, $attributes)
     {
         return [
-            $key => json_encode($value),
+            $key => json_encode(collect($value)->map(function ($rate) {
+                if ($rate->total instanceof Price) {
+                    $rate->total = $rate->total->value;
+                }
+                return $rate;
+            })->values()),
         ];
     }
 }

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -3,10 +3,11 @@
 namespace Lunar\Base\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Lunar\DataTypes\Price;
 use Lunar\Models\Currency;
 
-class TaxBreakdown implements CastsAttributes
+class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
 {
     /**
      * Cast the given value.
@@ -25,7 +26,6 @@ class TaxBreakdown implements CastsAttributes
             json_decode($value, false)
         )->map(function ($rate) use ($currency) {
             $rate->total = new Price($rate->total, $currency, 1);
-
             return $rate;
         });
     }
@@ -43,11 +43,33 @@ class TaxBreakdown implements CastsAttributes
     {
         return [
             $key => json_encode(collect($value)->map(function ($rate) {
-                if ($rate->total instanceof Price) {
-                    $rate->total = $rate->total->value;
+                if (! is_array($rate)) {
+                    if ($rate->total instanceof Price) {
+                        $rate->total = $rate->total->value;
+                    }
                 }
                 return $rate;
             })->values()),
         ];
+    }
+    
+    /**
+    * Get the serialized representation of the value.
+    *
+    * @param  array<string, mixed>  $attributes
+    */
+    public function serialize($model, $key, $value, $attributes)
+    {
+        return json_encode($value->map(function ($rate) {
+            if ($rate->total instanceof Price) {
+                $rate->total = (object) [
+                    'value' => $rate->total->value,
+                    'formatted' => $rate->total->formatted,    
+                    'currency' => $rate->total->currency->toArray(),
+                ];
+            }
+            return $rate;
+        })
+        ->values());
     }
 }

--- a/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
@@ -159,6 +159,10 @@ class CreateOrderTest extends TestCase
         $this->assertDatabaseHas((new OrderLine())->getTable(), [
             'identifier' => $shippingOption->getIdentifier(),
         ]);
+
+        $order->save();
+        $containsCurrency = str_contains($order->fresh()->getRawOriginal('tax_breakdown'), '"currency"');
+        $this->assertFalse($containsCurrency);
     }
 
     /** @test */


### PR DESCRIPTION
When saving a cast-ed tax break down value if total is a price then save its value. This avoids any serialised/json-ed objects being saved to the database.

Fixes: #882 