### PR TITLE
Fix accumulating discount breakdowns

### DIFF
--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -97,12 +97,6 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
      */
     protected function addDiscountBreakdown(Cart $cart, DiscountBreakdown $breakdown)
     {
-        if (! $cart->discountBreakdown) {
-            $cart->discountBreakdown = collect();
-        }
-
-        $cart->discountBreakdown = $cart->discountBreakdown->reject(fn ($b) => $b->discount == $breakdown->discount);
-
         $cart->discountBreakdown->push($breakdown);
 
         return $this;

--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -101,6 +101,8 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
             $cart->discountBreakdown = collect();
         }
 
+        $cart->discountBreakdown = $cart->discountBreakdown->reject(fn ($b) => $b->discount == $breakdown->discount);
+
         $cart->discountBreakdown->push($breakdown);
 
         return $this;

--- a/packages/core/src/Pipelines/Cart/ApplyDiscounts.php
+++ b/packages/core/src/Pipelines/Cart/ApplyDiscounts.php
@@ -15,6 +15,8 @@ final class ApplyDiscounts
      */
     public function handle(Cart $cart, Closure $next)
     {
+        $cart->discountBreakdown = collect([]);
+
         Discounts::apply($cart);
 
         return $next($cart);


### PR DESCRIPTION
As cart calculation can be called multiple times in a request the discount breakdowns were duplicating.

This PR fixes that by removing any for that discount before adding.