### PR TITLE
Laravel Pint Improvements

### DIFF
--- a/.github/workflows/laravel-pint-code-style.yml
+++ b/.github/workflows/laravel-pint-code-style.yml
@@ -4,13 +4,13 @@ on:
 jobs:
   Test:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-
-      - name: Install Dependencies
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress
-
-      - name: Check code style
-        run: ./vendor/bin/pint --test --preset laravel
+      - uses: actions/checkout@v1
+      - name: "laravel-pint"
+        uses: aglipanci/laravel-pint-action@2.0.0
+        with:
+          preset: laravel
+          verboseMode: true
+          testMode: true
+          pintVersion: 1.10.5
+          onlyDirty: true

--- a/docs/core/contributing.md
+++ b/docs/core/contributing.md
@@ -96,4 +96,3 @@ If you would like to contribute to the documentation you can do easily by follow
 7. Submit a pull request
 
 Lunar uses [VitePress](https://vitepress.dev/) for our documentation site which uses [Markdown](https://www.markdownguide.org/basic-syntax/) files to store the content. You'll find these Markdown files in the `/docs` directory.
-

--- a/packages/core/src/Actions/Carts/GetExistingCartLine.php
+++ b/packages/core/src/Actions/Carts/GetExistingCartLine.php
@@ -17,7 +17,7 @@ class GetExistingCartLine extends AbstractAction
         Cart $cart,
         Purchasable $purchasable,
         array $meta = []
-    ): CartLine|null {
+    ): ?CartLine {
         // Get all possible cart lines
         $lines = $cart->lines()
             ->wherePurchasableType(

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -556,7 +556,7 @@ class Cart extends BaseModel
     /**
      * Get the shipping option for the cart
      */
-    public function getShippingOption(): ShippingOption|null
+    public function getShippingOption(): ?ShippingOption
     {
         return ShippingManifest::getShippingOption($this);
     }


### PR DESCRIPTION
Laravel Pint was causing issues as when a new version was released our codebase suddenly didn't conform. This update locks the version of Pint and also only checks changed files.