### PR TITLE
Fix: cart total calculation when pricing.stored_inclusive_of_tax is set to true

### DIFF
--- a/packages/core/src/Pipelines/Cart/CalculateTax.php
+++ b/packages/core/src/Pipelines/Cart/CalculateTax.php
@@ -80,11 +80,15 @@ class CalculateTax
                 $shippingTax->amounts
             );
 
-            $cart->shippingTotal = new Price(
-                $shippingSubTotal + $shippingTaxTotal?->value,
-                $cart->currency,
-                1
-            );
+	        $shippingTotal = $shippingSubTotal;
+	        if(!prices_inc_tax()) {
+		        $shippingTotal += $shippingTaxTotal?->value;
+	        }
+	        $cart->shippingTotal = new Price(
+		        $shippingTotal,
+		        $cart->currency,
+		        1
+	        );
         }
 
         $cart->taxTotal = new Price($taxTotal, $cart->currency, 1);

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -775,7 +775,15 @@ class CartTest extends TestCase
 
         $this->assertEquals(100, $cart->subTotal->value);
         $this->assertEquals(500, $cart->shippingSubTotal->value);
+        $this->assertEquals(600, $cart->shippingTotal->value);
         $this->assertEquals(720, $cart->total->value);
+
+	    Config::set('lunar.pricing.stored_inclusive_of_tax', true);
+
+	    $cart->calculate();
+
+	    $this->assertEquals(500, $cart->shippingTotal->value);
+	    $this->assertEquals(600, $cart->total->value);
     }
 
     /** @test */


### PR DESCRIPTION
Resolves issue [1156](https://github.com/lunarphp/lunar/issues/1156).