### PR TITLE
Fix: Deleting a ProductVariant breaks the Hub Dashboard

### DIFF
--- a/packages/admin/resources/views/livewire/dashboard.blade.php
+++ b/packages/admin/resources/views/livewire/dashboard.blade.php
@@ -201,7 +201,7 @@
                     @foreach ($this->topSellingProducts as $product)
                         <div class="relative flex items-center py-8 space-x-3 bg-white border-b border-slate-100">
                             <div class="flex-shrink-0">
-                                @if ($thumbnail = $product->purchasable->getThumbnail())
+                                @if ($thumbnail = $product->purchasable?->getThumbnail())
                                     <x-hub::thumbnail :src="$thumbnail->getUrl('small')" />
                                 @else
                                     <x-hub::icon ref="photograph"
@@ -216,9 +216,9 @@
                                           aria-hidden="true"></span>
 
                                     <p class="text-sm font-medium text-gray-900">
-                                        {{ $product->purchasable->getDescription() }}
+                                        {{ $product->purchasable?->getDescription() ?? $product->description }}
                                         <span class="block text-sm">
-                                            {{ $product->purchasable->getIdentifier() }}
+                                            {{ $product->purchasable?->getIdentifier() ?? $product->identifier }}
                                         </span>
                                     </p>
 

--- a/packages/admin/src/Http/Livewire/Dashboard.php
+++ b/packages/admin/src/Http/Livewire/Dashboard.php
@@ -140,6 +140,8 @@ class Dashboard extends Component
         $orderTable = (new Order())->getTable();
 
         return OrderLine::with(['purchasable'])->select([
+            'description',
+            'identifier',
             'purchasable_type',
             'purchasable_id',
             DB::RAW('COUNT(*) as count'),
@@ -152,7 +154,7 @@ class Dashboard extends Component
             now()->parse($this->from),
             now()->parse($this->to),
         ])->where('type', '!=', 'shipping')
-            ->groupBy('purchasable_type', 'purchasable_id')
+            ->groupBy('purchasable_type', 'purchasable_id', 'description', 'identifier')
             ->orderBy('count', 'desc')
             ->take(2)->get();
     }


### PR DESCRIPTION
The issue:

When a product variant was deleted and it was in the top 2 selling products, the dashboard was broken.

The fix:

This fix updates the Top Selling Products section of the Hub Dashboard to fall back to the `description` and `identifier` properties of the `OrderLine` model when the `$product->purchasable` (the `ProductVariant`) model has been deleted.

Fixes https://github.com/lunarphp/lunar/issues/1179
