### PR TITLE
[0.2] Hotfix - Fix bulk action hydrating on tables

### DIFF
--- a/utils/livewire-tables/resources/views/index.blade.php
+++ b/utils/livewire-tables/resources/views/index.blade.php
@@ -180,7 +180,7 @@
                                     Bulk Actions
                                 </p>
 
-                                <div class="lt-flex lt-flex-wrap lt-gap-4 lt-mt-2">
+                                <div class="lt-flex lt-flex-wrap lt-gap-4 lt-mt-2" wire:ignore>
                                     @foreach ($this->bulkActions as $action)
                                         @livewire($action->getName(), [
                                             'label' => $action->label,


### PR DESCRIPTION
Currently if you have multiple bulk actions on a table and select table rows, the bulk actions are rehydrated which cause them to lose their listeners for some reason. Adding `wire:ignore` to the parent div will stop Livewire trying to hydrate them and keep their instance live.