### PR TITLE
Fixed 'Unknown format "secondaryAddress"' error

### DIFF
--- a/packages/core/database/factories/OrderAddressFactory.php
+++ b/packages/core/database/factories/OrderAddressFactory.php
@@ -17,7 +17,7 @@ class OrderAddressFactory extends Factory
             'last_name' => $this->faker->lastName,
             'company_name' => $this->faker->boolean ? $this->faker->company : null,
             'line_one' => $this->faker->streetName,
-            'line_two' => $this->faker->boolean ? $this->faker->secondaryAddress : null,
+            'line_two' => $this->faker->boolean ? "Suite " . $this->faker->numerify() : null,
             'line_three' => $this->faker->boolean ? $this->faker->buildingNumber : null,
             'city' => $this->faker->city,
             'state' => $this->faker->boolean ? $this->faker->state : null,


### PR DESCRIPTION
Fixed 'Unknown format "secondaryAddress"' when the `faker_locale` configuration value in Laravel is has different value than `en_US`.

As reported in #898, when the consumer of this library changes their `faker_locale` configuration value from something different then the default (`en_US`), generation of OrderAddress-models fails because `secondaryAddress` is only available in the en_US Address provider (see: https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/en_US/Address.php#L77-L80) and not in the generic Address provider (https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/Address.php).

Try to include the following in your Pull Request, where applicable...

- Documentation updates
- Automated tests
- Changelog entries (core and hub)
