### PR TITLE
Improve docs markdown syntax

### DIFF
--- a/docs/admin-hub/activity-log.md
+++ b/docs/admin-hub/activity-log.md
@@ -36,7 +36,7 @@ class ActivityLogRenderer extends AbstractRender
 
 Then in our view we have access to the `ActivityLog` model, so for example this one for displaying a payment against an order:
 
-```html
+```blade
 {{ __('adminhub::components.activity-log.orders.capture', [
     'amount' => price($log->getExtraProperty('amount'), $log->subject->currency)->formatted,
     'last_four' => $log->getExtraProperty('last_four'),

--- a/docs/admin-hub/extending.md
+++ b/docs/admin-hub/extending.md
@@ -146,13 +146,15 @@ Lunar comes with a collection of icons you can use in the Resources folder. If
 you wish to supply your own, simply use an SVG instead, e.g.
 
 ```php
-->icon('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#9A9AA9" fill="none" stroke-linecap="round" stroke-linejoin="round">
-  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-  <line x1="15" y1="5" x2="15" y2="7" />
-  <line x1="15" y1="11" x2="15" y2="13" />
-  <line x1="15" y1="17" x2="15" y2="19" />
-  <path d="M5 5h14a2 2 0 0 1 2 2v3a2 2 0 0 0 0 4v3a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-3a2 2 0 0 0 0 -4v-3a2 2 0 0 1 2 -2" />
-</svg>');
+->icon(<<<HTML
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#9A9AA9" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+        <line x1="15" y1="5" x2="15" y2="7" />
+        <line x1="15" y1="11" x2="15" y2="13" />
+        <line x1="15" y1="17" x2="15" y2="19" />
+        <path d="M5 5h14a2 2 0 0 1 2 2v3a2 2 0 0 0 0 4v3a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-3a2 2 0 0 0 0 -4v-3a2 2 0 0 1 2 -2" />
+    </svg>
+HTML);
 ```
 
 ## Slots

--- a/docs/admin-hub/field-types.md
+++ b/docs/admin-hub/field-types.md
@@ -111,14 +111,14 @@ When a staff member is editing something such as a product, we need to be able t
 
 In this view we have access to the `$field` variable, which contains everything we need for data binding.
 
-```php
+```blade
 {{ $field['signature'] }} // Contains the signature for wire:model
 {{ $field['data'] }} // The current data taken from the `attribute_data` column
 ```
 
 Using the above we might have a view that looks like this:
 
-```html
+```blade
 <input type="text" wire:model="{{ $field['signature'] }}" />
 ```
 

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -12,7 +12,6 @@ php artisan vendor:publish --tag=lunar
 
 `lunar/database.php`
 
-
 So that Lunar tables do not conflict with your existing application database tables, you can specify a prefix to use. If you change this after installation, you are on your own - happy renaming!
 
 ```php
@@ -26,14 +25,15 @@ So that Lunar tables do not conflict with your existing application database tab
  By default, the package uses the default database connection defined in Laravel. Here specify a custom database connection for Lunar.
 
 ```php
-    'connection' => 'some_custom_connection',
+'connection' => 'some_custom_connection',
 ```
 
 If you are using a custom database connection that is not the default connection in your Laravel configuration, you need to specify it in the .env file as well.
 
 ```
-    ACTIVITY_LOGGER_DB_CONNECTION=some_custom_connection
+ACTIVITY_LOGGER_DB_CONNECTION=some_custom_connection
 ```
+
 In our package, we utilize Spatie's [laravel-activitylog](https://spatie.be/docs/laravel-activitylog) for logging. The mentioned configuration allows the activity logger to use a different database connection instead of the default database connection.
 
 ### Orders
@@ -43,17 +43,17 @@ In our package, we utilize Spatie's [laravel-activitylog](https://spatie.be/docs
 Here you can set up the statuses you wish to use for your orders.
 
 ```php
-    'draft_status' => 'awaiting-payment',
-    'statuses' => [
-        'awaiting-payment' => [
-            'label' => 'Awaiting Payment',
-            'color' => '#848a8c',
-        ],
-        'payment-received' => [
-            'label' => 'Payment Received',
-            'color' => '#6a67ce',
-        ],
+'draft_status' => 'awaiting-payment',
+'statuses' => [
+    'awaiting-payment' => [
+        'label' => 'Awaiting Payment',
+        'color' => '#848a8c',
     ],
+    'payment-received' => [
+        'label' => 'Payment Received',
+        'color' => '#6a67ce',
+    ],
+],
 ```
 
 ### Media
@@ -110,7 +110,6 @@ Transformations for all uploaded images.
 
 If you want to store pricing inclusive of tax then set this config value to `true`.
 
+```php
+'stored_inclusive_of_tax' => false,
 ```
-    'stored_inclusive_of_tax' => false,
-```
-

--- a/docs/core/contributing.md
+++ b/docs/core/contributing.md
@@ -75,7 +75,7 @@ A PR should be able to include the following:
 
 ## Code Styles
 
-Lunar currently uses [Laravel Pint](https://laravel.com/docs/9.x/pint) for code styling. This is not automatically triggered, so you will need to run `vendor/bin/pint` on your branch.
+Lunar currently uses [Laravel Pint](https://laravel.com/docs/pint) for code styling. This is not automatically triggered, so you will need to run `vendor/bin/pint` on your branch.
 
 ## Asset compiling
 

--- a/docs/core/extending/models.md
+++ b/docs/core/extending/models.md
@@ -251,7 +251,7 @@ Order::resolveRelationUsing('ticket', function ($orderModel) {
 });
 ```
 
-See [https://laravel.com/docs/9.x/eloquent-relationships#dynamic-relationships](https://laravel.com/docs/9.x/eloquent-relationships#dynamic-relationships) for more information.
+See [https://laravel.com/docs/eloquent-relationships#dynamic-relationships](https://laravel.com/docs/eloquent-relationships#dynamic-relationships) for more information.
 
 
 ## Macroable

--- a/docs/core/extending/search.md
+++ b/docs/core/extending/search.md
@@ -20,7 +20,7 @@ Each of these can be extended using Model Observers in Laravel. The following mo
 
 ## Creating and using an Observer
 
-As mentioned, you simply need to add a [Model Observer](https://laravel.com/docs/9.x/eloquent#observers) for what you want to extend.
+As mentioned, you simply need to add a [Model Observer](https://laravel.com/docs/eloquent#observers) for what you want to extend.
 
 ```php
 <?php

--- a/docs/core/local-development.md
+++ b/docs/core/local-development.md
@@ -6,7 +6,7 @@ This guide is here to help you set-up Lunar locally so you can contribute to the
 
 ## Before your start
 
-You will need a Laravel application to run Lunar in. You can either use a fresh install of [Laravel](https://laravel.com/docs/9.x/installation) or the [Lunar Livewire Starter Kit](https://github.com/lunarphp/livewire-starter-kit).
+You will need a Laravel application to run Lunar in. You can either use a fresh install of [Laravel](https://laravel.com/docs/installation) or the [Lunar Livewire Starter Kit](https://github.com/lunarphp/livewire-starter-kit).
 
 ## Set-Up
 

--- a/docs/core/reference/addresses.md
+++ b/docs/core/reference/addresses.md
@@ -74,7 +74,7 @@ Lunar\Models\State
 
 ## Address Data
 
-Data for Countries and States is provided by https://github.com/dr5hn/countries-states-cities-database
+Data for Countries and States is provided by https://github.com/dr5hn/countries-states-cities-database.
 
 You can use the following command to import countries and states.
 

--- a/docs/core/reference/carts.md
+++ b/docs/core/reference/carts.md
@@ -124,22 +124,22 @@ foreach ($cart->discountBreakdown as $discountBreakdown) {
 }
 
 foreach ($cart->discountBreakdown as $discountBreakdown) {
-$discountBreakdown->discount_id
-foreach ($discountBreakdown->lines as $discountLine) {
-$discountLine->quantity
-$discountLine->line
-}
-$discountBreakdown->total->value
+    $discountBreakdown->discount_id
+    foreach ($discountBreakdown->lines as $discountLine) {
+        $discountLine->quantity
+        $discountLine->line
+    }
+    $discountBreakdown->total->value
 }
 
 foreach ($cart->lines as $cartLine) {
-$cartLine->unitPrice; // The monetary value for a single item.
-$cartLine->total; // The total price value for the cart
-$cartLine->subTotal; // The sub total, excluding tax
-$cartLine->subTotalDiscounted; // The sub total, minus the discount amount.
-$cartLine->taxAmount; // The monetary value for the amount of tax applied.
-$cartLine->taxBreakdown; // This is a collection of all taxes applied across all lines.
-$cartLine->discountTotal; // The monetary value for the discount total.
+    $cartLine->unitPrice; // The monetary value for a single item.
+    $cartLine->total; // The total price value for the cart
+    $cartLine->subTotal; // The sub total, excluding tax
+    $cartLine->subTotalDiscounted; // The sub total, minus the discount amount.
+    $cartLine->taxAmount; // The monetary value for the amount of tax applied.
+    $cartLine->taxBreakdown; // This is a collection of all taxes applied across all lines.
+    $cartLine->discountTotal; // The monetary value for the discount total.
 }
 
 ```
@@ -165,7 +165,6 @@ shipping address on the cart, which will then be used when we calculate which
 tax breakdowns should be applied.
 
 ```php
-
 $shippingAddress = [
     'country_id' => null,
     'title' => null,

--- a/docs/core/reference/orders.md
+++ b/docs/core/reference/orders.md
@@ -424,7 +424,7 @@ Since you may not always have additional content when sending out the mailer, yo
 
 Here's an example of what the template could look like:
 
-```html
+```blade
 <h1>It's on the way!</h1>
 
 <p>Your order with reference {{ $order->reference }} has been dispatched!</p>
@@ -432,12 +432,12 @@ Here's an example of what the template could look like:
 <p>{{ $order->total->formatted() }}</p>
 
 @if($content ?? null)
-<h2>Additional notes</h2>
-<p>{{ $content }}</p>
+    <h2>Additional notes</h2>
+    <p>{{ $content }}</p>
 @endif
 
 @foreach($order->lines as $line)
-<!--  -->
+    <!--  -->
 @endforeach
 ```
 

--- a/docs/core/reference/search.md
+++ b/docs/core/reference/search.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Search is configured using the [Laravel Scout](https://laravel.com/docs/9.x/scout) package.  Out the box we have configured the Lunar hub to use our own database Scout driver (see https://github.com/lunarphp/scout-database-engine).
+Search is configured using the [Laravel Scout](https://laravel.com/docs/scout) package.  Out the box we have configured the Lunar hub to use our own database Scout driver (see https://github.com/lunarphp/scout-database-engine).
 
 Using Scout allows us to provide search out the box but also make it easy for you as the developer to customise and tailor searching to your needs.
 

--- a/docs/core/securing-your-site.md
+++ b/docs/core/securing-your-site.md
@@ -12,9 +12,9 @@ If you find a security issue with Lunar, please reach out to us privately on Dis
 
 As a Laravel developer, we are sure you are well versed in their security practices and how to lock down your app. But, if you need a refresher here are some useful links:
 
-- [Deployment](https://laravel.com/docs/9.x/deployment)
-- [Encryption](https://laravel.com/docs/9.x/encryption)
-- [Hashing](https://laravel.com/docs/9.x/hashing)
+- [Deployment](https://laravel.com/docs/deployment)
+- [Encryption](https://laravel.com/docs/encryption)
+- [Hashing](https://laravel.com/docs/hashing)
 
 ## Securing search
 

--- a/docs/core/starter-kits.md
+++ b/docs/core/starter-kits.md
@@ -52,37 +52,37 @@ cp .env.example .env
 
 All the relevant configuration files should be present in the repo.
 
-### Migrate and seed.
+### Migrate and seed
 
 Run the migrations
 
-```
+```bash
 php artisan migrate
 ```
 
 Install Lunar
 
-```
+```bash
 php artisan lunar:install
 ```
 
 Seed the demo data.
 
-```
+```bash
 php artisan db:seed
 ```
 
 Link the storage directory
 
-```
+```bash
 php artisan storage:link
 ```
 
 ## Finished 🚀
 
-You are now installed! 
+You are now installed!
 
 - You can access the storefront at `http://<yoursite>`
 - You can access the admin hub at `http://<yoursite>/hub`
 
-You can review the source code at the GitHub Repository: [https://github.com/lunarphp/livewire-starter-kit](https://github.com/lunarphp/livewire-starter-kit)
+You can review the source code at the GitHub Repository: [https://github.com/lunarphp/livewire-starter-kit](https://github.com/lunarphp/livewire-starter-kit).

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,3 @@ features:
   - title: API - Coming Soon
     details: Connect to your store via a JSON:API, ideal for PWA storefronts and mobile apps.
 ---
-

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "vitepress": "^1.0.0-alpha.62"
+    "vitepress": "^1.0.0-beta.7"
   },
   "scripts": {
     "docs:dev": "vitepress dev",


### PR DESCRIPTION
- Replace Laravel target docs `9.x` with the latest version
- Match code language to highlight code
- Bump `vitepress` to `1.0.0-beta.7`