### PR TITLE
Fix scout search

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Brands/BrandsTable.php
+++ b/packages/admin/src/Http/Livewire/Components/Brands/BrandsTable.php
@@ -50,7 +50,11 @@ class BrandsTable extends LunarTable
         return Brand::with(['thumbnail'])
             ->when($this->query, function ($query) {
                 $this->resetPage();
-                $query->whereIn('id', Brand::search($this->query)->keys());
+                $query->whereIn('id', Brand::search($this->query)
+                    ->query(fn ($query) => $query->select('id'))
+                    ->options([
+                        'hitsPerPage' => 1000,
+                    ])->keys());
             })
             ->withCount(['products'])
             ->orderBy('name')

--- a/packages/admin/src/Tables/Builders/CustomersTableBuilder.php
+++ b/packages/admin/src/Tables/Builders/CustomersTableBuilder.php
@@ -21,7 +21,11 @@ class CustomersTableBuilder extends TableBuilder
         $query = Customer::query();
 
         if ($this->searchTerm) {
-            $query->whereIn('id', Customer::search($this->searchTerm)->keys());
+            $query->whereIn('id', Customer::search($this->searchTerm)
+                ->query(fn ($query) => $query->select('id'))
+                ->options([
+                    'hitsPerPage' => 500,
+                ])->keys());
         }
 
         return $query->paginate($this->perPage);

--- a/packages/admin/src/Tables/Builders/OrdersTableBuilder.php
+++ b/packages/admin/src/Tables/Builders/OrdersTableBuilder.php
@@ -79,7 +79,11 @@ class OrdersTableBuilder extends TableBuilder
         ])->orderBy($this->sortField, $this->sortDir);
 
         if ($this->searchTerm) {
-            $query->whereIn('id', Order::search($this->searchTerm)->keys());
+            $query->whereIn('id', Order::search($this->searchTerm)
+                ->query(fn ($query) => $query->select('id'))
+                ->options([
+                    'hitsPerPage' => 100,
+                ])->keys());
         }
 
         $filters = collect($this->queryStringFilters)->filter(function ($value) {

--- a/packages/admin/src/Tables/Builders/ProductsTableBuilder.php
+++ b/packages/admin/src/Tables/Builders/ProductsTableBuilder.php
@@ -22,7 +22,11 @@ class ProductsTableBuilder extends TableBuilder
             ->withTrashed();
 
         if ($this->searchTerm) {
-            $query->whereIn('id', Product::search($this->searchTerm)->keys());
+            $query->whereIn('id', Product::search($this->searchTerm)
+                ->query(fn ($query) => $query->select('id'))
+                ->options([
+                    'hitsPerPage' => 500,
+                ])->keys());
         }
 
         $filters = collect($this->queryStringFilters)->filter(function ($value) {


### PR DESCRIPTION
for some reason, in my setup scout search only return up to 20 result, thus causing the table pagination never get more than 1 page

- engine: meilisearch:v1.1.0
- `Model->perPage` should be laravel default 15
- meilisearch index setting: `"pagination":{"maxTotalHits":1000}"`

Found the reason for 20 records, meilisearch default value https://www.meilisearch.com/docs/reference/api/search#number-of-results-per-page

this PR changes `Model::search` calls to pass in `hitsPerPage` option to return more result so that eloquent pagination can work properly