### PR TITLE
Fix attribute group saving validation

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -77,7 +77,7 @@ class AttributeGroupEdit extends Component
         $this->attributeGroup->handle = $handle;
 
         $this->validate([
-            'attributeGroup.handle' => 'unique:'.get_class($this->attributeGroup).',handle',
+            'attributeGroup.handle' => 'unique:'.get_class($this->attributeGroup).',handle,'.$this->attributeGroup->id,
         ]);
 
         if ($this->attributeGroup->id) {


### PR DESCRIPTION
Currently if you attempt to resave an attribute group with the same name a validation exception is thrown.