### PR TITLE
Hotfix [0.2] - Fix discount logic for BuyXGetY

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -107,6 +107,11 @@ class BuyXGetY extends AbstractDiscountType
                 $qtyToAllocate = (int) round(($remainingRewardQty - $remainder) / $rewardLine->quantity);
             }
 
+            if ($rewardLine->quantity == 1 && $remainder) {
+                $qtyToAllocate = 1;
+                $remainder = $remainder - 1;
+            }
+
             if (! $qtyToAllocate) {
                 continue;
             }

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -99,12 +99,12 @@ class BuyXGetY extends AbstractDiscountType
                 continue;
             }
 
-            $remainder = $rewardLine->quantity % $remainingRewardQty;
+            $remainder = (int) floor($remainingRewardQty);
+            $qtyToAllocate = $remainder;
 
-            $qtyToAllocate = (int) round(($remainingRewardQty - $remainder) / $rewardLine->quantity);
-
-            if (! $remainder && $remainingRewardQty < $rewardLine->quantity) {
-                $qtyToAllocate = $remainingRewardQty;
+            if ($rewardLine->quantity < $remainder) {
+                $remainder = $rewardLine->quantity % $remainingRewardQty;
+                $qtyToAllocate = (int) round(($remainingRewardQty - $remainder) / $rewardLine->quantity);
             }
 
             if (! $qtyToAllocate) {

--- a/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
@@ -563,7 +563,6 @@ class BuyXGetYTest extends TestCase
 
     /**
      * @test
-     * @group bubba
      */
     public function can_supplement_correct_quantities()
     {
@@ -643,50 +642,30 @@ class BuyXGetYTest extends TestCase
         ]);
 
         $lines = [
-            // [
-            //     'condition_quantity' => 30,
-            //     'reward_quantity' => 1,
-            //     'expected_discount' => 0,
-            //     'expected_subtotal' => 0,
-            // ],
-            // [
-            //     'condition_quantity' => 60,
-            //     'reward_quantity' => 1,
-            //     'expected_discount' => 2280,
-            //     'expected_subtotal' => 0,
-            // ],
             [
                 'condition_quantity' => 60,
                 'reward_quantity' => 3,
                 'expected_discount' => (2280 * 2),
                 'expected_subtotal' => 2280,
             ],
-            // [
-            //     'condition_quantity' => 10,
-            //     'reward_quantity' => 2,
-            //     'expected_discount' => 1000,
-            //     'expected_subtotal' => 2280,
-            // ],
-            // [
-            //     'condition_quantity' => 10,
-            //     'reward_quantity' => 3,
-            //     'expected_discount' => 1000,
-            // ],
-            // [
-            //     'condition_quantity' => 15,
-            //     'reward_quantity' => 3,
-            //     'expected_discount' => 1500,
-            // ],
-            // [
-            //     'condition_quantity' => 13,
-            //     'reward_quantity' => 3,
-            //     'expected_discount' => 1000,
-            // ],
-            // [
-            //     'condition_quantity' => 13,
-            //     'reward_quantity' => 2,
-            //     'expected_discount' => 1000,
-            // ]
+            [
+                'condition_quantity' => 60,
+                'reward_quantity' => 4,
+                'expected_discount' => (2280 * 2),
+                'expected_subtotal' => (2280 * 2),
+            ],
+            [
+                'condition_quantity' => 120,
+                'reward_quantity' => 4,
+                'expected_discount' => (2280 * 4),
+                'expected_subtotal' => 0,
+            ],
+            [
+                'condition_quantity' => 120,
+                'reward_quantity' => 1,
+                'expected_discount' => 2280,
+                'expected_subtotal' => 0,
+            ],
         ];
 
         foreach ($lines as $line) {


### PR DESCRIPTION
Currently there is an issue with the BuyXGetY discount when various quantity combinations are used.

Consider the following discount:

- Buy 5 of Product A and get 1 Product B free
- Minimum Quantity: 5
- Reward Quantity: 1
- Maximum Reward Quantity: 999

Assume we have 10 of Product A in our cart and 3 of Product B

What seems to happen is if the quantity of the cart line is greater than the remaining allocation, the `%` logic compared with the division logic below results in `0` getting returned.

The PR looks to address this by checking whether the reward amount can just be deducted without worrying about remainders. There's also a test which hopefully demonstrates the changes.