### PR TITLE
Cache relations to avoid duplicate queries

### DIFF
--- a/packages/core/src/Base/BaseModel.php
+++ b/packages/core/src/Base/BaseModel.php
@@ -4,6 +4,7 @@ namespace Lunar\Base;
 
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Base\Traits\HasModelExtending;
+use Spatie\LaravelBlink\BlinkFacade as Blink;
 
 abstract class BaseModel extends Model
 {
@@ -21,5 +22,12 @@ abstract class BaseModel extends Model
         if ($connection = config('lunar.database.connection', false)) {
             $this->setConnection($connection);
         }
+    }
+    
+    protected function getCachedRelation($attribute, $callback, $morphType = '')
+    {
+        return Blink::once('lunar:'.$attribute.$morphType.':'.$this->{$attribute}, function() use ($callback) {
+            return $callback();    
+        });
     }
 }

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -189,6 +189,13 @@ class Cart extends BaseModel
     {
         return $this->belongsTo(Currency::class);
     }
+    
+    public function getCurrencyAttribute()
+    {
+        return $this->getCachedRelation('currency_id', function () {
+            return $this->currency()->first();    
+        });
+    }
 
     /**
      * Return the user relationship.
@@ -198,6 +205,13 @@ class Cart extends BaseModel
     public function user()
     {
         return $this->belongsTo(config('auth.providers.users.model'));
+    }
+    
+    public function getUserAttribute()
+    {
+        return $this->getCachedRelation('user_id', function () {
+            return $this->user()->first();    
+        });
     }
 
     public function scopeUnmerged($query)

--- a/packages/core/src/Models/CartLine.php
+++ b/packages/core/src/Models/CartLine.php
@@ -119,6 +119,13 @@ class CartLine extends BaseModel
     {
         return $this->belongsTo(Cart::class);
     }
+    
+    public function getCartAttribute()
+    {
+        return $this->getCachedRelation('cart_id', function () {
+            return $this->cart()->first();    
+        });
+    }
 
     /**
      * Return the tax class relationship.
@@ -153,5 +160,12 @@ class CartLine extends BaseModel
     public function purchasable()
     {
         return $this->morphTo();
+    }
+    
+    public function getPurchasableAttribute()
+    {
+        return $this->getCachedRelation('purchasable_id', function () {
+            return $this->purchasable()->first();    
+        }, 'purchasable_type');
     }
 }

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -55,6 +55,13 @@ class Price extends BaseModel
     {
         return $this->morphTo();
     }
+    
+    public function getPriceableAttribute()
+    {
+        return $this->getCachedRelation('priceable_id', function () {
+            return $this->priceable()->first();    
+        }, 'priceable_type');
+    }
 
     /**
      * Return the currency relationship.
@@ -65,6 +72,13 @@ class Price extends BaseModel
     {
         return $this->belongsTo(Currency::class);
     }
+    
+    public function getCurrencyAttribute()
+    {
+        return $this->getCachedRelation('currency_id', function () {
+            return $this->currency()->first();    
+        });
+    }
 
     /**
      * Return the customer group relationship.
@@ -74,5 +88,12 @@ class Price extends BaseModel
     public function customerGroup()
     {
         return $this->belongsTo(CustomerGroup::class);
+    }
+    
+    public function getCustomerGroupAttribute()
+    {
+        return $this->getCachedRelation('customer_group_id', function () {
+            return $this->customerGroup()->first();    
+        });
     }
 }

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -85,6 +85,13 @@ class ProductVariant extends BaseModel implements Purchasable
     {
         return $this->belongsTo(Product::class)->withTrashed();
     }
+    
+    public function getProductAttribute()
+    {
+        return $this->getCachedRelation('product_id', function () {
+            return $this->product()->first();    
+        });
+    }
 
     /**
      * Return the tax class relationship.
@@ -94,6 +101,13 @@ class ProductVariant extends BaseModel implements Purchasable
     public function taxClass()
     {
         return $this->belongsTo(TaxClass::class);
+    }
+    
+    public function getTaxClassAttribute()
+    {
+        return $this->getCachedRelation('tax_class_id', function () {
+            return $this->taxClass()->first();    
+        });
     }
 
     /**


### PR DESCRIPTION
You'll probably hate this approach, but I prefer to bring solutions than issues so it at least should give you something to think about.

We're getting a load of duplicate queries on our live 0.3 sites, which is obviously something we're keen to avoid! 

The approach is to use the attribute accessor methods to `Blink` the first call to the relation, and intentionally not make it specific to the model, so that other models dont need to do the same query. Where this is really useful is for relations like tax classes, channels and other models that are referenced by many other models.