### PR TITLE
[Fix] Dashboard error when top selling product variant deleted

### DIFF
--- a/packages/admin/src/Http/Livewire/Dashboard.php
+++ b/packages/admin/src/Http/Livewire/Dashboard.php
@@ -152,6 +152,7 @@ class Dashboard extends Component
             now()->parse($this->from),
             now()->parse($this->to),
         ])->where('type', '!=', 'shipping')
+            ->whereHas('purchasable')
             ->groupBy('purchasable_type', 'purchasable_id')
             ->orderBy('count', 'desc')
             ->take(2)->get();


### PR DESCRIPTION
The issue:

When a product variant was deleted and it was in the top 2 selling products, the dashboard was broken.

The fix:

This fix adds a `whereHas` where it checks if the variant exists and only includes the products whose variant exists in the dashboard top selling items.

Fixes #1179 