### PR TITLE
[Fix] Pricing not being deleted when variant is deleted

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -412,6 +412,7 @@ abstract class AbstractProduct extends Component
                 DB::transaction(function () use ($variantsToRemove) {
                     foreach ($variantsToRemove as $variant) {
                         $variant->values()->detach();
+                        $variant->prices()->delete();
                         $variant->forceDelete();
                     }
                 });
@@ -542,6 +543,7 @@ abstract class AbstractProduct extends Component
         }
         $variant = ProductVariant::find($variantId);
         $variant->values()->detach();
+        $variant->prices()->delete();
         $variant->delete();
         $this->product->refresh();
     }

--- a/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
@@ -340,6 +340,7 @@ class VariantShow extends Component
     {
         DB::transaction(function () {
             $this->variant->values()->detach();
+            $this->variant->prices()->delete();
             $this->variant->forceDelete();
         });
 


### PR DESCRIPTION
The issue:
The corresponding pricing rows in the `lunar_prices` table were not deleted when the variant was deleted either from the product show page by disabling variants or from the variant show page itself.

The fix:
This fix now deletes the record from the `lunar_prices` table for the deleted variant.

Closes #1190 