### PR TITLE
scheduleCustomerGroup remove start date null to `now()`

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+- when `Product->scheduleCustomerGroup($customerGroups, $startDate = null)` when `$startDate` is `null` it will not set to `now()` and always available
+
 ## 0.4
 
 ### Fixed

--- a/packages/core/src/Base/Traits/CanScheduleAvailability.php
+++ b/packages/core/src/Base/Traits/CanScheduleAvailability.php
@@ -42,8 +42,6 @@ trait CanScheduleAvailability
             throw new SchedulingException($error);
         }
 
-        $starts = $starts ?: now();
-
         $relation->syncWithoutDetaching(
             $this->getScheduleMapping($models, array_merge([
                 'starts_at' => $starts,

--- a/packages/core/tests/Unit/Base/Traits/HasCustomerGroupsTest.php
+++ b/packages/core/tests/Unit/Base/Traits/HasCustomerGroupsTest.php
@@ -37,6 +37,28 @@ class HasCustomerGroupsTest extends TestCase
     }
 
     /** @test */
+    public function can_schedule_always_available()
+    {
+        $product = Product::factory()->create();
+
+        $customerGroup = CustomerGroup::factory()->create();
+
+        $product->scheduleCustomerGroup($customerGroup);
+
+        $this->assertDatabaseHas(
+            'lunar_customer_group_product',
+            [
+                'customer_group_id' => $customerGroup->id,
+                'enabled' => 1,
+                'visible' => 1,
+                'purchasable' => 1,
+                'starts_at' => null,
+                'ends_at' => null,
+            ],
+        );
+    }
+
+    /** @test */
     public function can_schedule_using_array_of_models()
     {
         $product = Product::factory()->create();

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -147,6 +147,28 @@ class ProductTest extends TestCase
     }
 
     /** @test */
+    public function customer_groups_can_be_scheduled_always_available()
+    {
+        $product = Product::factory()->create();
+
+        $customerGroup = CustomerGroup::factory()->create();
+
+        $product->scheduleCustomerGroup($customerGroup);
+
+        $this->assertDatabaseHas(
+            'lunar_customer_group_product',
+            [
+                'customer_group_id' => $customerGroup->id,
+                'enabled' => 1,
+                'purchasable' => 1,
+                'visible' => 1,
+                'starts_at' => null,
+                'ends_at' => null,
+            ],
+        );
+    }
+
+    /** @test */
     public function customer_groups_can_be_scheduled_with_start_and_end()
     {
         $product = Product::factory()->create();


### PR DESCRIPTION
currently when schedule product customer group if no start date passed, the code will set `$start = now()` this behaviour may not be desired and is not consistent with `scheduleChannel` which does not set to now when null

also when start date is null the hub will show as "always available"

- ~~Documentation updates~~
- [x] Automated tests
- [x] Changelog entries (core ~~and hub~~)
