### PR TITLE
[0.2] Fix formatting on docs admin extending page

### DIFF
--- a/docs/admin-hub/extending.md
+++ b/docs/admin-hub/extending.md
@@ -168,8 +168,10 @@ class SeoSlot extends Component implements AbstractSlot
 }
 ```
 
-:::warning When creating a slot the namespace should contain either `Lunar` or
-`Hub` in order for the middleware to apply correctly. :::
+::: warning
+When creating a slot the namespace should contain either `Lunar` or
+`Hub` in order for the middleware to apply correctly.
+:::
 
 ### Available Methods
 


### PR DESCRIPTION
Fixed this issue

<img width="840" alt="image" src="https://user-images.githubusercontent.com/647407/230894287-631ecd35-1d86-44d1-be1a-d00fb11eb1cb.png">
