### PR TITLE
GetTaxZone: add the state logic to the Get Tax Zone class

### DIFF
--- a/packages/core/src/Actions/Taxes/GetTaxZone.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZone.php
@@ -16,6 +16,13 @@ class GetTaxZone
             }
         }
 
+        if ($address && $address->state) {
+            $stateZone = app(GetTaxZoneState::class)->execute($address->state);
+            if ($stateZone) {
+                return $stateZone->taxZone;
+            }
+        }
+
         return TaxZone::getDefault();
     }
 }

--- a/packages/core/src/Actions/Taxes/GetTaxZoneState.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZoneState.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lunar\Actions\Taxes;
+
+use Lunar\Models\TaxZoneState;
+
+class GetTaxZoneState
+{
+    /**
+     * Execute the action.
+     *
+     * @param  string  $state
+     * @return null|TaxZoneState
+     */
+    public function execute($state)
+    {
+        $stateZone = $this->getZoneMatches($state);
+
+        if ($stateZone instanceof TaxZoneState) {
+            return $stateZone;
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the zone or zones which match the given state name/code.
+     *
+     * @param  string  $state
+     * @return null|TaxZoneState
+     */
+    protected function getZoneMatches($state)
+    {
+        $state = (string) $state;
+
+        $stateZone = TaxZoneState::whereHas('state', function ($query) use ($state) {
+            return $query
+                ->where('name', $state)
+                ->orWhere('code', $state);
+        })->first();
+
+        if ($stateZone) {
+            return $stateZone;
+        }
+
+        return null;
+    }
+}

--- a/packages/core/tests/Unit/Actions/Taxes/GetTaxZoneStateTest.php
+++ b/packages/core/tests/Unit/Actions/Taxes/GetTaxZoneStateTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Lunar\Tests\Unit\Actions\Taxes;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Actions\Taxes\GetTaxZoneState;
+use Lunar\Models\State;
+use Lunar\Models\TaxZoneState;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group lunar.actions
+ */
+class GetTaxZoneStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_match_exact_state_name()
+    {
+        $california = State::factory()->create([
+            'code' => 'CA',
+            'name' => 'California',
+        ]);
+
+        $alabama = State::factory()->create([
+            'code' => 'AL',
+            'name' => 'Alabama',
+        ]);
+
+        TaxZoneState::factory()->create([
+            'state_id' => $california->id,
+        ]);
+
+        $al = TaxZoneState::factory()->create([
+           'state_id' => $alabama->id,
+        ]);
+
+        $zone = app(GetTaxZoneState::class)->execute('Alabama');
+
+        $this->assertEquals($al->id, $zone->id);
+    }
+
+    /** @test */
+    public function can_match_exact_state_code()
+    {
+        $california = State::factory()->create([
+            'code' => 'CA',
+            'name' => 'California',
+        ]);
+
+        $alabama = State::factory()->create([
+            'code' => 'AL',
+            'name' => 'Alabama',
+        ]);
+
+        TaxZoneState::factory()->create([
+            'state_id' => $california->id,
+        ]);
+
+        $al = TaxZoneState::factory()->create([
+           'state_id' => $alabama->id,
+        ]);
+
+        $zone = app(GetTaxZoneState::class)->execute('AL');
+
+        $this->assertNotNull($zone);
+
+        $this->assertEquals($al->id, $zone?->id);
+    }
+
+    /** @test */
+    public function can_mismatch_exact_state_name()
+    {
+        $california = State::factory()->create([
+            'code' => 'CA',
+            'name' => 'California',
+        ]);
+
+        $alabama = State::factory()->create([
+            'code' => 'AL',
+            'name' => 'Alabama',
+        ]);
+
+        TaxZoneState::factory()->create([
+            'state_id' => $california->id,
+        ]);
+
+        $al = TaxZoneState::factory()->create([
+           'state_id' => $alabama->id,
+        ]);
+
+        $zone = app(GetTaxZoneState::class)->execute('Alaba');
+
+        $this->assertNull($zone);
+
+        $this->assertNotEquals($al->id, $zone?->id);
+    }
+}


### PR DESCRIPTION
Hello 👋🏽 ! Thanks for the work already done, and here is my first contribution!

Context: I'm working on a project where I need to dynamically calculate taxes based on the state entered in the Shipping details form. So I've added the same logic used for the postal code related to the address typed in, and I've added tests to complete my code.

Let me know if there are any changes to be made! 