### PR TITLE
Add helper functions to Order model

### DIFF
--- a/docs/core/reference/orders.md
+++ b/docs/core/reference/orders.md
@@ -375,6 +375,16 @@ for you as laid out above.
 
 And as always, if you have any questions you can reach out on our Discord!
 
+## Order Status
+
+The `placed_at` field determines whether an Order is considered draft or placed. The Order model has two helper methods
+to determine the status of an Order.
+
+```php
+$order->isDraft();
+$order->isPlaced();
+```
+
 ## Order Notifications
 
 Lunar allows you to specify what Laravel mailers/notifications should be available for sending when you update an

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -534,7 +534,7 @@ class AdminHubServiceProvider extends ServiceProvider
      */
     protected function registerPermissionManifest()
     {
-        Gate::after(function (Staff $user, $ability) {
+        Gate::after(function ($user, $ability) {
             // Are we trying to authorize something within the hub?
             $permission = $this->app->get(Manifest::class)->getPermissions()->first(fn ($permission) => $permission->handle === $ability);
             if ($permission) {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -37,6 +37,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The `CreateOrder` pipelines will now handle and update the order if it already exists.
 - PricingManager properties changed from `protected` to `public`
 
+## 0.3.2
+
+### Changed
+
+- Removed `Staff` type declaration on permissions as this was causing issues with external packages with
+  authenticated users..
+
 ## 0.3.1
 
 ### Fixed

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added 'label' JSON field to `ProductOption` model.
 - Added pipelines to PricingManager.
 - Config to disable database migrations.
+- Added `isDraft()` and `isPlaced()` methods to Order model.
 
 ### Changed
 

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -351,8 +351,6 @@ class Order extends BaseModel
 
     /**
      * Determines if this is a draft order.
-     *
-     * @return bool
      */
     public function isDraft(): bool
     {
@@ -361,8 +359,6 @@ class Order extends BaseModel
 
     /**
      * Determines if this is a placed order.
-     *
-     * @return bool
      */
     public function isPlaced(): bool
     {

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -354,7 +354,7 @@ class Order extends BaseModel
      */
     public function isDraft(): bool
     {
-        return $this->placed_at ? false : true;
+        return !$this->isPlaced();
     }
 
     /**
@@ -362,6 +362,6 @@ class Order extends BaseModel
      */
     public function isPlaced(): bool
     {
-        return $this->placed_at ? true : false;
+        return !blank($this->placed_at);
     }
 }

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -360,7 +360,7 @@ class Order extends BaseModel
     }
 
     /**
-     * Determines if this is a draft order.
+     * Determines if this is a placed order.
      *
      * @return bool
      */

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -354,7 +354,7 @@ class Order extends BaseModel
      */
     public function isDraft(): bool
     {
-        return !$this->isPlaced();
+        return ! $this->isPlaced();
     }
 
     /**
@@ -362,6 +362,6 @@ class Order extends BaseModel
      */
     public function isPlaced(): bool
     {
-        return !blank($this->placed_at);
+        return ! blank($this->placed_at);
     }
 }

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -348,4 +348,24 @@ class Order extends BaseModel
 
         return $data;
     }
+
+    /**
+     * Determines if this is a draft order.
+     *
+     * @return bool
+     */
+    public function isDraft(): bool
+    {
+        return $this->placed_at ? false : true;
+    }
+
+    /**
+     * Determines if this is a draft order.
+     *
+     * @return bool
+     */
+    public function isPlaced(): bool
+    {
+        return $this->placed_at ? true : false;
+    }
 }

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -220,4 +220,22 @@ class OrderTest extends TestCase
         $this->assertEquals($customer->id, $order->customer->id);
         $this->assertEquals($user->getKey(), $order->user->getKey());
     }
+
+    /** @test */
+    public function can_check_order_is_placed()
+    {
+        Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        $order = Order::factory()->create([
+            'user_id' => null,
+        ]);
+
+        $this->assertTrue($order->isDraft());
+
+        $order->placed_at = now();
+
+        $this->assertTrue($order->isPlaced());
+    }
 }

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -241,8 +241,8 @@ class OrderTest extends TestCase
 
         $this->assertTrue($order->isPlaced());
     }
-  
-    /** @test */    
+
+    /** @test */
     public function can_cast_and_store_shipping_breakdown()
     {
         $order = Order::factory()->create();


### PR DESCRIPTION
An idea to help devs understand the "placed" status of an order. If we don't have a `placed_at` value, we consider the order draft.

- [x] Change log
- [x] Docs