### PR TITLE
Hotfix [0.3] - Freeze time in tests

### DIFF
--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -29,6 +29,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
         });
 
         activity()->disableLogging();
+
+        // Freeze time to avoid timestamp errors
+        $this->freezeTime();
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Attempting to avoid failed test runs where timestamps don't match.