### PR TITLE
Hotfix [0.2] - Add sub total discounted to Cart

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -80,6 +80,12 @@ class Cart extends BaseModel
     public ?Price $subTotal = null;
 
     /**
+     * The cart sub total.
+     * Sum of cart line amounts, before tax, shipping minus discount totals.
+     */
+    public ?Price $subTotalDiscounted = null;
+
+    /**
      * The shipping total for the cart.
      *
      * @var null|Price

--- a/packages/core/src/Pipelines/Cart/Calculate.php
+++ b/packages/core/src/Pipelines/Cart/Calculate.php
@@ -17,7 +17,14 @@ class Calculate
     {
         $discountTotal = $cart->lines->sum('discountTotal.value');
 
-        $subTotal = $cart->lines->sum('subTotal.value') - $discountTotal;
+        $subTotal = $cart->lines->sum('subTotal.value');
+
+        $subTotalDiscounted = $cart->lines->sum(function ($line) {
+            return $line->subTotalDiscounted ?
+                $line->subTotalDiscounted->value :
+                $line->subTotal->value;
+        });
+
         $total = $cart->lines->sum('total.value');
 
         // Get the shipping address
@@ -29,6 +36,7 @@ class Calculate
         }
 
         $cart->subTotal = new Price($subTotal, $cart->currency, 1);
+        $cart->subTotalDiscounted = new Price($subTotalDiscounted, $cart->currency, 1);
         $cart->discountTotal = new Price($discountTotal, $cart->currency, 1);
         $cart->total = new Price($total, $cart->currency, 1);
 

--- a/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
@@ -824,7 +824,8 @@ class AmountOffTest extends TestCase
         $cart = $cart->calculate();
 
         $this->assertEquals(1000, $cart->discountTotal->value);
-        $this->assertEquals(9000, $cart->subTotal->value);
+        $this->assertEquals(10000, $cart->subTotal->value);
+        $this->assertEquals(9000, $cart->subTotalDiscounted->value);
         $this->assertEquals(10800, $cart->total->value);
         $this->assertEquals(1800, $cart->taxTotal->value);
         $this->assertCount(1, $cart->discounts);
@@ -968,7 +969,8 @@ class AmountOffTest extends TestCase
         $cart = $cart->calculate();
 
         $this->assertEquals(1000, $cart->discountTotal->value);
-        $this->assertEquals(9000, $cart->subTotal->value);
+        $this->assertEquals(10000, $cart->subTotal->value);
+        $this->assertEquals(9000, $cart->subTotalDiscounted->value);
         $this->assertEquals(10800, $cart->total->value);
         $this->assertEquals(1800, $cart->taxTotal->value);
         $this->assertCount(1, $cart->discounts);
@@ -1052,7 +1054,8 @@ class AmountOffTest extends TestCase
 
         $this->assertEquals(1000, $cart->discountTotal->value);
         $this->assertEquals(1200, $cart->total->value);
-        $this->assertEquals(1000, $cart->subTotal->value);
+        $this->assertEquals(2000, $cart->subTotal->value);
+        $this->assertEquals(1000, $cart->subTotalDiscounted->value);
     }
 
     /**


### PR DESCRIPTION
We currently have `subtotalDiscounted` on CartLine's but this isn't mirrored on the `Cart` object leading to some inconsistency as `subTotal` on the `Cart` model includes the discount amount, whereas `subTotal` on a `CartLine` model doesn't.

This PR looks to add `subtotalDiscounted` to the `Cart` model.