### PR TITLE
Hotfix [0.2] Freeze time for tests

### DIFF
--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -29,6 +29,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
         });
 
         activity()->disableLogging();
+
+        // Freeze time to avoid timestamp errors
+        $this->freezeTime();
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Avoids Eloquent modal comparison assertions from failing if they have slightly different timestamps.