### PR TITLE
Hotfix - Ensure $rate is an object when serializing TaxBreakdown

### DIFF
--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -66,7 +66,8 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
     public function serialize($model, $key, $value, $attributes)
     {
         return $value->map(function ($rate) {
-            if (is_array($rate)) $rate = (object) $rate;
+            $rate = is_array($rate) ? (object) $rate : $rate;
+
             if ($rate->total instanceof Price) {
                 $rate->total = (object) [
                     'value' => $rate->total->value,

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -66,6 +66,7 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
     public function serialize($model, $key, $value, $attributes)
     {
         return $value->map(function ($rate) {
+            if (is_array($rate)) $rate = (object) $rate;
             if ($rate->total instanceof Price) {
                 $rate->total = (object) [
                     'value' => $rate->total->value,

--- a/packages/core/tests/Unit/Base/Casts/TaxBreakdownTest.php
+++ b/packages/core/tests/Unit/Base/Casts/TaxBreakdownTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lunar\Tests\Unit\Base\Casts;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Base\Casts\TaxBreakdown;
+use Lunar\Models\CartLine;
+use Lunar\Models\Currency;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group model.casts
+ */
+class TaxBreakdownTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_serialize_from_array()
+    {
+        $breakDown = new TaxBreakdown;
+
+        $result = $breakDown->serialize(
+            new CartLine,
+            'foo',
+            collect([
+                [
+                    'total' => [
+                        'value' => 123,
+                        'formatted' => '£1.23',
+                        'currency' => Currency::factory()->create()->toArray(),
+                    ]
+                ]
+            ]),
+            []
+        );
+
+        $this->assertJson($result);
+        $json = json_decode($result);
+
+        $this->assertCount(1, $json);
+        $this->assertIsObject($json[0]);
+    }
+}


### PR DESCRIPTION
There have been times where the `$rate` variable in this instance is an array, rather than an object, thus breaking the property accessors in this serialize method.

This commit ensures that $rate will always be an object, by checking if it is an array, and if so, converting it to an object.
