### PR TITLE
Add max user uses to discounts

### DIFF
--- a/packages/admin/resources/lang/en/inputs.php
+++ b/packages/admin/resources/lang/en/inputs.php
@@ -105,5 +105,6 @@ return [
     'postcodes.label' => 'Postcodes',
     'postcodes.instructions' => 'List each postcode on a new line. Supports wildcards such as NW*',
     'max_uses.label' => 'Max uses',
+    'max_uses_per_user.label' => 'Max uses per user',
     'size.placeholder' => 'Size',
 ];

--- a/packages/admin/resources/views/partials/forms/discount/conditions.blade.php
+++ b/packages/admin/resources/views/partials/forms/discount/conditions.blade.php
@@ -47,6 +47,12 @@
                       />
                     </x-hub::input.group>
                 </div>
+                
+                <div>
+                    <x-hub::input.group for="max_uses_per_user" :error="$errors->first('discount.max_uses_per_user')" :label="__('adminhub::inputs.max_uses_per_user.label')" instructions="Leave blank for unlimited uses.">
+                        <x-hub::input.text type="number" wire:model="discount.max_uses_per_user" />
+                    </x-hub::input.group>
+                </div>
             </div>
 
 

--- a/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
@@ -341,6 +341,7 @@ abstract class AbstractDiscount extends Component
 
         DB::transaction(function () {
             $this->discount->max_uses = $this->discount->max_uses ?: null;
+            $this->discount->max_uses_per_user = $this->discount->max_uses_per_user ?: null;
             $this->discount->save();
 
             $this->discount->brands()->sync(
@@ -431,6 +432,7 @@ abstract class AbstractDiscount extends Component
                 'has_errors' => $this->errorBag->hasAny([
                     'minPrices.*.price',
                     'discount.max_uses',
+                    'discount.max_uses_per_user',
                 ]),
             ],
             [

--- a/packages/admin/src/Http/Livewire/Components/Discounts/DiscountCreate.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/DiscountCreate.php
@@ -46,6 +46,7 @@ class DiscountCreate extends AbstractDiscount
             'discount.handle' => 'required|unique:'.Discount::class.',handle',
             'discount.stop' => 'nullable',
             'discount.max_uses' => 'nullable|numeric|min:0',
+            'discount.max_uses_per_user' => 'nullable|numeric|min:0',
             'discount.priority' => 'required|min:1',
             'discount.starts_at' => 'date',
             'discount.coupon' => 'nullable',

--- a/packages/admin/src/Http/Livewire/Components/Discounts/DiscountShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/DiscountShow.php
@@ -32,6 +32,7 @@ class DiscountShow extends AbstractDiscount
             'discount.handle' => 'required|unique:'.Discount::class.',handle,'.$this->discount->id,
             'discount.stop' => 'nullable',
             'discount.max_uses' => 'nullable|numeric|min:0',
+            'discount.max_uses_per_user' => 'nullable|numeric|min:0',
             'discount.priority' => 'required|min:1',
             'discount.starts_at' => 'date',
             'discount.coupon' => 'nullable',
@@ -73,6 +74,7 @@ class DiscountShow extends AbstractDiscount
             $this->discount->collections()->delete();
             $this->discount->customerGroups()->detach();
             $this->discount->channels()->detach();
+            $this->discount->users()->delete();
             $this->discount->delete();
         });
 

--- a/packages/core/database/migrations/2023_03_03_100001_add_max_uses_per_user_to_discounts_table.php
+++ b/packages/core/database/migrations/2023_03_03_100001_add_max_uses_per_user_to_discounts_table.php
@@ -9,7 +9,7 @@ class AddMaxUsesPerUserToDiscountsTable extends Migration
     public function up()
     {
         Schema::table($this->prefix.'discounts', function (Blueprint $table) {
-            $table->mediumInteger('max_uses')->unsigned()->nullable()->after('max_uses');
+            $table->mediumInteger('max_uses_per_user')->unsigned()->nullable()->after('max_uses');
         });
     }
 

--- a/packages/core/database/migrations/2023_03_03_100001_add_max_uses_per_user_to_discounts_table.php
+++ b/packages/core/database/migrations/2023_03_03_100001_add_max_uses_per_user_to_discounts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class AddMaxUsesPerUserToDiscountsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'discounts', function (Blueprint $table) {
+            $table->json('max_uses_per_user')->nullable()->after('max_uses');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'discounts', function ($table) {
+            $table->dropColumn('max_uses_per_user');
+        });
+    }
+}

--- a/packages/core/database/migrations/2023_03_03_100001_add_max_uses_per_user_to_discounts_table.php
+++ b/packages/core/database/migrations/2023_03_03_100001_add_max_uses_per_user_to_discounts_table.php
@@ -9,7 +9,7 @@ class AddMaxUsesPerUserToDiscountsTable extends Migration
     public function up()
     {
         Schema::table($this->prefix.'discounts', function (Blueprint $table) {
-            $table->json('max_uses_per_user')->nullable()->after('max_uses');
+            $table->mediumInteger('max_uses')->unsigned()->nullable()->after('max_uses');
         });
     }
 

--- a/packages/core/database/migrations/2023_03_13_100030_create_discount_user_table.php
+++ b/packages/core/database/migrations/2023_03_13_100030_create_discount_user_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class CreateDiscountUserTable extends Migration
+{
+    public function up()
+    {
+        Schema::create($this->prefix.'discount_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('discount_id')->constrained($this->prefix.'discounts')->cascadeOnDelete();
+            $table->userForeignKey();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix.'discount_user');
+    }
+}

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -152,8 +152,8 @@ class CreateOrder extends AbstractAction
 
             $cart->order()->associate($order);
 
-            $cart->discounts?->each(function ($discount) {
-                $discount->markAsUsed()->discount->save();
+            $cart->discounts?->each(function ($discount) use ($cart) {
+                $discount->markAsUsed($cart)->discount->save();
             });
 
             $cart->save();

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -40,9 +40,9 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
     public function markAsUsed(): self
     {
         $this->discount->uses = $this->discount->uses + 1;
-        
+
         if ($user = Auth::user()) {
-            $this->discount->customers()->attach($user);    
+            $this->discount->customers()->attach($user);
         }
 
         return $this;
@@ -81,7 +81,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $validMinSpend = $minSpend ? $minSpend < $lines->sum('subTotal.value') : true;
 
         $validMaxUses = $this->discount->max_uses ? $this->discount->uses < $this->discount->max_uses : true;
-            
+
         if ($validMaxUses && $this->discount->max_uses_per_user) {
             $user = Auth::user();
             $validMaxUses = $user && ($this->usesByUser($user) < $this->discount->max_uses_per_user);
@@ -107,7 +107,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
 
         return $this;
     }
-    
+
     /**
      * Check how many times this discount has been used by the logged in user's customers
      *
@@ -118,6 +118,6 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
     {
         return $this->discount->users()
             ->whereUserId($user->getKey())
-            ->count();   
+            ->count();
     }
 }

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -42,7 +42,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $this->discount->uses = $this->discount->uses + 1;
 
         if ($user = Auth::user()) {
-            $this->discount->customers()->attach($user);
+            $this->discount->users()->attach($user);
         }
 
         return $this;

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -37,11 +37,11 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
      *
      * @return self
      */
-    public function markAsUsed(): self
+    public function markAsUsed(Cart $cart): self
     {
         $this->discount->uses = $this->discount->uses + 1;
 
-        if ($user = Auth::user()) {
+        if ($user = $cart->user) {
             $this->discount->users()->attach($user);
         }
 

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -83,8 +83,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $validMaxUses = $this->discount->max_uses ? $this->discount->uses < $this->discount->max_uses : true;
 
         if ($validMaxUses && $this->discount->max_uses_per_user) {
-            $user = Auth::user();
-            $validMaxUses = $user && ($this->usesByUser($user) < $this->discount->max_uses_per_user);
+            $validMaxUses = $cart->user && ($this->usesByUser($cart->user) < $this->discount->max_uses_per_user);
         }
 
         return $validCoupon && $validMinSpend && $validMaxUses;

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -2,7 +2,9 @@
 
 namespace Lunar\DiscountTypes;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Lunar\Base\DiscountTypeInterface;
 use Lunar\Base\ValueObjects\Cart\DiscountBreakdown;
 use Lunar\Models\Cart;
@@ -38,6 +40,10 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
     public function markAsUsed(): self
     {
         $this->discount->uses = $this->discount->uses + 1;
+        
+        if ($user = Auth::user()) {
+            $this->discount->customers()->attach($user);    
+        }
 
         return $this;
     }
@@ -75,6 +81,11 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $validMinSpend = $minSpend ? $minSpend < $lines->sum('subTotal.value') : true;
 
         $validMaxUses = $this->discount->max_uses ? $this->discount->uses < $this->discount->max_uses : true;
+            
+        if ($validMaxUses && $this->discount->max_uses_per_user) {
+            $user = Auth::user();
+            $validMaxUses = $user && ($this->usesByUser($user) < $this->discount->max_uses_per_user);
+        }
 
         return $validCoupon && $validMinSpend && $validMaxUses;
     }
@@ -95,5 +106,18 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
         $cart->discountBreakdown->push($breakdown);
 
         return $this;
+    }
+    
+    /**
+     * Check how many times this discount has been used by the logged in user's customers
+     *
+     * @param  Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return int
+     */
+    protected function usesByUser(Authenticatable $user)
+    {
+        return $this->discount->users()
+            ->whereUserId($user->getKey())
+            ->count();   
     }
 }

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -57,6 +57,16 @@ class Discount extends BaseModel
         return DiscountFactory::new();
     }
 
+    public function users()
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return $this->belongsToMany(
+            config('auth.providers.users.model'),
+            "{$prefix}discount_user"
+        )->withTimestamps();
+    }
+
     /**
      * Return the purchasables relationship.
      *

--- a/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
@@ -991,6 +991,7 @@ class AmountOffTest extends TestCase
         $cart = Cart::factory()->create([
             'currency_id' => $currency->id,
             'channel_id' => $channel->id,
+            'user_id' => $user->getKey(),
         ]);
 
         $purchasableA = ProductVariant::factory()->create();

--- a/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
@@ -8,6 +8,7 @@ use Lunar\Models\Brand;
 use Lunar\Models\Cart;
 use Lunar\Models\Channel;
 use Lunar\Models\Currency;
+use Lunar\Models\Customer;
 use Lunar\Models\CustomerGroup;
 use Lunar\Models\Discount;
 use Lunar\Models\Price;
@@ -985,14 +986,19 @@ class AmountOffTest extends TestCase
         $channel = Channel::getDefault();
 
         $user = User::factory()->create();
+        $customer = Customer::factory()->create();
+        $customer->customerGroups()->attach($customerGroup);
+
+        $user->customers()->attach($customer);
 
         $this->actingAs($user);
 
         $cart = Cart::factory()->create([
             'currency_id' => $currency->id,
             'channel_id' => $channel->id,
-            'user_id' => $user->getKey(),
         ]);
+
+        $cart->user()->associate($user);
 
         $purchasableA = ProductVariant::factory()->create();
 
@@ -1061,6 +1067,10 @@ class AmountOffTest extends TestCase
         $channel = Channel::getDefault();
 
         $user = User::factory()->create();
+        $customer = Customer::factory()->create();
+        $customer->customerGroups()->attach($customerGroup);
+
+        $user->customers()->attach($customer);
 
         $this->actingAs($user);
 
@@ -1068,6 +1078,8 @@ class AmountOffTest extends TestCase
             'currency_id' => $currency->id,
             'channel_id' => $channel->id,
         ]);
+
+        $cart->user()->associate($user);
 
         $purchasableA = ProductVariant::factory()->create();
 

--- a/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
@@ -972,7 +972,7 @@ class AmountOffTest extends TestCase
         $this->assertEquals(1800, $cart->taxTotal->value);
         $this->assertCount(1, $cart->discounts);
     }
-    
+
     /**
      * @test
      */
@@ -983,9 +983,9 @@ class AmountOffTest extends TestCase
         $customerGroup = CustomerGroup::getDefault();
 
         $channel = Channel::getDefault();
-            
+
         $user = User::factory()->create();
-            
+
         $this->actingAs($user);
 
         $cart = Cart::factory()->create([
@@ -1022,9 +1022,9 @@ class AmountOffTest extends TestCase
                 ],
             ],
         ]);
-        
+
         $discount->users()->sync([
-            $user->id
+            $user->id,
         ]);
 
         $discount->customerGroups()->sync([
@@ -1058,9 +1058,9 @@ class AmountOffTest extends TestCase
         $customerGroup = CustomerGroup::getDefault();
 
         $channel = Channel::getDefault();
-            
+
         $user = User::factory()->create();
-            
+
         $this->actingAs($user);
 
         $cart = Cart::factory()->create([
@@ -1097,9 +1097,9 @@ class AmountOffTest extends TestCase
                 ],
             ],
         ]);
-        
+
         $discount->users()->sync([
-            $user->id
+            $user->id,
         ]);
 
         $discount->customerGroups()->sync([


### PR DESCRIPTION
This PR adds the ability to limit the number of times a user can apply a discount code. 

It adds a new relation between discounts and users with a pivot table
It tracks when a logged in user uses a discount
It adds a new field to the admin hub to "Max uses per user", when this has a value if there is no logged in user then it will fail to add the discount.