### PR TITLE
Fix price formatting for currencies with symbol to the right

### DIFF
--- a/packages/core/src/DataTypes/Price.php
+++ b/packages/core/src/DataTypes/Price.php
@@ -110,7 +110,9 @@ class Price
         $formattedPrice = $formatter->format($value);
 
         if ($trimTrailingZeros) {
-            $formattedPrice = preg_replace('/(\.\d{'.$this->currency->decimal_places.'}\d*?)0+$/', '$1', $formattedPrice);
+            $decimalSeparator = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+
+            $formattedPrice = preg_replace('/(\\'.$decimalSeparator.'\d{'.$this->currency->decimal_places.'}\d*?)0+(\s*\D*)$/', '$1$2', $formattedPrice);
         }
 
         return $formattedPrice;

--- a/packages/core/tests/Unit/DataTypes/PriceTest.php
+++ b/packages/core/tests/Unit/DataTypes/PriceTest.php
@@ -121,6 +121,23 @@ class PriceTest extends TestCase
     }
 
     /** @test */
+    function can_format_numbers_specifying_decimal_places_with_currency_suffix()
+    {
+        $currency = Currency::factory()->create([
+            'code' => 'SEK',
+            'decimal_places' => 2,
+        ]);
+
+        $dataType = new Price(15000, $currency, 1);
+        $this->assertEquals('150,00 kr', $dataType->formatted(locale: 'sv', decimalPlaces: 6, trimTrailingZeros: true));
+        $this->assertEquals('150,000000 kr', $dataType->formatted(locale: 'sv', decimalPlaces: 6, trimTrailingZeros: false));
+
+        $dataType = new Price(50050, $currency, 100);
+        $this->assertEquals('5,005 kr', $dataType->unitFormatted(locale: 'sv', decimalPlaces: 6, trimTrailingZeros: true));
+        $this->assertEquals('5,005000 kr', $dataType->unitFormatted(locale: 'sv', decimalPlaces: 6, trimTrailingZeros: false));
+    }
+
+    /** @test */
     public function can_handle_decimals_being_passed()
     {
         $currency = Currency::factory()->create([

--- a/packages/core/tests/Unit/DataTypes/PriceTest.php
+++ b/packages/core/tests/Unit/DataTypes/PriceTest.php
@@ -112,11 +112,11 @@ class PriceTest extends TestCase
         ]);
 
         $dataType = new Price(1500, $currency, 1);
-        $this->assertEquals('$15.00', $dataType->formatted(decimalPlaces: 6));
+        $this->assertEquals('$15.00', $dataType->formatted(decimalPlaces: 6, trimTrailingZeros: true));
         $this->assertEquals('$15.000000', $dataType->formatted(decimalPlaces: 6, trimTrailingZeros: false));
 
         $dataType = new Price(507, $currency, 100);
-        $this->assertEquals('$0.0507', $dataType->unitFormatted(decimalPlaces: 6));
+        $this->assertEquals('$0.0507', $dataType->unitFormatted(decimalPlaces: 6, trimTrailingZeros: true));
         $this->assertEquals('$0.050700', $dataType->unitFormatted(decimalPlaces: 6, trimTrailingZeros: false));
     }
 


### PR DESCRIPTION
`trimTrailingZeros` did not work for Swedish currency, because our symbol is shown to the right.

This PR adds a test and updates the regex to support other currencies (or at least SEK).

---

I feel like a regex could be a little flaky for this functionality? 

Also in Sweden, if there's no value after the decimals, we usually don't show them at all. So `150,00 kr` is shown as `150 kr`. Do you think that users should write custom logic for stuff like that, or should it be handled by Lunar?