### PR TITLE
Fix: SystemTaxDriver only adds tax amounts for the applicable tax zones

### DIFF
--- a/packages/core/src/Drivers/SystemTaxDriver.php
+++ b/packages/core/src/Drivers/SystemTaxDriver.php
@@ -100,9 +100,7 @@ class SystemTaxDriver implements TaxDriver
         $taxClass = $this->purchasable->getTaxClass();
 
         $taxAmounts = Blink::once('tax_zone_rates_'.$taxZone->id.'_'.$taxClass->id, function () use ($taxClass, $taxZone) {
-            return $taxZone->taxAmounts->first(
-                fn ($amount) => $amount->tax_class_id == $taxClass->id
-            )->get();
+            return $taxZone->taxAmounts()->whereTaxClassId($taxClass->id)->get();
         });
 
         if (prices_inc_tax()) {

--- a/packages/core/tests/Feature/Drivers/SystemTaxDriverTest.php
+++ b/packages/core/tests/Feature/Drivers/SystemTaxDriverTest.php
@@ -2,14 +2,20 @@
 
 namespace Lunar\Tests\Feature\Drivers;
 
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
+use Lunar\Actions\Taxes\GetTaxZone;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Drivers\SystemTaxDriver;
 use Lunar\Models\Address;
 use Lunar\Models\CartLine;
 use Lunar\Models\Currency;
 use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
+use Lunar\Models\TaxRate;
+use Lunar\Models\TaxRateAmount;
+use Lunar\Models\TaxZone;
 use Lunar\Tests\TestCase;
 
 /**
@@ -138,5 +144,47 @@ class SystemTaxDriverTest extends TestCase
 
         $this->assertInstanceOf(TaxBreakdown::class, $breakdown);
         $this->assertEquals(166, $breakdown->amounts[0]->price->value);
+    }
+
+    /** @test */
+    public function can_get_breakdown_with_correct_tax_zone()
+    {
+        $address = Address::factory()->create();
+        $currency = Currency::factory()->create();
+
+        $defaultTaxZone = TaxZone::factory()->state(['default' => true])->create();
+        $nonDefaultTaxZone1 = TaxZone::factory()->state(['default' => false])->create();
+        $nonDefaultTaxZone2 = TaxZone::factory()->state(['default' => false])->create();
+
+        $taxClass = TaxClass::factory()->has(
+            TaxRateAmount::factory()
+                ->count(4)
+                ->state(new Sequence(
+                    ['percentage' => 10, 'tax_rate_id' => TaxRate::factory()->state(['tax_zone_id' => $defaultTaxZone])],
+                    ['percentage' => 15, 'tax_rate_id' => TaxRate::factory()->state(['tax_zone_id' => $defaultTaxZone])],
+                    ['percentage' => 20, 'tax_rate_id' => TaxRate::factory()->state(['tax_zone_id' => $nonDefaultTaxZone1])],
+                    ['percentage' => 25, 'tax_rate_id' => TaxRate::factory()->state(['tax_zone_id' => $nonDefaultTaxZone2])],
+                ))
+        )->create();
+
+        $variant = ProductVariant::factory(['tax_class_id' => $taxClass->id])->create();
+        $line = CartLine::factory(['purchasable_id' => $variant->id])->create();
+        $subTotal = 1000; // 10.00 in decimal
+
+        $breakdown = (new SystemTaxDriver)
+            ->setShippingAddress($address)
+            ->setBillingAddress($address)
+            ->setCurrency($currency)
+            ->setPurchasable($variant)
+            ->setCartLine($line)
+            ->getBreakdown($subTotal);
+
+        $this->assertInstanceOf(TaxBreakdown::class, $breakdown);
+
+        //Only the 2 tax rates from the default tax zone should have been applied
+        $this->assertEquals(2, $breakdown->amounts->count());
+
+        $this->assertEquals(100, $breakdown->amounts[0]->price->value);
+        $this->assertEquals(150, $breakdown->amounts[1]->price->value);
     }
 }

--- a/packages/core/tests/Feature/Drivers/SystemTaxDriverTest.php
+++ b/packages/core/tests/Feature/Drivers/SystemTaxDriverTest.php
@@ -5,7 +5,6 @@ namespace Lunar\Tests\Feature\Drivers;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
-use Lunar\Actions\Taxes\GetTaxZone;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Drivers\SystemTaxDriver;
 use Lunar\Models\Address;


### PR DESCRIPTION
When a `TaxClass` has multiple `TaxRateAmount`s (e.g. one for every country), the `SystemTaxDriver` incorrectly applies every one of them, regardless of whether the `TaxZone` of the `TaxRateAmount` is relevant for the shipping address.

I believe this is a regression introduced in commit 809feeb7515203ded956138bcbd4a287cf07dbb2 when some code was wrapped in a `Blink::once()`. However, at the same time, the code inside was altered slightly, which changed the logic.

Please refer to the test I added in this PR. The `TaxClass` has 4 `TaxRateAmount`s, 2 of which should be applied (the default ones), and 2 of which should not be applied.

Running this test on the current `SystemTaxDriver` will fail.

My proposal is to revert the logic in `SystemTaxDriver` to what it was before the mentioned commit, while still being wrapped in `Blink::once()`.
