### PR TITLE
Feature/add null check for shipping options

### DIFF
--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -44,7 +44,7 @@ final class ApplyShipping
 
     private function getShippingOption(Cart $cart)
     {
-        if (! $cart->shippingAddress) {
+        if (! $cart->shippingAddress || ! $cart->shippingAddress->shipping_option) {
             return null;
         }
 


### PR DESCRIPTION
Add an extra shipping check if they have a shipping address set, but do not have the shipping option set yet.

It does not need to loop through the options checking if there is no shipping option set.