### PR TITLE
Allow brand to be null on products if config allows

### DIFF
--- a/packages/admin/resources/lang/en/components.php
+++ b/packages/admin/resources/lang/en/components.php
@@ -172,7 +172,7 @@ return [
     'brands.index.create_brand' => 'Create Brand',
     'brands.index.table_row_action_text' => 'Edit Brand',
     'brands.index.table_count_header_text' => 'Products Count',
-    'brands.choose_brand_default_option' => 'Choose brand',
+    'brands.choose_brand_default_option' => 'Unbranded',
     /**
      * Product Index.
      */

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -367,6 +367,8 @@ abstract class AbstractProduct extends Component
             $data = $this->prepareAttributeData();
             $variantData = $this->prepareAttributeData($this->variantAttributes);
 
+            $this->product->brand_id = $this->product->brand_id ?: null;
+
             if ($this->brand) {
                 $brand = Brand::create([
                     'name' => $this->brand,


### PR DESCRIPTION
Closes #1196 and also updates the "Choose brand" to "Unbranded" since it's not always a requirement.