### PR TITLE
Feature/docs support policy

### DIFF
--- a/docs/core/contributing.md
+++ b/docs/core/contributing.md
@@ -14,7 +14,7 @@ Lunar uses a monorepo [lunarphp/lunar](https://github.com/lunarphp/lunar) to hou
 
 **Bug Fixes** should target the latest compatible branch version i.e `0.1`. The `main` branch should never have bug fix PR's unless they fix features that are in an upcoming release.
 
-**Features** should target the `main` branch.
+**Features** should target the `main` branch if they introduce breaking changes, otherwise they can target the latest compatible branch version i.e `0.1`.
 
 ## Contributing Code
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -20,6 +20,10 @@ Re-publish the admin hub assets
 php artisan lunar:hub:install
 ```
 
+## Support Policy
+
+Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.3`. 
+
 ## 0.3
 
 ### High Impact


### PR DESCRIPTION
Sets out what versions we support for bug fixes and how contributions target releases.