### PR TITLE
Allow variant thumbnail to be eager loaded

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `fingerprint` method to the `Cart` model.
 - Added `checkFingerprint` method to the `Cart` model.
 
+### Changed
+
+- The `getThumbnail()` method on variants has been changed to allow for eager loading.
+
 ## 0.3.0
 
 > Latest updates from `0.2` have been brought in.

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -201,12 +201,8 @@ class ProductVariant extends BaseModel implements Purchasable
 
     public function getThumbnail()
     {
-        $thumbnail = $this->images()->wherePivot('primary', true)?->first();
-
-        if (! $thumbnail) {
-            return $this->product->thumbnail;
-        }
-
-        return $thumbnail;
+        return $this->images->first(function ($media) {
+            return (bool) $media->getCustomProperty('primary', false);
+        }) ?: $this->product->thumbnail;
     }
 }


### PR DESCRIPTION
Currently when calling `getThumbnail()` on a variant a query takes place against the variants images, this is okay if it's a one off but if you have a collection and need to get the thumbnail for each one, it results in a lot of queries.

This approach allows the images to be eager loaded by the developer to minimise the impact this has.