### PR TITLE
Hotfix [0.2] - extend DB facade to use connection from lunar.database.connection config

### DIFF
--- a/docs/admin-hub/extending.md
+++ b/docs/admin-hub/extending.md
@@ -364,7 +364,7 @@ Create a Livewire component to handle your custom discount type.
 
 namespace App\Http\Livewire\Components;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Discount;
 use Lunar\Hub\Http\Livewire\Components\Discounts\Types\AbstractDiscountType;
 

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -19,6 +19,23 @@ So that Lunar tables do not conflict with your existing application database tab
     'table_prefix' => 'lunar_',
 ```
 
+### Database Connection
+
+`lunar/database.php`
+
+ By default, the package uses the default database connection defined in Laravel. Here specify a custom database connection for Lunar.
+
+```php
+    'connection' => 'some_custom_connection',
+```
+
+If you are using a custom database connection that is not the default connection in your Laravel configuration, you need to specify it in the .env file as well.
+
+```
+    ACTIVITY_LOGGER_DB_CONNECTION=some_custom_connection
+```
+In our package, we utilize Spatie's [laravel-activitylog](https://spatie.be/docs/laravel-activitylog) for logging. The mentioned configuration allows the activity logger to use a different database connection instead of the default database connection.
+
 ### Orders
 
 `lunar/orders.php`

--- a/packages/admin/src/Actions/Pricing/UpdateTieredPricing.php
+++ b/packages/admin/src/Actions/Pricing/UpdateTieredPricing.php
@@ -4,7 +4,7 @@ namespace Lunar\Hub\Actions\Pricing;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Currency;
 use Lunar\Models\Price;
 

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Collections;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Lunar\FieldTypes\TranslatedText;

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionShow.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Collections;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
 use Livewire\Component;

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Collections;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\MapsCollectionTree;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;

--- a/packages/admin/src/Http/Livewire/Components/Customers/CustomerShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Customers/CustomerShow.php
@@ -4,7 +4,7 @@ namespace Lunar\Hub\Http\Livewire\Components\Customers;
 
 use Carbon\CarbonPeriod;
 use Exception;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
 use Livewire\Component;

--- a/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
@@ -5,7 +5,7 @@ namespace Lunar\Hub\Http\Livewire\Components\Discounts;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Validation\Validator;
 use Livewire\Component;
 use Lunar\Facades\Discounts;

--- a/packages/admin/src/Http/Livewire/Components/Discounts/DiscountShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/DiscountShow.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Discounts;
 
 use Illuminate\Routing\Redirector;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Discount;
 
 class DiscountShow extends AbstractDiscount

--- a/packages/admin/src/Http/Livewire/Components/Discounts/Types/BuyXGetY.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/Types/BuyXGetY.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Discounts\Types;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Currency;
 use Lunar\Models\Discount;
 use Lunar\Models\Product;

--- a/packages/admin/src/Http/Livewire/Components/FieldTypes/FileFieldtype.php
+++ b/packages/admin/src/Http/Livewire/Components/FieldTypes/FileFieldtype.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\FieldTypes;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 use Livewire\WithPagination;

--- a/packages/admin/src/Http/Livewire/Components/Orders/OrdersTable.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrdersTable.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Orders;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Hub\Models\SavedSearch;
 use Lunar\Hub\Tables\Builders\OrdersTableBuilder;

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -4,7 +4,7 @@ namespace Lunar\Hub\Http\Livewire\Components\Products;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Validation\Validator;
 use Livewire\Component;
 use Livewire\WithFileUploads;

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Products\ProductTypes;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Attribute;
 use Lunar\Models\Product;
 use Lunar\Models\ProductType;

--- a/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Products\Variants;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Livewire\TemporaryUploadedFile;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Attributes;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Facades\AttributeManifest;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Hub\Http\Livewire\Traits\WithLanguages;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Currencies/CurrencyShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Currencies/CurrencyShow.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Currencies;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\ConfirmsDelete;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionEdit.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Product\Options;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Hub\Http\Livewire\Traits\WithLanguages;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionsIndex.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionsIndex.php
@@ -4,7 +4,7 @@ namespace Lunar\Hub\Http\Livewire\Components\Settings\Product\Options;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Staff/AbstractStaff.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Staff/AbstractStaff.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Staff;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Hub\Models\Staff;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Tags/TagShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Tags/TagShow.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Tags;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Models\Tag;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Taxes/AbstractTaxZone.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Taxes/AbstractTaxZone.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Taxes;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Livewire\WithPagination;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Taxes/TaxClassesIndex.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Taxes/TaxClassesIndex.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Taxes;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Livewire\WithPagination;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Taxes/TaxZoneShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Taxes/TaxZoneShow.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Hub\Http\Livewire\Components\Settings\Taxes;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\TaxRateAmount;
 use Lunar\Models\TaxZone;
 

--- a/packages/admin/src/Http/Livewire/Components/Tags.php
+++ b/packages/admin/src/Http/Livewire/Components/Tags.php
@@ -4,7 +4,7 @@ namespace Lunar\Hub\Http\Livewire\Components;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\Hub\Http\Livewire\Traits\Notifies;
 use Lunar\Models\Tag;

--- a/packages/admin/src/Http/Livewire/Dashboard.php
+++ b/packages/admin/src/Http/Livewire/Dashboard.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire;
 
 use Carbon\CarbonPeriod;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Livewire\Component;
 use Lunar\DataTypes\Price;
 use Lunar\Models\Currency;

--- a/packages/admin/src/Http/Livewire/Traits/HasImages.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasImages.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Traits;
 
 use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\FileUploadConfiguration;
 use Livewire\TemporaryUploadedFile;

--- a/packages/admin/src/Http/Livewire/Traits/HasPrices.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasPrices.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Traits;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Lunar\Hub\Actions\Pricing\UpdateCustomerGroupPricing;
 use Lunar\Hub\Actions\Pricing\UpdatePrices;

--- a/packages/admin/src/Http/Livewire/Traits/HasUrls.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasUrls.php
@@ -3,7 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Traits;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Lunar\Models\Url;

--- a/packages/admin/src/Jobs/Products/GenerateVariants.php
+++ b/packages/admin/src/Jobs/Products/GenerateVariants.php
@@ -9,7 +9,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Lunar\Hub\Exceptions\InvalidProductValuesException;
 use Lunar\Hub\Exceptions\VariantsDisabledException;

--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\DataTypes\Price;
 
 if (! function_exists('max_upload_filesize')) {

--- a/packages/core/database/migrations/2022_01_18_100001_add_customer_id_to_orders_table.php
+++ b/packages/core/database/migrations/2022_01_18_100001_add_customer_id_to_orders_table.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Base\Migration;
 

--- a/packages/core/database/migrations/2022_03_17_100000_add_fields_to_transactions_table.php
+++ b/packages/core/database/migrations/2022_03_17_100000_add_fields_to_transactions_table.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Base\Migration;
 

--- a/packages/core/database/migrations/2022_08_09_100002_add_brand_id_to_products_table.php
+++ b/packages/core/database/migrations/2022_08_09_100002_add_brand_id_to_products_table.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Base\Migration;
 

--- a/packages/core/database/state/ConvertProductTypeAttributesToProducts.php
+++ b/packages/core/database/state/ConvertProductTypeAttributesToProducts.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Database\State;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Models\Product;
 use Lunar\Models\ProductType;

--- a/packages/core/database/state/EnsureMediaCollectionsAreRenamed.php
+++ b/packages/core/database/state/EnsureMediaCollectionsAreRenamed.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Database\State;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Models\Brand;
 use Lunar\Models\Collection;

--- a/packages/core/database/state/EnsureUserOrdersHaveACustomer.php
+++ b/packages/core/database/state/EnsureUserOrdersHaveACustomer.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Database\State;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Models\Order;
 

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Actions\Carts;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Actions\AbstractAction;
 use Lunar\Actions\Orders\GenerateOrderReference;
 use Lunar\DataTypes\ShippingOption;

--- a/packages/core/src/Actions/Carts/MergeCart.php
+++ b/packages/core/src/Actions/Carts/MergeCart.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Actions\Carts;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Cart;
 
 class MergeCart

--- a/packages/core/src/Actions/Carts/RemovePurchasable.php
+++ b/packages/core/src/Actions/Carts/RemovePurchasable.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Actions\Carts;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Actions\AbstractAction;
 use Lunar\Exceptions\CartLineIdMismatchException;
 use Lunar\Models\Cart;

--- a/packages/core/src/Actions/Carts/UpdateCartLine.php
+++ b/packages/core/src/Actions/Carts/UpdateCartLine.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Actions\Carts;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Actions\AbstractAction;
 use Lunar\Models\CartLine;
 

--- a/packages/core/src/Base/OrderReferenceGenerator.php
+++ b/packages/core/src/Base/OrderReferenceGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Base;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Order;
 
 class OrderReferenceGenerator implements OrderReferenceGeneratorInterface

--- a/packages/core/src/Base/Traits/HasChannels.php
+++ b/packages/core/src/Base/Traits/HasChannels.php
@@ -4,7 +4,7 @@ namespace Lunar\Base\Traits;
 
 use DateTime;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Channel;
 
 trait HasChannels

--- a/packages/core/src/Console/Commands/Import/AddressData.php
+++ b/packages/core/src/Console/Commands/Import/AddressData.php
@@ -3,7 +3,7 @@
 namespace Lunar\Console\Commands\Import;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Lunar\Models\Country;
 

--- a/packages/core/src/Console/Commands/MigrateGetCandy.php
+++ b/packages/core/src/Console/Commands/MigrateGetCandy.php
@@ -3,7 +3,7 @@
 namespace Lunar\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;

--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -3,7 +3,7 @@
 namespace Lunar\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Lunar\FieldTypes\TranslatedText;
 use Lunar\Hub\AdminHubServiceProvider;

--- a/packages/core/src/Facades/DB.php
+++ b/packages/core/src/Facades/DB.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Lunar\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\DB as DBFacade;
+use Lunar\Managers\DatabaseManager;
+
+class DB extends DBFacade
+{
+    /**
+     * Get the registered DatabaseManger class.
+     *
+     * @return \Lunar\Managers\DatabaseManager
+     */
+    public static function connection()
+    {
+        // return custom connection
+        return parent::connection(config('lunar.database.connection'));
+    }
+}
+

--- a/packages/core/src/Jobs/Collections/RebuildCollectionTree.php
+++ b/packages/core/src/Jobs/Collections/RebuildCollectionTree.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Collection;
 
 class RebuildCollectionTree implements ShouldQueue

--- a/packages/core/src/Jobs/Collections/UpdateProductPositions.php
+++ b/packages/core/src/Jobs/Collections/UpdateProductPositions.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Actions\Collections\SortProducts;
 use Lunar\Models\Collection;
 

--- a/packages/core/src/Jobs/Orders/MarkAsNewCustomer.php
+++ b/packages/core/src/Jobs/Orders/MarkAsNewCustomer.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Order;
 use Lunar\Models\OrderAddress;
 

--- a/packages/core/src/Jobs/Products/Associations/Associate.php
+++ b/packages/core/src/Jobs/Products/Associations/Associate.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Product;
 
 class Associate implements ShouldQueue

--- a/packages/core/src/Jobs/Products/Associations/Dissociate.php
+++ b/packages/core/src/Jobs/Products/Associations/Dissociate.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Product;
 
 class Dissociate implements ShouldQueue

--- a/packages/core/src/Jobs/SyncTags.php
+++ b/packages/core/src/Jobs/SyncTags.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Str;
 use Lunar\Models\Tag;
 

--- a/packages/core/src/Models/Attribute.php
+++ b/packages/core/src/Models/Attribute.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasTranslations;

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Actions\Carts\AddAddress;
 use Lunar\Actions\Carts\AddOrUpdatePurchasable;
 use Lunar\Actions\Carts\AssociateUser;

--- a/packages/core/src/Observers/LanguageObserver.php
+++ b/packages/core/src/Observers/LanguageObserver.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Observers;
 
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Language;
 
 class LanguageObserver

--- a/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
+++ b/packages/core/tests/Database/State/EnsureBrandsAreUpgradedTest.php
@@ -3,7 +3,7 @@
 namespace Lunar\Tests\Database\State;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Lunar\FieldTypes\Text;

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -4,7 +4,7 @@ namespace Lunar\Tests\Unit\Models;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Lunar\Models\Brand;
 use Lunar\Models\Channel;
 use Lunar\Models\Collection;

--- a/utils/scout-database-engine/database/migrations/2022_08_30_000000_create_search_index_table.php
+++ b/utils/scout-database-engine/database/migrations/2022_08_30_000000_create_search_index_table.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Lunar\Facades\DB;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration

--- a/utils/scout-database-engine/database/migrations/2022_08_30_000000_create_search_index_table.php
+++ b/utils/scout-database-engine/database/migrations/2022_08_30_000000_create_search_index_table.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
+use Lunar\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration


### PR DESCRIPTION
This PR is a continuation of [#990](https://github.com/lunarphp/lunar/pull/990). 

I have created a new DB Facade extending the default Facade with connection returning value from `lunar.database.connection` config.
