### PR TITLE
Fix - set database connection if specified in config

### DIFF
--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use Lunar\Hub\Auth\Manifest;
@@ -181,6 +182,10 @@ class AdminHubServiceProvider extends ServiceProvider
             $this->app->singleton($tableBuilder, function ($app) use ($tableBuilder) {
                 return new $tableBuilder;
             });
+        }
+
+        if ($connection = config('lunar.database.connection', false)) {
+            DB::setDefaultConnection($connection);
         }
     }
 

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Lunar\Addons\Manifest;
@@ -160,6 +161,10 @@ class LunarServiceProvider extends ServiceProvider
         $this->app->singleton(DiscountManagerInterface::class, function ($app) {
             return $app->make(DiscountManager::class);
         });
+
+        if ($connection = config('lunar.database.connection', false)) {
+            DB::setDefaultConnection($connection);
+        }
     }
 
     /**


### PR DESCRIPTION
PR [#235](https://github.com/lunarphp/lunar/pull/235) introduces a new feature to the BaseModel class. This feature allows users to set a custom database connection for the package. By implementing this change, all models within the package will utilize the specified custom database connection if one is provided.

However, I have noticed that when performing database transactions through the Database Manager Facades, it continues to utilize the default connection. In my opinion, it would be beneficial if the Database Manager also utilized the custom connection specified in the configuration file for these transactions. One of the many instances is when Adding/Updating permissions for Staff. 

Thus I have changed the default database connection if specified in the config.
