### PR TITLE
Feat [0.3] - Add price relationship to products

### DIFF
--- a/docs/core/reference/products.md
+++ b/docs/core/reference/products.md
@@ -568,6 +568,14 @@ $pricing->tiers;
 $pricing->customerGroupPrices;
 ```
 
+Sometimes you might want to simply get all prices a product has from the variants, instead of loading up all a products variants fetching the prices that way, you can use the `prices` relationship on the product.
+
+```php
+$product->prices
+```
+
+This will return a collection of `Price` models.
+
 ## Full Example
 
 For this example, we're going to be creating some Dr. Martens boots. Below is a screenshot of what we're aiming for:

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -5,6 +5,7 @@ namespace Lunar\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Lunar\Base\BaseModel;
@@ -264,5 +265,20 @@ class Product extends BaseModel implements SpatieHasMedia
     public function brand()
     {
         return $this->belongsTo(Brand::class);
+    }
+
+    /**
+     * Return the prices relationship.
+     *
+     * @return HasManyThrough
+     */
+    public function prices()
+    {
+        return $this->hasManyThrough(
+            Price::class,
+            ProductVariant::class,
+            'product_id',
+            'priceable_id'
+        )->wherePriceableType(ProductVariant::class);
     }
 }

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -9,13 +9,15 @@ use Lunar\Models\Brand;
 use Lunar\Models\Channel;
 use Lunar\Models\Collection;
 use Lunar\Models\CustomerGroup;
+use Lunar\Models\Price;
 use Lunar\Models\Product;
 use Lunar\Models\ProductAssociation;
 use Lunar\Models\ProductType;
+use Lunar\Models\ProductVariant;
 use Lunar\Tests\TestCase;
 
 /**
- * @group associations
+ * @group lunar.products
  */
 class ProductTest extends TestCase
 {
@@ -454,5 +456,35 @@ class ProductTest extends TestCase
         $this->assertInstanceOf(Collection::class, $product->collections->first());
         $this->assertNotNull($product->collections->first()->pivot);
         $this->assertNotNull($product->collections->first()->pivot->position);
+    }
+
+    /** @test */
+    public function can_retrieve_prices()
+    {
+        $attribute_data = collect([
+            'meta_title' => new \Lunar\FieldTypes\Text('I like cake'),
+            'pack_qty' => new \Lunar\FieldTypes\Number(12345),
+            'description' => new \Lunar\FieldTypes\TranslatedText(collect([
+                'en' => new \Lunar\FieldTypes\Text('Blue'),
+                'fr' => new \Lunar\FieldTypes\Text('Bleu'),
+            ])),
+        ]);
+
+        $product = Product::factory()
+            ->for(ProductType::factory())
+            ->create([
+                'attribute_data' => $attribute_data,
+            ]);
+
+        $variant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+        ]);
+
+        Price::factory()->create([
+            'priceable_id' => $variant->id,
+            'priceable_type' => ProductVariant::class,
+        ]);
+
+        $this->assertCount(1, $product->refresh()->prices);
     }
 }


### PR DESCRIPTION
It would be handy to be able to fetch all prices a product has without having to load up all variants first, this PR adds a relationship for that purpose.