### PR TITLE
Add shipping breakdown

### DIFF
--- a/docs/core/reference/carts.md
+++ b/docs/core/reference/carts.md
@@ -97,11 +97,21 @@ $cart->taxAmount; // The monetary value for the amount of tax applied.
 $cart->taxBreakdown; // This is a collection of all taxes applied across all lines.
 $cart->discountTotal; // The monetary value for the discount total.
 $cart->discountBreakdown; // This is a collection of how discounts were calculated
+$cart->shippingSubTotal; // The shipping total, excluding tax.
+$cart->shippingTotal; // The shipping total including tax.
+$cart->shippingBreakdown; // This is a collection of the shipping breakdown for the cart.
 
 foreach ($cart->taxBreakdown as $taxRate) {
     $taxRate->name
     $taxRate->total->value
 }
+
+foreach ($cart->shippingBreakdown->items as $shippingBreakdown) {
+    $shippingBreakdown->name;
+    $shippingBreakdown->identifier;
+    $shippingBreakdown->price->formatted();
+}
+    
 
 foreach ($cart->discountBreakdown as $discountBreakdown) {
     $discountBreakdown->discount_id

--- a/docs/core/reference/orders.md
+++ b/docs/core/reference/orders.md
@@ -212,12 +212,14 @@ Lunar\Models\OrderLine
 | sub_total        | The sub total minus any discounts, excl. tax                                                
 | discount_total   | Any discount amount excl. tax                                                               
 | tax_breakdown    | A json field for the tax breakdown e.g. `[{"name": "VAT", "total": 123, "percentage": 20}]` 
+| shipping_breakdown| A json field for the shipping breakdown e.g. `[{"name": "Standard Delivery", "identifier": "STD", "price": 123}]`
 | tax_total        | The total amount of tax applied                                                             
 | total            | The grand total with tax                                                                    
 | notes            | Any additional order notes                                                                  
 | meta             | Any additional meta info you wish to store                                                  
 | created_at       |                                                                                             |
 | updated_at       |                                                                                             |
+
 
 ### Create an order line
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -32,6 +32,28 @@ Lunar currently provides bug fixes and security updates for only the latest mino
 With MySQL 5.7 EOL coming in October 2023 and Lunar's heavy use of JSON fields, Lunar now only supports MySQL 8.x.
 You may find your project continues to work fine in MySQL 5.7, but we advise upgrading.
 
+#### Carts
+
+- The `shippingTotal` property now includes the tax in the amount, use `shippingSubTotal` instead.
+- A new `shippingBreakdown` property has been added which will include all shipping costs and be available to pipelines.
+
+If you are modifying the shipping cost outside of your own shipping options in the shipping manifest, you should create a custom cart pipeline and use the shipping breakdown property as this is where the shipping total will be calculated from.
+
+```php
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdownItem;
+
+$shippingBreakdown = $cart->shippingBreakdown ?: new ShippingBreakdown;
+
+$shippingBreakdown->items->put('ADDSHIP',
+    new ShippingBreakdownItem(
+        name: 'Additional Shipping Cost',
+        identifier: 'ADDSHIP',
+        price: new Price(123, $currency, 1),
+    )
+);
+```
+
 #### Cart/Order Relationship
 
 The relationship between a cart and an order has been changed, previously the `carts` table had an `order_id` column,
@@ -75,6 +97,7 @@ Add the new fingerprint class reference to `config/lunar/carts.php` if you have 
 ```php
 'fingerprint_generator' => Lunar\Actions\Carts\GenerateFingerprint::class,
 ```
+
 
 ## 0.3
 

--- a/packages/core/database/migrations/2023_04_19_100000_add_shipping_breakdown_to_orders_table.php
+++ b/packages/core/database/migrations/2023_04_19_100000_add_shipping_breakdown_to_orders_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class AddShippingBreakdownToOrdersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'orders', function (Blueprint $table) {
+            $table->json('shipping_breakdown')->nullable()->after('discount_total');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'orders', function ($table) {
+            $table->dropColumn('shipping_breakdown');
+        });
+    }
+}

--- a/packages/core/src/Base/Casts/ShippingBreakdown.php
+++ b/packages/core/src/Base/Casts/ShippingBreakdown.php
@@ -71,7 +71,7 @@ class ShippingBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function serialize($model, $key, $value, $attributes)
     {
-        return $value->items->map(function ($rate) {
+        return $value->map(function ($rate) {
             if ($rate->price instanceof Price) {
                 $rate->total = (object) [
                     'name' => $rate->name,

--- a/packages/core/src/Base/Casts/ShippingBreakdown.php
+++ b/packages/core/src/Base/Casts/ShippingBreakdown.php
@@ -4,6 +4,7 @@ namespace Lunar\Base\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Support\Collection;
 use Lunar\DataTypes\Price;
 use Lunar\Models\Currency;
 
@@ -29,8 +30,6 @@ class ShippingBreakdown implements CastsAttributes, SerializesCastableAttributes
 
             return $shipping;
         });
-
-        return json_decode($value, false);
     }
 
     /**
@@ -44,7 +43,11 @@ class ShippingBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        return $value->items->map(function ($rate) {
+        if (!$value instanceof Collection) {
+            $value = $value->items;
+        }
+
+        return $value->map(function ($rate) {
             $data = [
                 'name' => $rate->name,
                 'identifier' => $rate->identifier,

--- a/packages/core/src/Base/Casts/ShippingBreakdown.php
+++ b/packages/core/src/Base/Casts/ShippingBreakdown.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Lunar\Base\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+
+class ShippingBreakdown implements CastsAttributes, SerializesCastableAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return \Illuminate\Support\Collection
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return json_decode($value, false);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  \Lunar\DataTypes\Price  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+
+    /**
+     * Get the serialized representation of the value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  \Illuminate\Support\Collection  $value
+     * @param  array<string, mixed>  $attributes
+     */
+    public function serialize($model, $key, $value, $attributes)
+    {
+        return $value->toJson();
+    }
+}

--- a/packages/core/src/Base/Casts/ShippingBreakdown.php
+++ b/packages/core/src/Base/Casts/ShippingBreakdown.php
@@ -43,7 +43,7 @@ class ShippingBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        if (!$value instanceof Collection) {
+        if (! $value instanceof Collection) {
             $value = $value->items;
         }
 

--- a/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
+++ b/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lunar\Base\ValueObjects\Cart;
+
+use Illuminate\Support\Collection;
+use Lunar\DataTypes\Price;
+
+class ShippingBreakdown
+{
+    public function __construct(
+        public Collection $items
+    ) {
+        //
+    }
+}

--- a/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
+++ b/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
@@ -8,8 +8,8 @@ use Lunar\DataTypes\Price;
 class ShippingBreakdown
 {
     public function __construct(
-        public Collection $items
+        public ?Collection $items = null
     ) {
-        //
+        $this->items = $items ?: collect();
     }
 }

--- a/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
+++ b/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
@@ -3,7 +3,6 @@
 namespace Lunar\Base\ValueObjects\Cart;
 
 use Illuminate\Support\Collection;
-use Lunar\DataTypes\Price;
 
 class ShippingBreakdown
 {

--- a/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
+++ b/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdown.php
@@ -12,4 +12,9 @@ class ShippingBreakdown
     ) {
         $this->items = $items ?: collect();
     }
+
+    public function __toString()
+    {
+        return $this->items->toJson();
+    }
 }

--- a/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdownItem.php
+++ b/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdownItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lunar\Base\ValueObjects\Cart;
+
+use Lunar\DataTypes\Price;
+
+class ShippingBreakdownItem
+{
+    public function __construct(
+        public string $description,
+        public string $code,
+        public Price $price
+    ) {
+        //
+    }
+}

--- a/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdownItem.php
+++ b/packages/core/src/Base/ValueObjects/Cart/ShippingBreakdownItem.php
@@ -7,8 +7,8 @@ use Lunar\DataTypes\Price;
 class ShippingBreakdownItem
 {
     public function __construct(
-        public string $description,
-        public string $code,
+        public string $name,
+        public string $identifier,
         public Price $price
     ) {
         //

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -25,6 +25,7 @@ use Lunar\Base\Traits\LogsActivity;
 use Lunar\Base\ValueObjects\Cart\DiscountBreakdown;
 use Lunar\Base\ValueObjects\Cart\FreeItem;
 use Lunar\Base\ValueObjects\Cart\Promotion;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Database\Factories\CartFactory;
 use Lunar\DataTypes\Price;
@@ -86,6 +87,11 @@ class Cart extends BaseModel
     public ?Price $subTotalDiscounted = null;
 
     /**
+     * The shipping sub total for the cart.
+     */
+    public ?Price $shippingSubTotal = null;
+
+    /**
      * The shipping total for the cart.
      */
     public ?Price $shippingTotal = null;
@@ -108,6 +114,11 @@ class Cart extends BaseModel
      * @var null|Collection<DiscountBreakdown>
      */
     public ?Collection $discountBreakdown = null;
+
+    /**
+     * All the shipping breakdowns for the cart.
+     */
+    public ?ShippingBreakdown $shippingBreakdown = null;
 
     /**
      * The cart total.

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\DiscountBreakdown;
 use Lunar\Base\Casts\Price;
+use Lunar\Base\Casts\ShippingBreakdown;
 use Lunar\Base\Casts\TaxBreakdown;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasTags;
@@ -25,6 +26,7 @@ use Lunar\Database\Factories\OrderFactory;
  * @property int $sub_total
  * @property int $discount_total
  * @property array $discount_breakdown
+ * @property array $shipping_breakdown
  * @property array $tax_breakdown
  * @property int $tax_total
  * @property int $total
@@ -79,6 +81,7 @@ class Order extends BaseModel
         'sub_total' => Price::class,
         'discount_total' => Price::class,
         'discount_breakdown' => DiscountBreakdown::class,
+        'shipping_breakdown' => ShippingBreakdown::class,
         'tax_total' => Price::class,
         'total' => Price::class,
         'shipping_total' => Price::class,

--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -22,7 +22,7 @@ final class ApplyShipping
         $shippingBreakdown = $cart->shippingBreakdown ?: new ShippingBreakdown;
 
         if ($shippingOption = $this->getShippingOption($cart)) {
-            $shippingBreakdown->items->push(
+            $shippingBreakdown->items->put($shippingOption->getIdentifier(),
                 new ShippingBreakdownItem(
                     name: $shippingOption->getName(),
                     identifier: $shippingOption->getIdentifier(),

--- a/packages/core/src/Pipelines/Cart/Calculate.php
+++ b/packages/core/src/Pipelines/Cart/Calculate.php
@@ -26,7 +26,13 @@ class Calculate
         });
 
         $total = $cart->lines->sum('total.value') + $cart->shippingTotal?->value;
-
+        
+        $subTotalDiscounted = $cart->lines->sum(function ($line) {
+            return $line->subTotalDiscounted ?
+                $line->subTotalDiscounted->value :
+                $line->subTotal->value;
+        });
+        
         $cart->subTotal = new Price($subTotal, $cart->currency, 1);
         $cart->subTotalDiscounted = new Price($subTotalDiscounted, $cart->currency, 1);
         $cart->discountTotal = new Price($discountTotal, $cart->currency, 1);

--- a/packages/core/src/Pipelines/Cart/Calculate.php
+++ b/packages/core/src/Pipelines/Cart/Calculate.php
@@ -26,13 +26,13 @@ class Calculate
         });
 
         $total = $cart->lines->sum('total.value') + $cart->shippingTotal?->value;
-        
+
         $subTotalDiscounted = $cart->lines->sum(function ($line) {
             return $line->subTotalDiscounted ?
                 $line->subTotalDiscounted->value :
                 $line->subTotal->value;
         });
-        
+
         $cart->subTotal = new Price($subTotal, $cart->currency, 1);
         $cart->subTotalDiscounted = new Price($subTotalDiscounted, $cart->currency, 1);
         $cart->discountTotal = new Price($discountTotal, $cart->currency, 1);

--- a/packages/core/src/Pipelines/Cart/Calculate.php
+++ b/packages/core/src/Pipelines/Cart/Calculate.php
@@ -25,15 +25,7 @@ class Calculate
                 $line->subTotal->value;
         });
 
-        $total = $cart->lines->sum('total.value');
-
-        // Get the shipping address
-        if ($shippingAddress = $cart->shippingAddress) {
-            if ($shippingAddress->shippingSubTotal) {
-                $subTotal += $shippingAddress->shippingSubTotal?->value;
-                $total += $shippingAddress->shippingTotal?->value;
-            }
-        }
+        $total = $cart->lines->sum('total.value') + $cart->shippingTotal?->value;
 
         $cart->subTotal = new Price($subTotal, $cart->currency, 1);
         $cart->subTotalDiscounted = new Price($subTotalDiscounted, $cart->currency, 1);

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -570,7 +570,10 @@ class CartTest extends TestCase
         ]);
     }
 
-    /** @test */
+    /**
+    * @test
+    * @group thisone
+    */
     public function can_calculate_shipping()
     {
         $country = Country::factory()->create();

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -570,10 +570,7 @@ class CartTest extends TestCase
         ]);
     }
 
-    /**
-    * @test
-    * @group thisone
-    */
+    /** @test */
     public function can_calculate_shipping()
     {
         $country = Country::factory()->create();

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -657,7 +657,8 @@ class CartTest extends TestCase
 
         $cart->calculate();
 
-        $this->assertEquals(600, $cart->subTotal->value);
+        $this->assertEquals(100, $cart->subTotal->value);
+        $this->assertEquals(500, $cart->shippingSubTotal->value);
         $this->assertEquals(720, $cart->total->value);
     }
 

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -224,11 +224,7 @@ class OrderTest extends TestCase
         $this->assertEquals($user->getKey(), $order->user->getKey());
     }
 
-    /**
-     * @test
-     *
-     * @group orders
-     */
+    /** @test */
     public function can_cast_and_store_shipping_breakdown()
     {
         $order = Order::factory()->create();
@@ -248,7 +244,22 @@ class OrderTest extends TestCase
         $order->save();
 
         $this->assertDatabaseHas((new Order)->getTable(), [
-            'shipping_breakdown' => (string) $breakdown,
+            'shipping_breakdown' => json_encode([[
+                'name' => 'Breakdown A',
+                'identifier' => 'BA',
+                'price' => 123,
+            ]]),
         ]);
+
+        $breakdown = $order->refresh()->shipping_breakdown;
+
+        $this->assertCount(1, $breakdown);
+
+        $breakdownItem = $breakdown->first();
+
+        $this->assertEquals('Breakdown A', $breakdownItem->name);
+        $this->assertEquals('BA', $breakdownItem->identifier);
+        $this->assertInstanceOf(Price::class, $breakdownItem->price);
+        $this->assertEquals(123, $breakdownItem->price->value);
     }
 }

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -4,6 +4,9 @@ namespace Lunar\Tests\Unit\Models;
 
 use DateTime;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdownItem;
+use Lunar\DataTypes\Price;
 use Lunar\Models\Cart;
 use Lunar\Models\Currency;
 use Lunar\Models\Customer;
@@ -219,5 +222,33 @@ class OrderTest extends TestCase
 
         $this->assertEquals($customer->id, $order->customer->id);
         $this->assertEquals($user->getKey(), $order->user->getKey());
+    }
+
+    /**
+     * @test
+     *
+     * @group orders
+     */
+    public function can_cast_and_store_shipping_breakdown()
+    {
+        $order = Order::factory()->create();
+
+        $breakdown = new ShippingBreakdown(
+            items: collect([
+                new ShippingBreakdownItem(
+                    name: 'Breakdown A',
+                    identifier: 'BA',
+                    price: new Price(123, Currency::getDefault(), 1)
+                ),
+            ])
+        );
+
+        $order->shipping_breakdown = $breakdown;
+
+        $order->save();
+
+        $this->assertDatabaseHas((new Order)->getTable(), [
+            'shipping_breakdown' => (string) $breakdown,
+        ]);
     }
 }

--- a/packages/core/tests/Unit/Pipelines/Cart/ApplyShippingTest.php
+++ b/packages/core/tests/Unit/Pipelines/Cart/ApplyShippingTest.php
@@ -55,7 +55,7 @@ class ApplyShippingTest extends TestCase
             return $cart;
         });
 
-        $this->assertInstanceOf(PriceDataType::class, $cart->shippingTotal);
+        $this->assertInstanceOf(PriceDataType::class, $cart->shippingSubTotal);
     }
 
     /** @test */
@@ -137,7 +137,7 @@ class ApplyShippingTest extends TestCase
             return $cart;
         });
 
-        $this->assertInstanceOf(PriceDataType::class, $cart->shippingTotal);
-        $this->assertEquals(500, $cart->shippingTotal->value);
+        $this->assertInstanceOf(PriceDataType::class, $cart->shippingSubTotal);
+        $this->assertEquals(500, $cart->shippingSubTotal->value);
     }
 }


### PR DESCRIPTION
This PR will add a new `shipping_breakdown` to orders and carts. This will allow developers to add additional shipping costs and provide a more complete breakdown similar to discounts and taxes.

The idea being that you may have outside factors which affect the cost of shipping outside of what's provided by the manifest, such as split delivery or additional charges for awkward items, this should facilitate that.