### PR TITLE
Fix link Unicode bug

### DIFF
--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -248,7 +248,7 @@ class InstallLunar extends Command
         $this->newLine();
 
         $this->line('Please show some love for Lunar by giving us a star on GitHub ⭐️');
-        $this->info('https://github.com/lunarphp/lunar️');
+        $this->info('https://github.com/lunarphp/lunar');
         $this->newLine(3);
     }
 


### PR DESCRIPTION
This commit fixes a Unicode issue in the GitHub repository URL displayed in the shell. The issue was causing a 404 error when accessing the URL due to an extra Unicode character at the end.