### PR TITLE
Feat [0.3] - Add status scope to products

### DIFF
--- a/docs/core/reference/products.md
+++ b/docs/core/reference/products.md
@@ -320,6 +320,12 @@ $taxClass = TaxClass::where(...)->first();
 $currency = Currency::where(...)->first();
 ```
 
+You can also specify a status to limit results to using the provided scope.
+
+```php
+Product::status('published')->get();
+```
+
 Then we need to create our base option and it's values.
 
 ```php

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -265,4 +265,17 @@ class Product extends BaseModel implements SpatieHasMedia
     {
         return $this->belongsTo(Brand::class);
     }
+
+    /**
+     * Apply the status scope.
+     *
+     * @param Builder $query
+     * @param string $status
+     *
+     * @return Builder
+     */
+    public function scopeStatus(Builder $query, $status)
+    {
+        return $query->whereStatus($status);
+    }
 }

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -15,7 +15,7 @@ use Lunar\Models\ProductType;
 use Lunar\Tests\TestCase;
 
 /**
- * @group associations
+ * @group lunar.products
  */
 class ProductTest extends TestCase
 {
@@ -40,6 +40,30 @@ class ProductTest extends TestCase
             ]);
 
         $this->assertEquals($attribute_data, $product->attribute_data);
+    }
+
+    /** @test */
+    public function can_fetch_using_status_scope()
+    {
+        $attribute_data = collect([
+            'meta_title' => new \Lunar\FieldTypes\Text('I like cake'),
+            'pack_qty' => new \Lunar\FieldTypes\Number(12345),
+            'description' => new \Lunar\FieldTypes\TranslatedText(collect([
+                'en' => new \Lunar\FieldTypes\Text('Blue'),
+                'fr' => new \Lunar\FieldTypes\Text('Bleu'),
+            ])),
+        ]);
+
+        Product::factory()
+            ->for(ProductType::factory())
+            ->create([
+                'attribute_data' => $attribute_data,
+                'status' => 'draft',
+            ]);
+
+        $this->assertCount(0, Product::status('published')->get());
+
+        $this->assertCount(1, Product::status('draft')->get());
     }
 
     /**


### PR DESCRIPTION
This PR adds a simple scope to the product model so you can limit results by status.