### PR TITLE
Improve wire:key on product associations

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### [Unreleased]
+
+### Changed
+
+- Improved `wire:key` on product associations when editing a product to avoid duplicate keys causing DOM diffing issues.
+
 ## 0.3.0
 
 > Latest updates from `0.2` have been brought in.
@@ -67,14 +73,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added missing notification translation.
 - Variant stock level will now be validated correctly to prevent DB exception on save.
 - Variant image uploading will now check for S3 usage when uploading, the same as product saving.
-- When reordering items, the `$index` now checks for an integer instead of purely existence to prevent failure when `$index` is `0`.
+- When reordering items, the `$index` now checks for an integer instead of purely existence to prevent failure
+  when `$index` is `0`.
 - Improved validation on translatable attributes to prevent exception when entering multiple languages.
 
 ## 0.2.6
 
 ### Fixed
 
-- When creating an option, `wire:model` should now correctly reference `newProductOption` when editing the name in a different locale.
+- When creating an option, `wire:model` should now correctly reference `newProductOption` when editing the name in a
+  different locale.
 
 ## 0.2.5
 
@@ -96,7 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.2.4
 
-### Changed
+### Changed
 
 - Alpinejs CDN now points to `jsdelivr` as per the recommendation.
 
@@ -147,13 +155,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [0.2] Hotfix - Upload Image by @Aslam97 in https://github.com/lunarphp/lunar/pull/810
 - Hotfix [0.2] - Fix duplicate language code on tests by @alecritson in https://github.com/lunarphp/lunar/pull/802
 - Hotfix [0.2] - UI Tweaks by @alecritson in https://github.com/lunarphp/lunar/pull/805
-- fix blade directive issue causing error on products index page in hub by @kylekanderson in https://github.com/lunarphp/lunar/pull/801
+- fix blade directive issue causing error on products index page in hub by @kylekanderson
+  in https://github.com/lunarphp/lunar/pull/801
 - [0.2] Hotfix - Fix save form layout and clean up by @alecritson in https://github.com/lunarphp/lunar/pull/795
 - fix images key by @wychoong in https://github.com/lunarphp/lunar/pull/789
 - Hotfix - Fix discount saving by @alecritson in https://github.com/lunarphp/lunar/pull/793
-- [0.2] Hotfix - Check for variants existence when saving images. by @alecritson in https://github.com/lunarphp/lunar/pull/778
+- [0.2] Hotfix - Check for variants existence when saving images. by @alecritson
+  in https://github.com/lunarphp/lunar/pull/778
 - [0.2] Hotfix - Fix product/collection syncing by @alecritson in https://github.com/lunarphp/lunar/pull/781
-- [0.2] Feat - Delay loading Collection products when large amounts by @alecritson in https://github.com/lunarphp/lunar/pull/770
+- [0.2] Feat - Delay loading Collection products when large amounts by @alecritson
+  in https://github.com/lunarphp/lunar/pull/770
 - [0.2] Feat - Add fallback to images by @charlielangridge in https://github.com/lunarphp/lunar/pull/682
 
 ### Changed
@@ -168,7 +179,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - [0.2] Preview/View URLs for Products by @alecritson in https://github.com/lunarphp/lunar/pull/772
 - [0.2] Image editor by @wychoong in https://github.com/lunarphp/lunar/pull/505
-- Feat [0.2] - Enable validation extending on product variant by @alecritson in https://github.com/lunarphp/lunar/pull/824
+- Feat [0.2] - Enable validation extending on product variant by @alecritson
+  in https://github.com/lunarphp/lunar/pull/824
 - Add products to discount limitations by @ryanmitchell in https://github.com/lunarphp/lunar/pull/813
 - [0.2] File upload field type by @alecritson in https://github.com/lunarphp/lunar/pull/452
 - [0.2] Manage customer groups by @adam-code-labx in https://github.com/lunarphp/lunar/pull/496

--- a/packages/admin/resources/views/partials/products/editing/associations.blade.php
+++ b/packages/admin/resources/views/partials/products/editing/associations.blade.php
@@ -1,102 +1,105 @@
 <div class="shadow sm:rounded-md">
-  <div class="flex-col px-4 py-5 space-y-4 bg-white rounded-md sm:p-6">
-    <header class="flex items-center justify-between">
-      <div class="flex">
-        <h3 class="mr-4 text-lg font-medium leading-6 text-gray-900">
-          {{ __('adminhub::partials.products.associations.heading') }}
-        </h3>
-        <div class="flex items-center space-x-2 text-xs">
+    <div class="flex-col px-4 py-5 space-y-4 bg-white rounded-md sm:p-6">
+        <header class="flex items-center justify-between">
+            <div class="flex">
+                <h3 class="mr-4 text-lg font-medium leading-6 text-gray-900">
+                    {{ __('adminhub::partials.products.associations.heading') }}
+                </h3>
+                <div class="flex items-center space-x-2 text-xs">
           <span class="@if($showInverseAssociations)text-green-500 @endif">
             {{ __('adminhub::partials.products.associations.show_inverse') }}
           </span>
-          <x-hub::input.toggle wire:model="showInverseAssociations" />
+                    <x-hub::input.toggle wire:model="showInverseAssociations"/>
+                </div>
+            </div>
+            <div class="flex items-center space-x-2">
+                <x-hub::dropdown>
+                    <x-slot name="value">
+                        {{ __(
+                            $showInverseAssociations ? 'adminhub::partials.products.associations.add_inverse'
+                            : 'adminhub::partials.products.associations.add_association')
+                        }}
+                    </x-slot>
+                    <x-slot name="options">
+                        <x-hub::dropdown.button wire:click.prevent="openAssociationBrowser('alternate')">
+                            {{ __('adminhub::partials.products.associations.alternate') }}
+                        </x-hub::dropdown.button>
+                        <x-hub::dropdown.button wire:click.prevent="openAssociationBrowser('cross-sell')">
+                            {{ __('adminhub::partials.products.associations.cross-sell') }}
+                        </x-hub::dropdown.button>
+                        <x-hub::dropdown.button wire:click.prevent="openAssociationBrowser('up-sell')">
+                            {{ __('adminhub::partials.products.associations.up-sell') }}
+                        </x-hub::dropdown.button>
+                    </x-slot>
+                </x-hub::dropdown>
+                @livewire('hub.components.product-search', [
+                'existing' => $this->associatedProductIds,
+                'ref' => 'product-associations',
+                'showBtn' => false,
+                'exclude' => [$product->id]
+                ])
+            </div>
+        </header>
+
+        <x-hub::errors :error="$errors->first('associations')"/>
+
+        <div>
+            <div class="lt-overflow-hidden lt-border lt-border-gray-200 lt-rounded-lg">
+                <table class="lt-min-w-full lt-divide-y lt-divide-gray-200">
+                    <thead class="lt-bg-white">
+                    <th></th>
+
+                    <th class="lt-px-4 lt-py-3 lt-text-sm lt-font-medium lt-text-left lt-text-gray-700">
+                        {{ __('adminhub::global.product') }}
+                    </th>
+
+                    <th class="lt-px-4 lt-py-3 lt-text-sm lt-font-medium lt-text-left lt-text-gray-700">
+                        {{ __('adminhub::global.type') }}
+                    </th>
+
+                    <th></th>
+                    </thead>
+
+                    <tbody>
+                    @foreach($associations->filter(fn($product) => $product['inverse'] == $showInverseAssociations) as $index => $product)
+                        <tr class="lt-bg-white even:lt-bg-gray-50"
+                            wire:key="table_row_{{ $showInverseAssociations ? '_inverse_' : '' }}{{ $product['target_id'] }}">
+                            <x-l-tables::cell>
+                                <x-hub::thumbnail src="{{ $product['thumbnail'] }}"/>
+                            </x-l-tables::cell>
+
+                            <x-l-tables::cell>
+                                <a href="{{ route('hub.products.show', $product['target_id']) }}"
+                                   class="lt-text-sky-500 hover:underline">
+                                    {{ $product['name'] }}
+                                </a>
+                            </x-l-tables::cell>
+
+                            <x-l-tables::cell>
+                                <x-hub::input.select wire:model="associations.{{ $index }}.type">
+                                    <option value="alternate">
+                                        {{ __('adminhub::partials.products.associations.alternate') }}
+                                    </option>
+                                    <option value="cross-sell">
+                                        {{ __('adminhub::partials.products.associations.cross-sell') }}
+                                    </option>
+                                    <option value="up-sell">
+                                        {{ __('adminhub::partials.products.associations.up-sell') }}
+                                    </option>
+                                </x-hub::input.select>
+                            </x-l-tables::cell>
+
+                            <x-l-tables::cell>
+                                <button type="button" wire:click.prevent="removeAssociation({{ $index }})"
+                                        class="text-red-500 hover:underline">
+                                    {{ __('adminhub::global.remove') }}
+                                </button>
+                            </x-l-tables::cell>
+                        </tr>
+                    @endforeach
+                    </tbody>
+                </table>
+            </div>
         </div>
-      </div>
-      <div class="flex items-center space-x-2">
-          <x-hub::dropdown>
-              <x-slot name="value">
-                {{ __(
-                    $showInverseAssociations ? 'adminhub::partials.products.associations.add_inverse'
-                    : 'adminhub::partials.products.associations.add_association')
-                }}
-              </x-slot>
-              <x-slot name="options">
-                <x-hub::dropdown.button wire:click.prevent="openAssociationBrowser('alternate')">
-                  {{ __('adminhub::partials.products.associations.alternate') }}
-                </x-hub::dropdown.button>
-                <x-hub::dropdown.button wire:click.prevent="openAssociationBrowser('cross-sell')">
-                  {{ __('adminhub::partials.products.associations.cross-sell') }}
-                </x-hub::dropdown.button>
-                <x-hub::dropdown.button wire:click.prevent="openAssociationBrowser('up-sell')">
-                  {{ __('adminhub::partials.products.associations.up-sell') }}
-                </x-hub::dropdown.button>
-              </x-slot>
-            </x-hub::dropdown>
-          @livewire('hub.components.product-search', [
-            'existing' => $this->associatedProductIds,
-            'ref' => 'product-associations',
-            'showBtn' => false,
-            'exclude' => [$product->id]
-          ])
-      </div>
-    </header>
-
-    <x-hub::errors :error="$errors->first('associations')"/>
-
-    <div>
-      <div class="lt-overflow-hidden lt-border lt-border-gray-200 lt-rounded-lg">
-        <table class="lt-min-w-full lt-divide-y lt-divide-gray-200">
-          <thead class="lt-bg-white">
-            <th></th>
-
-            <th class="lt-px-4 lt-py-3 lt-text-sm lt-font-medium lt-text-left lt-text-gray-700">
-              {{ __('adminhub::global.product') }}
-            </th>
-
-            <th class="lt-px-4 lt-py-3 lt-text-sm lt-font-medium lt-text-left lt-text-gray-700">
-              {{ __('adminhub::global.type') }}
-            </th>
-
-            <th></th>
-          </thead>
-
-          <tbody>
-            @foreach($associations->filter(fn($product) => $product['inverse'] == $showInverseAssociations) as $index => $product)
-              <tr class="lt-bg-white even:lt-bg-gray-50" wire:key="table_row_{{ $product['target_id'] }}">
-                <x-l-tables::cell>
-                    <x-hub::thumbnail src="{{ $product['thumbnail'] }}" />
-                </x-l-tables::cell>
-
-                <x-l-tables::cell>
-                  <a href="{{ route('hub.products.show', $product['target_id']) }}" class="lt-text-sky-500 hover:underline">
-                    {{ $product['name'] }}
-                  </a>
-                </x-l-tables::cell>
-
-                <x-l-tables::cell>
-                  <x-hub::input.select wire:model="associations.{{ $index }}.type">
-                    <option value="alternate">
-                      {{ __('adminhub::partials.products.associations.alternate') }}
-                    </option>
-                    <option value="cross-sell">
-                      {{ __('adminhub::partials.products.associations.cross-sell') }}
-                    </option>
-                    <option value="up-sell">
-                      {{ __('adminhub::partials.products.associations.up-sell') }}
-                    </option>
-                  </x-hub::input.select>
-                </x-l-tables::cell>
-
-                <x-l-tables::cell>
-                  <button type="button" wire:click.prevent="removeAssociation({{ $index }})" class="text-red-500 hover:underline">
-                    {{ __('adminhub::global.remove') }}
-                  </button>
-                </x-l-tables::cell>
-              </tr>
-            @endforeach
-          </tbody>
-        </table>
-      </div>
     </div>
-  </div>
 </div>


### PR DESCRIPTION
Closes #1077 

If you had a product which was both an association and an inverse association, the Livewire `wire:key` might mess up since two rows would share the same key with DOM Diffing happens.

It's a bit awkward to see with formatting changes but essentially, we attempt to make the key more unique depending on what you're looking at to try avoid this:

```html
<!-- old -->
wire:key="table_row_{{ $product['target_id'] }}"

<!-- new -->
wire:key="table_row_{{ $showInverseAssociations ? '_inverse_' : '' }}{{ $product['target_id'] }}"
```