### PR TITLE
[0.3] reposition Tag section in order page

### DIFF
--- a/packages/admin/resources/views/livewire/components/orders/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/orders/show.blade.php
@@ -101,17 +101,6 @@
         </div>
 
         <div class="space-y-4">
-        <section class="p-4 bg-white rounded-lg shadow">
-            <header>
-                <strong class="text-gray-700">
-                  {{ __('adminhub::components.orders.show.tags_header') }}
-                </strong>
-            </header>
-            @livewire('hub.components.tags', [
-              'taggable' => $order,
-              'independant' => true,
-            ])
-        </section>
             @if ($order->customer)
                 <header class="flex items-center justify-between">
                     <strong class="text-gray-700 truncate">
@@ -154,6 +143,18 @@
                     'hidden' => $this->shippingEqualsBilling,
                     'message' => __('adminhub::components.orders.show.billing_matches_shipping'),
                     'address' => $this->billingAddress,
+                ])
+            </section>
+
+            <section class="p-4 bg-white rounded-lg shadow">
+                <header>
+                    <strong class="text-gray-700">
+                      {{ __('adminhub::components.orders.show.tags_header') }}
+                    </strong>
+                </header>
+                @livewire('hub.components.tags', [
+                  'taggable' => $order,
+                  'independant' => true,
                 ])
             </section>
 


### PR DESCRIPTION
move Tag section to before Additional Info section

Before:
![image](https://github.com/lunarphp/lunar/assets/67364036/473965bc-d736-4f79-9f74-ea086c646dfa)

After:
![image](https://github.com/lunarphp/lunar/assets/67364036/d9c24fc8-d12f-4c1f-9bc6-df450398db89)
