### PR TITLE
Fix incorrect totals due to discounts

### DIFF
--- a/packages/core/src/Pipelines/Cart/Calculate.php
+++ b/packages/core/src/Pipelines/Cart/Calculate.php
@@ -17,8 +17,8 @@ class Calculate
     {
         $discountTotal = $cart->lines->sum('discountTotal.value');
 
-        $subTotal = $cart->lines->sum('subTotal.value') - $discountTotal;
-        $total = $cart->lines->sum('total.value');
+        $subTotal = $cart->lines->sum('subTotal.value');
+        $total = $subTotal - $discountTotal + ($cart->taxTotal->value ?? 0);
 
         // Get the shipping address
         if ($shippingAddress = $cart->shippingAddress) {


### PR DESCRIPTION
The Calculate pipeline hadn't been updated since discounts stopped affecting line totals, so they were generating the wrong totals.

This PR changes the approach to calculating the final cart total.