### PR TITLE
remove duplicate refresh method on CachesProperties trait

### DIFF
--- a/packages/core/src/Base/Traits/CachesProperties.php
+++ b/packages/core/src/Base/Traits/CachesProperties.php
@@ -13,21 +13,6 @@ trait CachesProperties
             $model->restoreProperties();
         });
     }
-    
-    public function refresh()
-    {
-        parent::refresh();
-
-        $ro = new ReflectionClass($this);
-
-        foreach ($this->cachableProperties as $property) {
-            $defaultValue = $ro->getProperty($property)->getDefaultValue();
-
-            $this->{$property} = $defaultValue;
-        }
-
-        return $this;
-    }
 
     public function refresh()
     {


### PR DESCRIPTION
The `packages/core/src/Base/Traits/CachesProperties.php` file contains a duplicated `refresh()` method. This breaks composer when attempting to install the package. Both instances of the method were exactly the same, so I just removed one of them.