### PR TITLE
Hotfix [0.2] discount priority 

### DIFF
--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -165,7 +165,7 @@ class DiscountManager implements DiscountManagerInterface
                     $query->whereNull("{$joinTable}.ends_at")
                         ->orWhere("{$joinTable}.ends_at", '>', now());
                 });
-        })->orderBy('priority')->get();
+        })->orderBy('priority', 'desc')->get();
     }
 
     /**

--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -165,7 +165,10 @@ class DiscountManager implements DiscountManagerInterface
                     $query->whereNull("{$joinTable}.ends_at")
                         ->orWhere("{$joinTable}.ends_at", '>', now());
                 });
-        })->orderBy('priority', 'desc')->get();
+        })
+            ->orderBy('priority', 'desc')
+            ->orderBy('id')
+            ->get();
     }
 
     /**


### PR DESCRIPTION
discount should apply from high to low 

`priority => 1: Low, 5: Medium, 10: High`