### PR TITLE
Fix Postgres Compatibility

### DIFF
--- a/packages/core/database/state/PopulateProductOptionLabelWithName.php
+++ b/packages/core/database/state/PopulateProductOptionLabelWithName.php
@@ -37,6 +37,6 @@ class PopulateProductOptionLabelWithName
 
     protected function shouldRun()
     {
-        return ProductOption::where('label', '')->orWhereNull('label')->count() > 0;
+        return ProductOption::whereJsonLength('label', 0)->count() > 0;
     }
 }


### PR DESCRIPTION
Fix #1143 so that Lunar installs without errors when using PostgreSQL.

This has been manually tested in MySQL 8.0 and Postgres 15.