### PR TITLE
Bug fix on exiting discount product associations

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Laravel 10 support added.
 - Changed Auth guard to use Laravel's default driver.
 - Updated `db_date` function to return just the formmatted string.
+- Fixed a bug where existing product associations were not passed correctly on discount editing
 
 ## 0.2-RC3
 

--- a/packages/admin/resources/views/partials/forms/discount/limitations.blade.php
+++ b/packages/admin/resources/views/partials/forms/discount/limitations.blade.php
@@ -142,7 +142,7 @@
                 </h4>
     
                 @livewire('hub.components.product-search', [
-                    'existing' => $selectedProducts->pluck('id'),
+                    'existing' => $selectedProducts->map(fn ($product) => ['id' => $product['id']]),
                     'ref' => 'discount-limitations',
                 ])
             </header>   


### PR DESCRIPTION
Fixes a bug where the existing product associations were not being shown as selected on discounts