### PR TITLE
Discount delete - detach not delete users

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Discounts/DiscountShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/DiscountShow.php
@@ -74,7 +74,7 @@ class DiscountShow extends AbstractDiscount
             $this->discount->collections()->delete();
             $this->discount->customerGroups()->detach();
             $this->discount->channels()->detach();
-            $this->discount->users()->delete();
+            $this->discount->users()->detach();
             $this->discount->delete();
         });
 


### PR DESCRIPTION
Bit of a serious bug here in that when deleting discounts it was trying to delete users instead of detaching them.
This fixes it.