### PR TITLE
Stop popover closing on click away

### DIFF
--- a/packages/admin/resources/views/components/slideover.blade.php
+++ b/packages/admin/resources/views/components/slideover.blade.php
@@ -24,7 +24,6 @@
         <div class="fixed inset-y-0 right-0 flex max-w-full pl-10">
             <div x-show="show"
                  x-trap.noscroll="show"
-                 x-on:click.away="show = false"
                  x-cloak
                  x-init="$watch('show', (isShown) => isShown && $focus.first())"
                  class="w-screen {{ $nested ? 'max-w-xl' : 'max-w-2xl' }}"


### PR DESCRIPTION
See following screen recording for a example of the issue caused by this:

https://user-images.githubusercontent.com/51899/229046628-34421ad5-5242-499e-8b7e-b77faf6ae83f.mov

This PR removes the click away function - there is already a close button so its how the popover is closed.