### PR TITLE
fix: set ListField data to `[]` rather than `null`

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -77,7 +77,6 @@ trait WithAttributes
                 $value = $value ?? [];
             }
 
-
             $reference = 'a_'.$attribute->id;
 
             return [

--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -3,6 +3,7 @@
 namespace Lunar\Hub\Http\Livewire\Traits;
 
 use Illuminate\Support\Collection;
+use Lunar\FieldTypes\ListField;
 use Lunar\FieldTypes\Number;
 use Lunar\FieldTypes\Text;
 use Lunar\FieldTypes\TranslatedText;
@@ -70,6 +71,12 @@ trait WithAttributes
             if ($attribute->type == TranslatedText::class) {
                 $value = $this->prepareTranslatedText($value);
             }
+
+            // No data (null) for ListField is an empty array
+            if ($attribute->type == ListField::class) {
+                $value = $value ?? [];
+            }
+
 
             $reference = 'a_'.$attribute->id;
 


### PR DESCRIPTION
**Issue:** When a store has attributes of type `ListField` attached to product types and you try adding a product via the hub, switching between product types breaks the UI of all attributes of `ListField` type.

I think the problem is caused by setting `$value` (see the changes) to `null`, `ListField` should be set to `[]` (an empty array).

[Here's a short video of the problem](https://github.com/lunarphp/lunar/assets/1038697/faba3098-fe04-4b04-9c74-f4e92022a5d9), and [this is after my fix](https://github.com/lunarphp/lunar/assets/1038697/ca189018-baf5-4d29-9bca-5a481b023ba4).