### PR TITLE
Hotfix [0.2] - Added nullable validation for not required attributes

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -198,9 +198,13 @@ trait WithAttributes
                 foreach ($this->languages as $language) {
                     // all rules set when attribute was created (resets on each iteration)
                     $validationRules = $validation;
-                    if ($language->default && $isRequired) {
+                    if ($language->default) {
                         // append required for the default language
-                        $validationRules = array_merge($validationRules, ['required']);
+                        if ($isRequired) {
+                            $validationRules = array_merge($validationRules, ['required']);
+                        } else {
+                            $validationRules = array_merge($validationRules, ['nullable']);
+                        }
                     }
                     $rules["{$attribute['signature']}.{$language->code}"] = $validationRules;
                 }
@@ -210,6 +214,8 @@ trait WithAttributes
 
             if ($isRequired) {
                 $validation = array_merge($validation, ['required']);
+            } else {
+                $validation = array_merge($validation, ['nullable']);
             }
 
             if ($attribute['type'] == Number::class) {


### PR DESCRIPTION
### Behaviour before the fix:
If you add Laravel validation rules to a text field (i.e. `url`) then it throws a validation error. Adding `nullable|url` to the validation field corrects this.

### Fixed behavior:
When adding a custom attribute, leaving Required unchecked will make the field nullable.

Fixes #985 

Steps To Reproduce:
Add an attribute (i.e. to a collection or a product). Select Type of Text, disable Required, and set Validation Rules of `url`.
Attempt to save collection without setting a value in your new attribute. The fix will allow to save without throwing validation error.

