### PR TITLE
Variant backorder validation

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The iframe height on email previews has been increased to avoid cut off.
 - Refactor row selection on tables to avoid extra roundtrips to Livewire.
 - AttributeGroup saving will now pass the id if being edited to prevent false validation exception being thrown.
+- Added a validation check for the product variant backorder.
 
 ### Changed
 

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -242,7 +242,7 @@ abstract class AbstractProduct extends Component
                 $this->hasPriceValidationRules(),
                 [
                     'variant.stock' => 'required|min:0|numeric|max:10000000',
-                    'variant.backorder' => 'numeric|max:10000000',
+                    'variant.backorder' => 'required|min:0|numeric|max:10000000',
                     'variant.purchasable' => 'string|required',
                     'variant.length_value' => 'numeric|nullable',
                     'variant.length_unit' => 'string|nullable',

--- a/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
@@ -154,7 +154,7 @@ class VariantShow extends Component
                 'variant.volume_value' => 'numeric|nullable',
                 'variant.volume_unit' => 'string|nullable',
                 'variant.shippable' => 'boolean|nullable',
-                'variant.backorder' => 'numeric|max:10000000',
+                'variant.backorder' => 'required|min:0|numeric|max:10000000',
                 'variant.tax_ref' => 'nullable|string|max:255',
                 'variant.purchasable' => 'string|required',
                 'variant.unit_quantity' => 'required|numeric|min:1|max:10000000',


### PR DESCRIPTION
This pull request is similar to #997 

The variant backorder gives the same database error if there is no data in the input.
