### PR TITLE
Feat [0.3] - Scroll to top on page change.

### DIFF
--- a/utils/livewire-tables/resources/views/index.blade.php
+++ b/utils/livewire-tables/resources/views/index.blade.php
@@ -1,7 +1,9 @@
 <div x-data="{
     savingSearch: false,
     init() {
-        Livewire.on('savedSearch', () => this.savingSearch = false)
+      Livewire.on('savedSearch', () => this.savingSearch = false)
+
+      Livewire.on('updatedPage', () => window.scrollTo(0, 0))
     }
 }">
     <div x-cloak

--- a/utils/livewire-tables/src/Components/Table.php
+++ b/utils/livewire-tables/src/Components/Table.php
@@ -122,6 +122,11 @@ class Table extends Component
         $this->resetSavedSearch();
     }
 
+    public function updatedPage($page)
+    {
+        $this->emit('updatedPage', $page);
+    }
+
     public function updatedSelected($value)
     {
         $this->emit('table.selectedRows', $value);


### PR DESCRIPTION
This pull request adds an event for when the page is changed on data tables and then listens to that event in alpine to scroll the page to the top.