### PR TITLE
Feature/exclude searchable attributes

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -46,7 +46,7 @@ export default defineConfig({
         ]
       },
       {
-        text: '0.3',
+        text: '0.4',
         items: [
           { text: 'Changelog', link: '/core/upgrading' },
           { text: 'Contributing', link: '/core/contributing' }

--- a/docs/core/reference/search.md
+++ b/docs/core/reference/search.md
@@ -38,6 +38,34 @@ php artisan lunar:search:index
 
 The command will import the records of the models listed in the `lunar/indexer.php` configuration file. Type `--help` to see the available options.
 
+## Exclude Attributes
+
+You can exclude any attribute on a Lunar model by adding the attribute to the respective model's array in the `config/search.php`
+
+```php
+'exclude_model_attributes' => [
+    'collection' => [],
+    'product' => [],
+    'product_option' => [],
+    'order' => [],
+    'customer' => [],
+    'brand' => [],
+],
+```
+
+Example: If you did not want to include the `id` and the `vat_no` on the Customer model, you would do this:
+
+```php
+'exclude_model_attributes' => [
+    ...
+    'customer' => ['id', 'vat_no'],
+    ...
+],
+```
+
+You will need to re-sync your indexes after any changes. You can refresh them by using `php artisan lunar:search:index --refresh`
+
+
 ## Engine Mapping
 
 By default, Scout will use the driver defined in your .env file as `SCOUT_DRIVER`. So if that's set to `meilisearch`, all your models will be indexed via the Meilisearch driver. This can present some issues, if you wanted to use a service like Algolia for Products, you wouldn't want all your Orders being indexed there since it will ramp up the record count and the cost.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.1
+
+### Added
+
+- Added `exclude_model_attributes` to `config/search.php` to exclude the model's searchable attributes.
+
+### Changed
+
+- Changed `getSearchableAttributes` from `protected` to `public` on `Lunar\Models\Order`
+- Changed each searchable model in `config/search.php` to exclude attributes based on the model in the config: `exclude_model_attributes`
+
 ## 0.4
 
 ### Fixed

--- a/packages/core/config/search.php
+++ b/packages/core/config/search.php
@@ -23,6 +23,22 @@ return [
     ],
     /*
     |--------------------------------------------------------------------------
+    | Attributes to exclude when indexing
+    |--------------------------------------------------------------------------
+    |
+    | Enter the attributes for each model you do not wish to not index.
+    |
+    */
+    'exclude_model_attributes' => [
+        'collection' => [],
+        'product' => [],
+        'product_option' => [],
+        'order' => [],
+        'customer' => [],
+        'brand' => [],
+    ],
+    /*
+    |--------------------------------------------------------------------------
     | Search engine mapping
     |--------------------------------------------------------------------------
     |

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Arr;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
@@ -72,10 +73,12 @@ class Brand extends BaseModel implements SpatieHasMedia
      */
     public function getSearchableAttributes()
     {
-        return [
+        $data = [
             'id' => $this->id,
             'name' => $this->name,
         ];
+
+        return Arr::except($data, config('lunar.search.exclude_model_attributes.brand', []));
     }
 
     /**

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -130,8 +130,9 @@ class Collection extends BaseModel implements SpatieHasMedia
     public function getSearchableAttributes()
     {
         $attributes = $this->getAttributes();
+        $keys = array_merge(['attribute_data'], config('lunar.search.exclude_model_attributes.collection', []));
 
-        $data = Arr::except($attributes, 'attribute_data');
+        $data = Arr::except($attributes, $keys);
 
         foreach ($this->attribute_data ?? [] as $field => $value) {
             if ($value instanceof TranslatedText) {

--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Arr;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasAttributes;
@@ -121,7 +122,7 @@ class Customer extends BaseModel
 
         $data['user_emails'] = $this->users->pluck('email')->toArray();
 
-        return $data;
+        return Arr::except($data, config('lunar.search.exclude_model_attributes.customer', []));
     }
 
     /**

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Arr;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\DiscountBreakdown;
 use Lunar\Base\Casts\Price;
@@ -298,7 +299,7 @@ class Order extends BaseModel
     /**
      * {@inheritDoc}
      */
-    protected function getSearchableAttributes()
+    public function getSearchableAttributes()
     {
         $data = [
             'id' => $this->id,
@@ -349,7 +350,7 @@ class Order extends BaseModel
 
         $data['tags'] = $this->tags->pluck('value')->toArray();
 
-        return $data;
+        return Arr::except($data, config('lunar.search.exclude_model_attributes.order', []));
     }
 
     /**

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -216,8 +216,9 @@ class Product extends BaseModel implements SpatieHasMedia
     public function getSearchableAttributes()
     {
         $attributes = $this->getAttributes();
+        $keys = array_merge(['attribute_data'], config('lunar.search.exclude_model_attributes.product', []));
 
-        $data = Arr::except($attributes, 'attribute_data');
+        $data = Arr::except($attributes, $keys);
 
         foreach ($this->attribute_data ?? [] as $field => $value) {
             if ($value instanceof TranslatedText) {

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -5,6 +5,7 @@ namespace Lunar\Models;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Arr;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
@@ -136,6 +137,6 @@ class ProductOption extends BaseModel implements SpatieHasMedia
             }
         }
 
-        return $data;
+        return Arr::except($data, config('lunar.search.exclude_model_attributes.product_option', []));
     }
 }

--- a/packages/core/tests/Unit/Base/RemoveSearchableAttributesTest.php
+++ b/packages/core/tests/Unit/Base/RemoveSearchableAttributesTest.php
@@ -20,7 +20,7 @@ use Lunar\Models\TaxRateAmount;
 use Lunar\Tests\TestCase;
 
 /**
- * @group shipping-manifest
+ * @group models.base
  */
 class RemoveSearchableAttributesTest extends TestCase
 {

--- a/packages/core/tests/Unit/Base/RemoveSearchableAttributesTest.php
+++ b/packages/core/tests/Unit/Base/RemoveSearchableAttributesTest.php
@@ -4,9 +4,6 @@ namespace Lunar\Tests\Unit\Base;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
-use Lunar\DataTypes\Price;
-use Lunar\DataTypes\ShippingOption;
-use Lunar\Facades\ShippingManifest;
 use Lunar\Models\Brand;
 use Lunar\Models\Collection;
 use Lunar\Models\Currency;
@@ -27,10 +24,15 @@ class RemoveSearchableAttributesTest extends TestCase
     use RefreshDatabase;
 
     private ?Collection $collection;
+
     private ?Product $product;
+
     private ?ProductOption $product_option;
+
     private ?Order $order;
+
     private ?Customer $customer;
+
     private ?Brand $brand;
 
     public function setUp(): void
@@ -48,7 +50,6 @@ class RemoveSearchableAttributesTest extends TestCase
         $this->customer = Customer::factory()->create();
 
         $this->brand = Brand::factory()->create();
-
 
         $taxClass = TaxClass::factory()->create([
             'name' => 'Foobar',
@@ -76,21 +77,21 @@ class RemoveSearchableAttributesTest extends TestCase
 
         $modelTypes = ['collection', 'product', 'product_option', 'order', 'customer', 'brand'];
 
-        foreach($modelTypes as $type) {
+        foreach ($modelTypes as $type) {
 
             $model = $this->$type;
 
-            $this->assertNotEmpty( $model );
+            $this->assertNotEmpty($model);
 
             //get first array key from searchable array
-            $key = key( $model->getSearchableAttributes() );
+            $key = key($model->getSearchableAttributes());
 
             //set that key to be excluded
             Config::set('lunar.search.exclude_model_attributes.'.$type, [$key]);
 
             $attributes = $model->getSearchableAttributes();
 
-            $this->assertFalse( isset($attributes[$key]) );
+            $this->assertFalse(isset($attributes[$key]));
         }
     }
 }

--- a/packages/core/tests/Unit/Base/RemoveSearchableAttributesTest.php
+++ b/packages/core/tests/Unit/Base/RemoveSearchableAttributesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Lunar\Tests\Unit\Base;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Lunar\DataTypes\Price;
+use Lunar\DataTypes\ShippingOption;
+use Lunar\Facades\ShippingManifest;
+use Lunar\Models\Brand;
+use Lunar\Models\Collection;
+use Lunar\Models\Currency;
+use Lunar\Models\Customer;
+use Lunar\Models\Order;
+use Lunar\Models\Product;
+use Lunar\Models\ProductOption;
+use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
+use Lunar\Models\TaxRateAmount;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group shipping-manifest
+ */
+class RemoveSearchableAttributesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ?Collection $collection;
+    private ?Product $product;
+    private ?ProductOption $product_option;
+    private ?Order $order;
+    private ?Customer $customer;
+    private ?Brand $brand;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Currency::factory()->create();
+
+        $this->collection = Collection::factory()->create();
+
+        $this->product_option = ProductOption::factory()->create();
+
+        $this->order = Order::factory()->create();
+
+        $this->customer = Customer::factory()->create();
+
+        $this->brand = Brand::factory()->create();
+
+
+        $taxClass = TaxClass::factory()->create([
+            'name' => 'Foobar',
+        ]);
+
+        $taxClass->taxRateAmounts()->create(
+            TaxRateAmount::factory()->make([
+                'percentage' => 20,
+                'tax_class_id' => $taxClass->id,
+            ])->toArray()
+        );
+
+        $purchasable = ProductVariant::factory()->create([
+            'tax_class_id' => $taxClass->id,
+            'unit_quantity' => 1,
+        ]);
+
+        $this->product = $purchasable->product;
+    }
+
+    /** @test */
+    public function can_exclude_searchable_attributes()
+    {
+        $this->assertNotEmpty(Config::get('lunar.search.exclude_model_attributes'));
+
+        $modelTypes = ['collection', 'product', 'product_option', 'order', 'customer', 'brand'];
+
+        foreach($modelTypes as $type) {
+
+            $model = $this->$type;
+
+            $this->assertNotEmpty( $model );
+
+            //get first array key from searchable array
+            $key = key( $model->getSearchableAttributes() );
+
+            //set that key to be excluded
+            Config::set('lunar.search.exclude_model_attributes.'.$type, [$key]);
+
+            $attributes = $model->getSearchableAttributes();
+
+            $this->assertFalse( isset($attributes[$key]) );
+        }
+    }
+}


### PR DESCRIPTION
Added a new configuration field in the search.php file to exclude searchable attributes.

This makes it easy to exclude information you do not want included when indexing them.

I have also included a test, and updated the docs.
