### PR TITLE
Fix discount calculation

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `AmountOff` discount type will now use `discountTotal` when adding up the total discount for that line.
+- `getEligibleLines` method will now reject any lines where the `purchasableLimitations` doesn't exist.
+- `subTotalDiscounted` will now reset when calling the `CalculateLines` pipeline.
+
 ### Added
 
 - Added `fingerprint` method to the `Cart` model.

--- a/packages/core/src/DiscountTypes/AmountOff.php
+++ b/packages/core/src/DiscountTypes/AmountOff.php
@@ -145,7 +145,9 @@ class AmountOff extends AbstractDiscountType
     {
         $collectionIds = $this->discount->collections->pluck('id');
         $brandIds = $this->discount->brands->pluck('id');
-        $productIds = $this->discount->purchasableLimitations->map(fn ($limitation) => get_class($limitation->purchasable).'::'.$limitation->purchasable->id);
+        $productIds = $this->discount->purchasableLimitations
+            ->reject(fn ($limitation) => ! $limitation->purchasable)
+            ->map(fn ($limitation) => get_class($limitation->purchasable).'::'.$limitation->purchasable->id);
 
         $lines = $cart->lines;
 

--- a/packages/core/src/DiscountTypes/AmountOff.php
+++ b/packages/core/src/DiscountTypes/AmountOff.php
@@ -201,7 +201,7 @@ class AmountOff extends AbstractDiscountType
             $totalDiscount += $amount;
 
             $line->discountTotal = new Price(
-                $subTotalDiscounted + $amount,
+                $line->discountTotal?->value + $amount,
                 $cart->currency,
                 1
             );

--- a/packages/core/src/Pipelines/Cart/CalculateLines.php
+++ b/packages/core/src/Pipelines/Cart/CalculateLines.php
@@ -18,14 +18,14 @@ class CalculateLines
     {
         foreach ($cart->lines as $line) {
             $cartLine = app(Pipeline::class)
-            ->send($line)
-            ->through(
-                config('lunar.cart.pipelines.cart_lines', [])
-            )->thenReturn(function ($cartLine) {
-                $cartLine->cacheProperties();
+                ->send($line)
+                ->through(
+                    config('lunar.cart.pipelines.cart_lines', [])
+                )->thenReturn(function ($cartLine) {
+                    $cartLine->cacheProperties();
 
-                return $cartLine;
-            });
+                    return $cartLine;
+                });
 
             $purchasable = $cartLine->purchasable;
             $unitQuantity = $purchasable->getUnitQuantity();
@@ -37,6 +37,7 @@ class CalculateLines
             $cartLine->subTotal = new Price($subTotal, $cart->currency, $unitQuantity);
             $cartLine->taxAmount = new Price(0, $cart->currency, $unitQuantity);
             $cartLine->total = new Price($subTotal, $cart->currency, $unitQuantity);
+            $cartLine->subTotalDiscounted = new Price($subTotal, $cart->currency, $unitQuantity);
             $cartLine->discountTotal = new Price(0, $cart->currency, $unitQuantity);
         }
 


### PR DESCRIPTION
There's a few issues with discounts.

- If a purchasable item has been soft deleted or otherwise removed, `getEligibleLines` will error due to referencing `->id` on null, so now we reject any lines where the purchasable cannot be found.
- The `$line->subTotalDiscounted` was not being reset like `subTotal` on `CalculateLines` which was causing the amount to stack with repeated calls.
- The `discountTotal` being set when applying percentages was using the `subTotalDiscounted` as the base an adding the amount on top, which is wrong as this value is not the discount amount, it should add the `$amount` calculated to any existing `discountTotal` on the line.