### PR TITLE
Change requirements to support MySQL 8.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository serves as a monorepo for the main packages that make up Lunar.
 
 - PHP ^8.1
 - Laravel 9+
-- MySQL 5.7+ / PostgreSQL 9.2+
+- MySQL 8.0+ / PostgreSQL 9.2+
 
 ## Documentation
 

--- a/docs/core/installation.md
+++ b/docs/core/installation.md
@@ -4,7 +4,7 @@
 
 - PHP ^8.1
 - Laravel 9|10
-- MySQL 5.7+ / PostgreSQL 9.2+
+- MySQL 8.0+ / PostgreSQL 9.2+
 - exif PHP extension (on most systems it will be installed by default)
 - intl PHP extension (on most systems it will be installed by default)
 - bcmath PHP extension (on most systems it will be installed by default)

--- a/docs/core/starter-kits.md
+++ b/docs/core/starter-kits.md
@@ -13,7 +13,7 @@ If you would prefer to install Lunar into your own Laravel application, please f
 ## Requirements
 
 - PHP ^8.1
-- MySQL 5.7+ / PostgreSQL 9.2+
+- MySQL 8.0+ / PostgreSQL 9.2+
 - exif PHP extension (on most systems it will be installed by default)
 - GD PHP extension (used for image manipulation)
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -28,6 +28,10 @@ Lunar currently provides bug fixes and security updates for only the latest mino
 
 ### High Impact
 
+#### MySQL 8.x Requirement
+With MySQL 5.7 EOL coming in October 2023 and Lunar's heavy use of JSON fields, Lunar now only supports MySQL 8.x.
+You may find your project continues to work fine in MySQL 5.7, but we advise upgrading.
+
 #### Cart/Order Relationship
 
 The relationship between a cart and an order has been changed, previously the `carts` table had an `order_id` column,

--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dashboard stats are now responsible for their own date ranges where applicable.
 - The tags panel on the order detail screen has been moved below the address details.
 - Brands will now list alphabetically by default.
+- MySQL 5.7 is no longer supported, MySQL 8.0+ is required.
 
 ### Added
 

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -8,7 +8,7 @@ The admin hub is an open source app that allows you to manage all aspects of you
 ## Requirements
 - PHP ^8.1
 - Laravel 9+
-- MySQL 5.7+ / PostgreSQL 9.2+
+- MySQL 8.0+ / PostgreSQL 9.2+
 - Lunar Core
 
 ## Documentation

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The `CreateOrder` action will now ensure we are working with a draft order before proceeding.
 - The `CreateOrder` pipelines will now handle and update the order if it already exists.
 - PricingManager properties changed from `protected` to `public`
+- MySQL 5.7 is no longer supported, MySQL 8.0+ is required.
 
 ## 0.3.0
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,7 +11,7 @@ We put developers first and try to ensure your experience is as smooth as possib
 ## Requirements
 - PHP ^8.1
 - Laravel 9+
-- MySQL 5.7+ / PostgreSQL 9.2+
+- MySQL 8.0+ / PostgreSQL 9.2+
 - exif PHP extension (on most systems it will be installed by default)
 - GD PHP extension (used for image manipulation)
 


### PR DESCRIPTION
MySQL 5.7 is coming to EOL and its support for JSON fields is lacking. As Lunar makes heavy use of JSON fields, we want to ensure we can make the most of MySQL 8.0.