### PR TITLE
Remove sorting by default for admin measurements

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/HasDimensions.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasDimensions.php
@@ -85,7 +85,6 @@ trait HasDimensions
     protected function formatMeasurements($measurements)
     {
         return collect($measurements)
-            ->sortByDesc('unit')
             ->keys();
     }
 }


### PR DESCRIPTION
The unit is what the measurements are sorted by currently. By re-arranging the array keys in the shipping config file, it will automatically change the order in the admin area. By removing the sorting, you can easily re-arrange the array to the order of your choosing.