### PR TITLE
Hotfix [0.2] - Fixed visibility of the save search button when $canSaveSearches is s…

### DIFF
--- a/utils/livewire-tables/resources/views/index.blade.php
+++ b/utils/livewire-tables/resources/views/index.blade.php
@@ -99,7 +99,7 @@
                             </div>
                         @endif
 
-                        @if ($this->hasSearchApplied)
+                        @if ($this->canSaveSearches)
                             <x-l-tables::button x-on:click="savingSearch = true">
                                 Save Search
                             </x-l-tables::button>


### PR DESCRIPTION
Steps to reproduce:
1. Open Products page.
2. Type something in the search input and save search button will appear.
3. Open lunarphp/lunar/packages/admin/src/Http/Livewire/Components/Products/Tables/ProductsTable.php and set $canSaveSearches to false.
4. Refresh page and type something in the search input again.

Actual result: the save search button will appear.
Expected result: the search button will not appear.