### PR TITLE
Fix bug that sets the default weight to kg instead of using a length …

### DIFF
--- a/packages/core/src/Base/Traits/HasDimensions.php
+++ b/packages/core/src/Base/Traits/HasDimensions.php
@@ -67,7 +67,7 @@ trait HasDimensions
      */
     public function getWeightAttribute()
     {
-        $unit = $this->weight_unit ?: 'mm';
+        $unit = $this->weight_unit ?: 'kg';
 
         return Converter::from("weight.{$unit}")->value($this->weight_value ?: 0);
     }


### PR DESCRIPTION
Update the default weight unit. mm is a length attribute. Setting to kg to keep it on par with the metric system currently.