### PR TITLE
Feat - Price formatter classes

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,160 +1,164 @@
-import { defineConfig } from 'vitepress'
+import {defineConfig} from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "Lunar",
-  description: "Laravel Headless E-Commerce",
-  head: [
-    [
-      'link',
-      { rel: 'icon', href: '/icon.svg', type: 'image/svg' }
-    ],
-    [
-      'link',
-      { rel: 'preconnect', href: 'https://fonts.googleapis.com' }
-    ],
-    [
-      'link',
-      { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }
-    ],
-    [
-      'link',
-      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&display=swap' }
-    ]
-    // would render: <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  ],
-
-  appearance: 'dark',
-
-  themeConfig: {
-    // https://vitepress.dev/reference/default-theme-config
-    logo: {
-      light: '/icon.svg',
-      dark: '/icon-dark.svg',
-    },
-
-    nav: [
-      { text: 'Core', link: '/core/overview', activeMatch: '/core/' },
-      { text: 'Admin Hub', link: '/admin-hub/overview', activeMatch: '/admin-hub/'  },
-      {
-        text: 'Resources',
-        items: [
-          { text: 'Livewire Starter Kit', link: 'https://github.com/lunarphp/livewire-starter-kit' },
-          { text: 'Add-ons', link: 'https://github.com/lunarphp/awesome' },
-          { text: 'Discord', link: 'https://discord.gg/v6qVWaf' },
-          { text: 'Discussions', link: 'https://github.com/lunarphp/lunar/discussions' }
+    title: "Lunar",
+    description: "Laravel Headless E-Commerce",
+    head: [
+        [
+            'link',
+            {rel: 'icon', href: '/icon.svg', type: 'image/svg'}
+        ],
+        [
+            'link',
+            {rel: 'preconnect', href: 'https://fonts.googleapis.com'}
+        ],
+        [
+            'link',
+            {rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: ''}
+        ],
+        [
+            'link',
+            {
+                rel: 'stylesheet',
+                href: 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;900&display=swap'
+            }
         ]
-      },
-      {
-        text: '0.5',
-        items: [
-          { text: 'Changelog', link: '/core/upgrading' },
-          { text: 'Contributing', link: '/core/contributing' },
-          { text: 'Docs Next', link: 'https://docs-next.lunarphp.io/' }
-        ]
-      }
+        // would render: <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     ],
 
-    sidebar: {
-      // This sidebar gets displayed when a user
-      // is on `guide` directory.
-      '/core/': [
-        {
-          text: 'Getting Started',
-          collapsed: false,
-          items: [
-            { text: 'Overview', link: '/core/overview' },
-            { text: 'Installation', link: '/core/installation' },
-            { text: 'Starter Kits', link: '/core/starter-kits' },
-            { text: 'Configuration', link: '/core/configuration' },
-            { text: 'Initial Set-Up', link: '/core/set-up' },
-            { text: 'Upgrade Guide', link: '/core/upgrading' },
-            { text: 'Release Schedule', link: '/core/release-schedule' },
-            { text: 'Security', link: '/core/securing-your-site' },
-            { text: 'Contributing', link: '/core/contributing' }
-          ]
+    appearance: 'dark',
+
+    themeConfig: {
+        // https://vitepress.dev/reference/default-theme-config
+        logo: {
+            light: '/icon.svg',
+            dark: '/icon-dark.svg',
         },
-        {
-          text: 'Reference',
-          collapsed: false,
-          items: [
-            { text: 'Activity Log', link: '/core/reference/activity-log' },
-            { text: 'Addresses', link: '/core/reference/addresses' },
-            { text: 'Associations', link: '/core/reference/associations' },
-            { text: 'Attributes', link: '/core/reference/attributes' },
-            { text: 'Carts', link: '/core/reference/carts' },
-            { text: 'Channels', link: '/core/reference/channels' },
-            { text: 'Collections', link: '/core/reference/collections' },
-            { text: 'Currencies', link: '/core/reference/currencies' },
-            { text: 'Customers', link: '/core/reference/customers' },
-            { text: 'Discounts', link: '/core/reference/discounts' },
-            { text: 'Images', link: '/core/reference/images' },
-            { text: 'Languages', link: '/core/reference/languages' },
-            { text: 'Orders', link: '/core/reference/orders' },
-            { text: 'Payments', link: '/core/reference/payments' },
-            { text: 'Products', link: '/core/reference/products' },
-            { text: 'Search', link: '/core/reference/search' },
-            { text: 'Tags', link: '/core/reference/tags' },
-            { text: 'Taxation', link: '/core/reference/taxation' },
-            { text: 'URLs', link: '/core/reference/urls' }
-          ]
+
+        nav: [
+            {text: 'Core', link: '/core/overview', activeMatch: '/core/'},
+            {text: 'Admin Hub', link: '/admin-hub/overview', activeMatch: '/admin-hub/'},
+            {
+                text: 'Resources',
+                items: [
+                    {text: 'Livewire Starter Kit', link: 'https://github.com/lunarphp/livewire-starter-kit'},
+                    {text: 'Add-ons', link: 'https://github.com/lunarphp/awesome'},
+                    {text: 'Discord', link: 'https://discord.gg/v6qVWaf'},
+                    {text: 'Discussions', link: 'https://github.com/lunarphp/lunar/discussions'}
+                ]
+            },
+            {
+                text: '0.5',
+                items: [
+                    {text: 'Changelog', link: '/core/upgrading'},
+                    {text: 'Contributing', link: '/core/contributing'},
+                    {text: 'Docs Next', link: 'https://docs-next.lunarphp.io/'}
+                ]
+            }
+        ],
+
+        sidebar: {
+            // This sidebar gets displayed when a user
+            // is on `guide` directory.
+            '/core/': [
+                {
+                    text: 'Getting Started',
+                    collapsed: false,
+                    items: [
+                        {text: 'Overview', link: '/core/overview'},
+                        {text: 'Installation', link: '/core/installation'},
+                        {text: 'Starter Kits', link: '/core/starter-kits'},
+                        {text: 'Configuration', link: '/core/configuration'},
+                        {text: 'Initial Set-Up', link: '/core/set-up'},
+                        {text: 'Upgrade Guide', link: '/core/upgrading'},
+                        {text: 'Release Schedule', link: '/core/release-schedule'},
+                        {text: 'Security', link: '/core/securing-your-site'},
+                        {text: 'Contributing', link: '/core/contributing'}
+                    ]
+                },
+                {
+                    text: 'Reference',
+                    collapsed: false,
+                    items: [
+                        {text: 'Activity Log', link: '/core/reference/activity-log'},
+                        {text: 'Addresses', link: '/core/reference/addresses'},
+                        {text: 'Associations', link: '/core/reference/associations'},
+                        {text: 'Attributes', link: '/core/reference/attributes'},
+                        {text: 'Carts', link: '/core/reference/carts'},
+                        {text: 'Channels', link: '/core/reference/channels'},
+                        {text: 'Collections', link: '/core/reference/collections'},
+                        {text: 'Currencies', link: '/core/reference/currencies'},
+                        {text: 'Customers', link: '/core/reference/customers'},
+                        {text: 'Discounts', link: '/core/reference/discounts'},
+                        {text: 'Images', link: '/core/reference/images'},
+                        {text: 'Languages', link: '/core/reference/languages'},
+                        {text: 'Orders', link: '/core/reference/orders'},
+                        {text: 'Payments', link: '/core/reference/payments'},
+                        {text: 'Pricing', link: '/core/reference/pricing'},
+                        {text: 'Products', link: '/core/reference/products'},
+                        {text: 'Search', link: '/core/reference/search'},
+                        {text: 'Tags', link: '/core/reference/tags'},
+                        {text: 'Taxation', link: '/core/reference/taxation'},
+                        {text: 'URLs', link: '/core/reference/urls'}
+                    ]
+                },
+                {
+                    text: 'Storefront',
+                    collapsed: false,
+                    items: [
+                        {text: 'Storefront Session', link: '/core/storefront-utils/storefront-session'},
+                    ]
+                },
+                {
+                    text: 'Extending',
+                    collapsed: true,
+                    items: [
+                        {text: 'Carts', link: '/core/extending/carts'},
+                        {text: 'Discounts', link: '/core/extending/discounts'},
+                        {text: 'Models', link: '/core/extending/models'},
+                        {text: 'Orders', link: '/core/extending/orders'},
+                        {text: 'Payments', link: '/core/extending/payments'},
+                        {text: 'Search', link: '/core/extending/search'},
+                        {text: 'Shipping', link: '/core/extending/shipping'},
+                        {text: 'Taxation', link: '/core/extending/taxation'}
+                    ]
+                }
+            ],
+
+            // This sidebar gets displayed when a user
+            // is on `config` directory.
+            '/admin-hub/': [
+                {
+                    text: 'Developer Reference',
+                    items: [
+                        {text: 'Overview', link: '/admin-hub/overview'},
+                        {text: 'Extending', link: '/admin-hub/extending'},
+                        {text: 'Activity Log', link: '/admin-hub/activity-log'},
+                        {text: 'Assets', link: '/admin-hub/assets'},
+                        {text: 'Branding', link: '/admin-hub/branding'},
+                        {text: 'Discounts', link: '/admin-hub/discounts'},
+                        {text: 'Field Types', link: '/admin-hub/field-types'},
+                        {text: 'Preview URLs', link: '/admin-hub/preview'},
+                        {text: 'Staff', link: '/admin-hub/staff'},
+                        {text: 'Tables', link: '/admin-hub/tables'},
+                        {text: 'Validation', link: '/admin-hub/validation'}
+                    ]
+                }
+            ],
+
         },
-        {
-          text: 'Storefront',
-          collapsed: false,
-          items: [
-            { text: 'Storefront Session', link: '/core/storefront-utils/storefront-session' },
-          ]
+
+        socialLinks: [
+            {icon: 'github', link: 'https://github.com/lunarphp/lunar'},
+            {icon: 'twitter', link: 'https://twitter.com/lunarphp'},
+            {icon: 'discord', link: 'https://discord.gg/v6qVWaf'},
+        ],
+
+        algolia: {
+            appId: 'ZHX0K72823',
+            apiKey: '42f3d86ed75f289e5cb75e9d7c6f43f9',
+            indexName: 'lunarphp'
         },
-        {
-          text: 'Extending',
-          collapsed: true,
-          items: [
-            { text: 'Carts', link: '/core/extending/carts' },
-            { text: 'Discounts', link: '/core/extending/discounts' },
-            { text: 'Models', link: '/core/extending/models' },
-            { text: 'Orders', link: '/core/extending/orders' },
-            { text: 'Payments', link: '/core/extending/payments' },
-            { text: 'Search', link: '/core/extending/search' },
-            { text: 'Shipping', link: '/core/extending/shipping' },
-            { text: 'Taxation', link: '/core/extending/taxation' }
-          ]
-        }
-      ],
-
-      // This sidebar gets displayed when a user
-      // is on `config` directory.
-      '/admin-hub/': [
-        {
-          text: 'Developer Reference',
-          items: [
-            { text: 'Overview', link: '/admin-hub/overview' },
-            { text: 'Extending', link: '/admin-hub/extending' },
-            { text: 'Activity Log', link: '/admin-hub/activity-log' },
-            { text: 'Assets', link: '/admin-hub/assets' },
-            { text: 'Branding', link: '/admin-hub/branding' },
-            { text: 'Discounts', link: '/admin-hub/discounts' },
-            { text: 'Field Types', link: '/admin-hub/field-types' },
-            { text: 'Preview URLs', link: '/admin-hub/preview' },
-            { text: 'Staff', link: '/admin-hub/staff' },
-            { text: 'Tables', link: '/admin-hub/tables' },
-            { text: 'Validation', link: '/admin-hub/validation' }
-          ]
-        }
-      ],
-
-    },
-
-    socialLinks: [
-      { icon: 'github', link: 'https://github.com/lunarphp/lunar' },
-      { icon: 'twitter', link: 'https://twitter.com/lunarphp' },
-      { icon: 'discord', link: 'https://discord.gg/v6qVWaf' },
-    ],
-
-    algolia: {
-      appId: 'ZHX0K72823',
-      apiKey: '42f3d86ed75f289e5cb75e9d7c6f43f9',
-      indexName: 'lunarphp'
-    },
-  }
+    }
 })

--- a/docs/core/reference/pricing.md
+++ b/docs/core/reference/pricing.md
@@ -46,16 +46,6 @@ dealing with prices, other examples include:
 
 - `amount`
 
-```php
-$productVariant = \Lunar\Models\ProductVariant::first();
-
-// Lunar\Models\Price
-$priceModel = $productVariant->basePrices->first();
-
-// Lunar\DataTypes\Price
-$priceDataType = $priceModel->price;
-```
-
 ### `DefaultPriceFormatter`
 
 The default price formatter ships with Lunar and will handle most use cases for formatting a price, lets go through

--- a/docs/core/reference/pricing.md
+++ b/docs/core/reference/pricing.md
@@ -9,7 +9,7 @@ Every storefront is different. We understand as a developer you might want to do
 requirements, so we have made price formatting easy to swap out with your own implementation, but also we provide a
 suitable default that will suit most use cases.
 
-### Price formatting
+## Price formatting
 
 The class which handles price formatting is referenced in the `config/pricing.php` file:
 
@@ -21,7 +21,30 @@ return [
 ```
 
 When you retrieve a `Lunar\Models\Price` model, you will have access to the `->price` attribute which will return
-a `DataType` of `Price`, this is what we will use to get our formatted pricing.
+a `Lunar\DataTypes\Price` object. This is what we will use to get our formatted values.
+
+The `Lunar\DataTypes\Price` class is not limited to database columns and can be found throughout the Lunar core when
+dealing with prices, other examples include:
+
+### `Lunar\Models\Order`
+
+- `subTotal`
+- `total`
+- `taxTotal`
+- `discount_total`
+- `shipping_total`
+
+### `Lunar\Models\OrderLine`
+
+- `unit_price`
+- `sub_total`
+- `tax_total`
+- `discount_total`
+- `total`
+
+### `Lunar\Models\Transaction`
+
+- `amount`
 
 ```php
 $productVariant = \Lunar\Models\ProductVariant::first();
@@ -33,7 +56,7 @@ $priceModel = $productVariant->basePrices->first();
 $priceDataType = $priceModel->price;
 ```
 
-#### `DefaultPriceFormatter`
+### `DefaultPriceFormatter`
 
 The default price formatter ships with Lunar and will handle most use cases for formatting a price, lets go through
 them, first we'll create a standard price model.
@@ -108,7 +131,7 @@ $priceDataType->price->formatted('en-gb', \NumberFormatter::SPELLOUT) // ten poi
 $priceDataType->price->formattedUnit('en-gb') // £10.00
 ```
 
-### Full reference for `DefaultPriceFormatter`
+## Full reference for `DefaultPriceFormatter`
 
 ```php
 $priceDataType->decimal(
@@ -134,7 +157,7 @@ $priceDataType->unitFormatted(
 );
 ```
 
-### Creating a custom formatter
+## Creating a custom formatter
 
 Your formatter should implement the `PriceFormatterInterface` and have a constructor was accepts and sets
 the `$value`, `$currency` and `$unitQty` properties.
@@ -194,7 +217,7 @@ return [
 ];
 ```
 
-### Model Casting
+## Model Casting
 
 If you have your own models which you want to use price formatting for, Lunar has a cast class you can use. The only
 requirement is the column returns an `integer`.

--- a/docs/core/reference/pricing.md
+++ b/docs/core/reference/pricing.md
@@ -182,6 +182,9 @@ class CustomPriceFormatter implements PriceFormatterInterface
 }
 ```
 
+The methods you implement can accept any number of arguments you want to support, you are not bound to what
+the `DefaultPriceFormatter` accepts.
+
 Once you have implemented the required methods, simply swap it out in `config/lunar/pricing.php`:
 
 ```php

--- a/docs/core/reference/pricing.md
+++ b/docs/core/reference/pricing.md
@@ -1,0 +1,207 @@
+# Pricing
+
+## Overview
+
+When you display prices on your storefront, you want to be sure the customer is seeing the correct format relative to
+the currency they are purchasing in.
+
+Every storefront is different. We understand as a developer you might want to do this your own way or have very specific
+requirements, so we have made price formatting easy to swap out with your own implementation, but also we provide a
+suitable default that will suit most use cases.
+
+### Price formatting
+
+The class which handles price formatting is referenced in the `config/pricing.php` file:
+
+```php
+return [
+    // ...
+    'formatter' => \Lunar\Pricing\DefaultPriceFormatter::class,
+];
+```
+
+When you retrieve a `Lunar\Models\Price` model, you will have access to the `->price` attribute which will return
+a `DataType` of `Price`, this is what we will use to get our formatted pricing.
+
+```php
+$productVariant = \Lunar\Models\ProductVariant::first();
+
+// Lunar\Models\Price
+$priceModel = $productVariant->basePrices->first();
+
+// Lunar\DataTypes\Price
+$priceDataType = $priceModel->price;
+```
+
+#### `DefaultPriceFormatter`
+
+The default price formatter ships with Lunar and will handle most use cases for formatting a price, lets go through
+them, first we'll create a standard price model.
+
+```php
+$priceModel = \Lunar\Models\Price::create([
+    // ...
+    'price' => 1000, // Price is an int and should be in the lowest common denominator
+    'tier' => 1,
+]);
+
+// Lunar\DataTypes\Price
+$priceDataType = $priceModel->price;
+```
+
+Return the raw value, as it's stored in the database.
+
+```php
+echo $priceDataType->value; // 1000
+```
+
+Return the decimal representation for the price.The decimal value takes into account how many decimal places you have
+set for the currency. So in this example if the
+decimal places was 3 you would get 10.000
+
+```php
+echo $priceDataType->decimal(rounding: true); // 10.00
+echo $priceDataType->unitDecimal(rounding: true); // 10.00
+```
+
+You may have noticed these two values are the same, so what's happening? Well the unit decimal will take into account
+the unit quantity of the purchasable we have the price for. Let's show another example:
+
+```php
+$productVariant = \Lunar\Models\ProductVariant::create([
+    // ...
+    'unit_quantity' => 10,
+]);
+```
+
+By setting `unit_quantity` to 10 we're telling Lunar that 10 individual units make up this product at this price point,
+this is useful if you're selling something that by itself would be under 1 cent i.e. 0.001EUR, which isn't a valid
+price.
+
+```php
+$priceModel = $productVariant->prices()->create([
+    'price' => 10, // 0.10 EUR
+]);
+
+// Lunar\DataTypes\Price
+$priceDataType = $priceModel->price;
+```
+
+Now lets try again:
+
+```php
+echo $priceDataType->decimal(rounding: true); // 0.10
+echo $priceDataType->unitDecimal(rounding: true); // 0.01
+```
+
+You can see the `unitDecimal` method has taken into account that `10` units make up the price so this gives a unit cost
+of `0.01`.
+
+##### Formatting to a currency string
+
+The formatted price uses the native PHP [NumberFormatter](https://www.php.net/manual/en/class.numberformatter.php). If
+you wish to specify a locale or formatting style you can, see the examples below.
+
+```php
+$priceDataType->price->formatted('fr') // 10,00 £GB
+$priceDataType->price->formatted('en-gb', \NumberFormatter::SPELLOUT) // ten point zero zero.
+$priceDataType->price->formattedUnit('en-gb') // £10.00
+```
+
+### Full reference for `DefaultPriceFormatter`
+
+```php
+$priceDataType->decimal(
+    rounding: false
+);
+
+$priceDataType->decimalUnit(
+    rounding: false
+);
+
+$priceDataType->formatted(
+    locale: null, 
+    formatterStyle: NumberFormatter::CURRENCY,
+    decimalPlaces: null, 
+    trimTrailingZeros: true
+);
+
+$priceDataType->unitFormatted(
+    locale: null, 
+    formatterStyle: NumberFormatter::CURRENCY,
+    decimalPlaces: null, 
+    trimTrailingZeros: true
+);
+```
+
+### Creating a custom formatter
+
+Your formatter should implement the `PriceFormatterInterface` and have a constructor was accepts and sets
+the `$value`, `$currency` and `$unitQty` properties.
+
+```php
+<?php
+
+namespace Lunar\Pricing;
+
+use Illuminate\Support\Facades\App;
+use Lunar\Models\Currency;
+use NumberFormatter;
+
+class CustomPriceFormatter implements PriceFormatterInterface
+{
+    public function __construct(
+        public int $value,
+        public ?Currency $currency = null,
+        public int $unitQty = 1
+    ) {
+        if (! $this->currency) {
+            $this->currency = Currency::getDefault();
+        }
+    }
+
+    public function decimal(): float
+    {
+        // ...
+    }
+
+    public function unitDecimal(): float
+    {
+        // ...
+    }
+
+    public function formatted(): mixed
+    {
+        // ...
+    }
+
+    public function unitFormatted(): mixed
+    {
+        // ...
+    }
+}
+```
+
+Once you have implemented the required methods, simply swap it out in `config/lunar/pricing.php`:
+
+```php
+return [
+    // ...
+    'formatter' => \App\Pricing\CustomPriceFormatter::class,
+];
+```
+
+### Model Casting
+
+If you have your own models which you want to use price formatting for, Lunar has a cast class you can use. The only
+requirement is the column returns an `integer`.
+
+```php
+class MyModel extends Model
+{
+    protected $casts = [
+        //...
+        'price' => \Lunar\Base\Casts\Price::class
+    ];
+}
+```

--- a/docs/core/reference/products.md
+++ b/docs/core/reference/products.md
@@ -2,9 +2,12 @@
 
 ## Overview
 
-Products are generally what you will be selling in your store. You define all your attributes against the product and products can also have variations. In Lunar a product will always have at least one variation. From a UX point of view, it will just look like you're editing a single product, but behind the scenes you'll be editing one variant.
+Products are generally what you will be selling in your store. You define all your attributes against the product and
+products can also have variations. In Lunar a product will always have at least one variation. From a UX point of view,
+it will just look like you're editing a single product, but behind the scenes you'll be editing one variant.
 
-Products also belong to a `ProductType` and aside from the attributes, which you are free to define yourself, will have a base SKU and a brand name.
+Products also belong to a `ProductType` and aside from the attributes, which you are free to define yourself, will have
+a base SKU and a brand name.
 
 ## Creating a product
 
@@ -24,7 +27,8 @@ Lunar\Models\Product::create([
 
 ## Customer Groups
 
-You can assign customer groups to a product, this allows you to either always have that product enabled for the customer group, or you can state which dates they should be active for (as long as the customer group is enabled).
+You can assign customer groups to a product, this allows you to either always have that product enabled for the customer
+group, or you can state which dates they should be active for (as long as the customer group is enabled).
 
 ### Attaching customer groups
 
@@ -42,7 +46,8 @@ $product->schedule(CustomerGroup::get());
 
 ### Retrieving products for a customer group
 
-If you want to get all products related to a customer group, you can use the `customerGroup` scope. This scope can either take a single customer group (or customer group id) or a collection/array of ids/customer group models.
+If you want to get all products related to a customer group, you can use the `customerGroup` scope. This scope can
+either take a single customer group (or customer group id) or a collection/array of ids/customer group models.
 
 ```php
 // Can be an array of ids
@@ -68,21 +73,27 @@ Lunar\Models\ProductType::create([
 ]);
 ```
 
-Product Types also have [Attributes](/core/reference/attributes) associated to them. These associated attributes will determine what fields are available to products when editing. For example if you had an attribute of `Screen Type` associated to a `TVs` product type, any products with that product type would have access to that attribute when editing.
+Product Types also have [Attributes](/core/reference/attributes) associated to them. These associated attributes will
+determine what fields are available to products when editing. For example if you had an attribute of `Screen Type`
+associated to a `TVs` product type, any products with that product type would have access to that attribute when
+editing.
 
-You can associate attributes to a product type like so (it's just a straight forward [Polymorphic relationship](https://laravel.com/docs/8.x/eloquent-relationships#many-to-many-polymorphic-relations)).
+You can associate attributes to a product type like so (it's just a straight
+forward [Polymorphic relationship](https://laravel.com/docs/8.x/eloquent-relationships#many-to-many-polymorphic-relations)).
 
 ```php
 $productType->mappedAttributes()->associate([ /* attribute ids ... */ ]);
 ```
 
-You can associate both `Product` and `ProductVariant` attributes to a product type which will then display on either the product or product variant when editing.
+You can associate both `Product` and `ProductVariant` attributes to a product type which will then display on either the
+product or product variant when editing.
 
 ::: warning
 If you decide to delete an attribute, this will cause the association to be dropped and you could lose data.
 :::
 
 ### Retrieving the product type relationship
+
 If you have a product, you can fetch its product type like so:
 
 ```php
@@ -91,31 +102,40 @@ $product->productType;
 $product->load(['productType']);
 ```
 
-##  Product Identifiers
+## Product Identifiers
 
-You can choose to add product identifiers to each product variant. These are fields which, as the name suggests, allow you to identify a product and it's variants for use in your internal systems. You can choose whether these are required and unique in the hub whilst editing.
+You can choose to add product identifiers to each product variant. These are fields which, as the name suggests, allow
+you to identify a product and it's variants for use in your internal systems. You can choose whether these are required
+and unique in the hub whilst editing.
 
 ### Available fields
 
 **SKU**
 
-SKU stands for “stock keeping unit” and — as the name suggests — it is a number (usually eight alphanumeric digits) that you can assign to products to keep track of stock levels internally. If a product has different colors and sizes, each variation may use a unique SKU number.
+SKU stands for “stock keeping unit” and — as the name suggests — it is a number (usually eight alphanumeric digits) that
+you can assign to products to keep track of stock levels internally. If a product has different colors and sizes, each
+variation may use a unique SKU number.
 
 **GTIN**
 
-A Global Trade Item Number (GTIN) is a unique and internationally recognized identifier for a product. These usually accompany a barcode and are useful when using services such as Google to help them classify the product.
+A Global Trade Item Number (GTIN) is a unique and internationally recognized identifier for a product. These usually
+accompany a barcode and are useful when using services such as Google to help them classify the product.
 
 **MPN**
 
-MPN (Manufacturer Part Number) is the product identifier used to differentiate a product among other (similar) products from the same brand/manufacturer, making it easier for customers to find and buy your products and protecting them from counterfeit.
+MPN (Manufacturer Part Number) is the product identifier used to differentiate a product among other (similar) products
+from the same brand/manufacturer, making it easier for customers to find and buy your products and protecting them from
+counterfeit.
 
 **EAN**
 
-European Article numbering code (EAN) is a series of letters and numbers in a unique order that helps identify specific products within your own inventory.
+European Article numbering code (EAN) is a series of letters and numbers in a unique order that helps identify specific
+products within your own inventory.
 
 ### Validation
 
-Depending on your storefront needs, you might not need any of these fields to be required or unique. For this reason you can change this behaviour at a validation level.
+Depending on your storefront needs, you might not need any of these fields to be required or unique. For this reason you
+can change this behaviour at a validation level.
 
 `config/lunar-hub/products.php`
 
@@ -138,11 +158,14 @@ Depending on your storefront needs, you might not need any of these fields to be
     ],
 ```
 
-##  Product Options
+## Product Options
 
-These are what you use to define the different options a product has available to it. These are directly related to the different variants a product might have. Each `ProductOption` will have a set of `ProductOptionValue` models related to it. For example:
+These are what you use to define the different options a product has available to it. These are directly related to the
+different variants a product might have. Each `ProductOption` will have a set of `ProductOptionValue` models related to
+it. For example:
 
-You could have a `ProductOption` called "Colour" and then multiple `ProductionOptionValue` models for each colour you would like to offer.
+You could have a `ProductOption` called "Colour" and then multiple `ProductionOptionValue` models for each colour you
+would like to offer.
 
 ::: tip
 Product options and Product option values are defined at a system level and are translatable.
@@ -187,7 +210,8 @@ This Product option and it's values are now ready to be used to with Product Var
 
 # Product Shipping
 
-By default Lunar will mark all product variants as `shippable`. If you don't need to ship a certain variant then you can simply set this to false.
+By default Lunar will mark all product variants as `shippable`. If you don't need to ship a certain variant then you can
+simply set this to false.
 
 ```php
 $variant->update([
@@ -205,7 +229,8 @@ Product's can have different dimensions assigned to them, the values we have ava
 - Weight
 - Volume
 
-For handling conversions, we use the [Cartalyst Converter](https://github.com/cartalyst/converter/tree/master) package. This supports a wide range of UOM and can convert those values to different measurements.
+For handling conversions, we use the [Cartalyst Converter](https://github.com/cartalyst/converter/tree/master) package.
+This supports a wide range of UOM and can convert those values to different measurements.
 
 Each UOM has a corresponding `_value` and `_unit` column in the database. For example:
 
@@ -218,7 +243,8 @@ width_unit
 
 ### Configuring measurements
 
-You can configure the available UOM's in the `lunar/shipping.php` config file. Here is an example of what Lunar provides by default:
+You can configure the available UOM's in the `lunar/shipping.php` config file. Here is an example of what Lunar provides
+by default:
 
 **Length**
 
@@ -235,15 +261,16 @@ You can configure the available UOM's in the `lunar/shipping.php` config file. H
 - lbs
 
 **Volume**
+
 - l
 - ml
 - gal
 - floz
 
-
 ### Getting and converting measurement values
 
-You are free to access to the `*_value` and `*_unit` values for the variant and use them in their raw form, however we do offer an accessor for each unit that you can use:
+You are free to access to the `*_value` and `*_unit` values for the variant and use them in their raw form, however we
+do offer an accessor for each unit that you can use:
 
 ```php
 $variant->length->to('length.ft')->convert();
@@ -251,7 +278,8 @@ $variant->length->to('length.ft')->convert();
 
 #### Volume calculation
 
-Volume is calculated different to the rest of the measurements. You can either have it automatically figure out the volume or manually set it yourself:
+Volume is calculated different to the rest of the measurements. You can either have it automatically figure out the
+volume or manually set it yourself:
 
 ```php
 $variant->update([
@@ -290,15 +318,21 @@ $variant->length->format(); // 50cm
 
 ## Variants
 
-Variants allow you to specify different variations of a product. Think things like Small Blue T-shirt, or Size 8 and Size 9 Leather Boots. Your product is the main parent and your variants are based off that product to create multiple permutations.
+Variants allow you to specify different variations of a product. Think things like Small Blue T-shirt, or Size 8 and
+Size 9 Leather Boots. Your product is the main parent and your variants are based off that product to create multiple
+permutations.
 
-Variants are also responsible for storing data such as Pricing, Inventory/Stock information, Shipping information etc. For that reason a product will always have at least one variant.
+Variants are also responsible for storing data such as Pricing, Inventory/Stock information, Shipping information etc.
+For that reason a product will always have at least one variant.
 
-When you decide you want to offer more than one variant for a product, upon generation, Lunar will take the first variant and use that as a base for all other variants in terms of pricing, inventory etc. So you won't lose any data you may have already saved against the existing product.
+When you decide you want to offer more than one variant for a product, upon generation, Lunar will take the first
+variant and use that as a base for all other variants in terms of pricing, inventory etc. So you won't lose any data you
+may have already saved against the existing product.
 
 ## Creating variants
 
 ### New Product
+
 If you have a new product, you would create your variants in bulk based on an array of `ProductOptionValue` IDs.
 
 You will need to determine what variants you need to create and assign the correct option values to that variant.
@@ -311,6 +345,7 @@ If you do not have these entities created, you will need to do so before continu
 :::
 
 If needed, Create the product and tax class.
+
 ```php
 $product = Product::create([...]);
 $taxClass = TaxClass::create([...]);
@@ -318,6 +353,7 @@ $currency = Currency::create([...]);
 ```
 
 Otherwise, fetch them.
+
 ```php
 $product = Product::where(...)->first();
 $taxClass = TaxClass::where(...)->first();
@@ -374,6 +410,7 @@ $redVariant->values()->attach($redOption);
 ```
 
 Now, we need to create a price for our variant. This is where we use our *currency* created or fetched earlier.
+
 ```php
 $variant->prices()->create([
     'price' => 199,
@@ -382,10 +419,11 @@ $variant->prices()->create([
 ```
 
 ### Exceptions
+
 When creating variants there are some exceptions that will be thrown if certain conditions are met.
 
 | Exception                                        | Conditions                                                                             |
-| :----------------------------------------------- | :------------------------------------------------------------------------------------- |
+|:-------------------------------------------------|:---------------------------------------------------------------------------------------|
 | `Lunar\Exceptions\InvalidProductValuesException` | Thrown if you try and create a variant with less option values than what are required. |
 | `Illuminate\Validation\ValidationException`      | Thrown if validation fails on the value options array.                                 |
 
@@ -393,10 +431,12 @@ When creating variants there are some exceptions that will be thrown if certain 
 
 ### Overview
 
-Prices are stored in the database as integers. When retrieving a `Price` model the `price` and `compare_price` attributes are cast to a `Price` datatype. This casting gives you some useful helpers when dealing with prices on your front end.
+Prices are stored in the database as integers. When retrieving a `Price` model the `price` and `compare_price`
+attributes are cast to a `Price` datatype. This casting gives you some useful helpers when dealing with prices on your
+front end.
 
 | Field               | Description                                                                          | Default | Required |
-| :------------------ | :----------------------------------------------------------------------------------- | :------ | :------- |
+|:--------------------|:-------------------------------------------------------------------------------------|:--------|:---------|
 | `price`             | A integer value for the price                                                        | `null`  | yes      |
 | `compare_price`     | For display purposes, allows you to show a comparison price, e.g. RRP.               | `null`  | no       |
 | `currency_id`       | The ID of the related currency                                                       | `null`  | yes      |
@@ -417,50 +457,19 @@ $price = \Lunar\Models\Price::create([
 ]);
 ```
 
+## Price formatting
+
+For the full reference on how to format prices for your storefront see the [Pricing Reference](/core/reference/pricing)
+
 ::: tip
 The same methods apply to the compare_price attribute
 :::
 
-Return the value for the price column, as it is in the database
-```php
-$price->price->value // 199
-```
-
-The decimal value takes in to account how many decimal places you have set for the currency. So in this example if the decimal places was 3 you would get 0.199
-```php
-$price->price->decimal // 1.99
-```
-
-You can get the full formatted value for the price, this is based on the currency associated to that price.
-
-```php
-$price->price->formatted // £1.99
-```
-
-The formatted price uses the native PHP [NumberFormatter](https://www.php.net/manual/en/class.numberformatter.php). If you wish to specify a locale or formatting style you can, see the examples below.
-
-```php
-$price->price->formatted('fr') // 1,99 £GB
-$price->price->formatted('en-gb', \NumberFormatter::SPELLOUT) // one point nine nine.
-```
-
-If you are using unit quantities in your product pricing, then you may wish to also use the following methods.
-
-```php
-// will give the decimal price for a single unit
-$price->price->unitDecimal  
-
-// will give the decimal price for a single unit, without rounding
-$price->price->unitDecimal(false)  
-
-// will give the formatted price for a single unit
-$price->price->unitFormatted  
-```
-
 ### Base Pricing
 
-Pricing is defined on a variant level, meaning you will have a different price for each variant and also for each currency in the system. In order to add pricing to a variant, you can either create the model directly or use the relationship method.
-
+Pricing is defined on a variant level, meaning you will have a different price for each variant and also for each
+currency in the system. In order to add pricing to a variant, you can either create the model directly or use the
+relationship method.
 
 ```php
 \Lunar\Models\Price::create([
@@ -480,11 +489,14 @@ $variant->prices()->create([/* .. */]);
 
 ### Customer group pricing
 
-You can specify which customer group the price applies to by setting the `customer_group_id` column. If left as `null` the price will apply to all customer groups. This is useful if you want to have different pricing for certain customer groups and also different price tiers per customer group.
+You can specify which customer group the price applies to by setting the `customer_group_id` column. If left as `null`
+the price will apply to all customer groups. This is useful if you want to have different pricing for certain customer
+groups and also different price tiers per customer group.
 
 ### Tiered Pricing
 
-Tiered pricing is a concept in which when you buy in bulk, the cost per item will change (usually go down). With Pricing on Lunar, this is determined by the `tier` column when creating prices. For example:
+Tiered pricing is a concept in which when you buy in bulk, the cost per item will change (usually go down). With Pricing
+on Lunar, this is determined by the `tier` column when creating prices. For example:
 
 ```php
 Price::create([
@@ -502,11 +514,13 @@ Price::create([
 ]);
 ```
 
-In the above example if you order between 1 and 9 items you will pay `1.99` per item. But if you order at least 10 you will pay `1.50` per item.
+In the above example if you order between 1 and 9 items you will pay `1.99` per item. But if you order at least 10 you
+will pay `1.50` per item.
 
 ## Fetching the price
 
-Once you've got your pricing all set up, you're likely going to want to display it on your storefront. We've created a `PricingManager` which is available via a facade to make this process as painless as possible.
+Once you've got your pricing all set up, you're likely going to want to display it on your storefront. We've created
+a `PricingManager` which is available via a facade to make this process as painless as possible.
 
 To get the pricing for a product you can simple use the following helpers:
 
@@ -519,13 +533,15 @@ $pricing = \Lunar\Facades\Pricing::for($variant)->get();
 ```
 
 #### With Quantities
+
 ```php
 $pricing = \Lunar\Facades\Pricing::qty(5)->for($variant)->get();
 ```
 
 #### With Customer Groups
 
-If you don't pass in a customer group, Lunar will use the default, including any pricing that isn't specific to a customer group.
+If you don't pass in a customer group, Lunar will use the default, including any pricing that isn't specific to a
+customer group.
 
 ```php
 $pricing = \Lunar\Facades\Pricing::customerGroups($groups)->for($variant)->get();
@@ -535,6 +551,7 @@ $pricing = \Lunar\Facades\Pricing::customerGroup($group)->for($variant)->get();
 ```
 
 #### Specific to a user
+
 The PricingManager assumes you want the price for the current authenticated user.
 
 If you want to always return the guest price, you may use...
@@ -558,19 +575,23 @@ $pricing = \Lunar\Facades\Pricing::currency($currency)->for($variant)->get();
 ```
 
 #### For a model
-Assuming you have a model that implements the `hasPrices` trait, such as a `ProductVariant`, you can use the following to retrieve pricing.
+
+Assuming you have a model that implements the `hasPrices` trait, such as a `ProductVariant`, you can use the following
+to retrieve pricing.
 
 ```php
 $pricing = $variant->pricing()->qty(5)->get();
 ```
 
 ::: danger Be aware
-If you try and fetch a price for a currency that doesn't exist, a ` Lunar\Exceptions\MissingCurrencyPriceException` exception will be thrown.
+If you try and fetch a price for a currency that doesn't exist, a ` Lunar\Exceptions\MissingCurrencyPriceException`
+exception will be thrown.
 :::
 
 ---
 
-This will return a `PricingResponse` object which you can interact with to display the correct prices. Unless it's a collection, each property will return a `Lunar\Models\Price` object.
+This will return a `PricingResponse` object which you can interact with to display the correct prices. Unless it's a
+collection, each property will return a `Lunar\Models\Price` object.
 
 ```php
 /**
@@ -594,7 +615,8 @@ $pricing->tiers;
 $pricing->customerGroupPrices;
 ```
 
-Sometimes you might want to simply get all prices a product has from the variants, instead of loading up all a products variants fetching the prices that way, you can use the `prices` relationship on the product.
+Sometimes you might want to simply get all prices a product has from the variants, instead of loading up all a products
+variants fetching the prices that way, you can use the `prices` relationship on the product.
 
 ```php
 $product->prices
@@ -604,13 +626,16 @@ This will return a collection of `Price` models.
 
 ### Storing Prices Inclusive of Tax
 
-Lunar allows you to store pricing inclusive of tax if you need to. This is helpful if you need to show charm pricing, at $9.99 for example, which may not be possible if pricing is stored exclusive of tax due to rounding.
+Lunar allows you to store pricing inclusive of tax if you need to. This is helpful if you need to show charm pricing, at
+$9.99 for example, which may not be possible if pricing is stored exclusive of tax due to rounding.
 
-To start you will need to set the `stored_inclusive_of_tax` config value in `lunar/pricing` to `true`. Then you will need to ensure your default Tax Zone is set up correctly with the correct tax rates.
+To start you will need to set the `stored_inclusive_of_tax` config value in `lunar/pricing` to `true`. Then you will
+need to ensure your default Tax Zone is set up correctly with the correct tax rates.
 
 Once set, the cart will automatically calculate the tax for you.
 
-If you need to show both ex. and inc. tax pricing on your product pages, you can use the following methods which are available on the `Lunar\Models\Price` model.
+If you need to show both ex. and inc. tax pricing on your product pages, you can use the following methods which are
+available on the `Lunar\Models\Price` model.
 
 ```php
 $price->priceIncTax();
@@ -685,7 +710,8 @@ $productType = Lunar\Models\ProductType::create([
 ```
 
 ::: tip Note
-This example assumes we already have Attributes set up for name and description and that they're assigned to the product type.
+This example assumes we already have Attributes set up for name and description and that they're assigned to the product
+type.
 :::
 
 ### Create the initial product
@@ -730,6 +756,7 @@ $size = Lunar\Models\ProductOption::create([
 ```
 
 ### Product Option Values
+
 From here we now need to create our option values like so:
 
 ```php
@@ -773,7 +800,8 @@ $size->values()->createMany([
 
 ### Generate the variants
 
-First we just need to grab the values we want to use to generate the variants. Since we're generating them for everything, we just grab all of them.
+First we just need to grab the values we want to use to generate the variants. Since we're generating them for
+everything, we just grab all of them.
 
 ```php
 $optionValueIds = $size->values->merge($colour->values)->pluck('id');
@@ -782,13 +810,14 @@ $optionValueIds = $size->values->merge($colour->values)->pluck('id');
 ```
 
 ::: tip
-When generating variants, the sku will be derived from the Product's base SKU, in this case `DRBOOT` and will be suffixed with `-{count}`.
+When generating variants, the sku will be derived from the Product's base SKU, in this case `DRBOOT` and will be
+suffixed with `-{count}`.
 :::
 
 The resulting generation is as follows:
 
 | SKU      | Colour    | Size |
-| :------- | :-------- | :--- |
+|:---------|:----------|:-----|
 | DRBOOT-1 | Black     | 3    |
 | DRBOOT-2 | Black     | 6    |
 | DRBOOT-3 | White     | 3    |

--- a/packages/core/config/pricing.php
+++ b/packages/core/config/pricing.php
@@ -11,6 +11,8 @@ return [
     */
     'stored_inclusive_of_tax' => false,
 
+    'formatter' => \Lunar\Pricing\DefaultPriceFormatter::class,
+
     /*
     |--------------------------------------------------------------------------
     | Pricing Pipelines

--- a/packages/core/config/pricing.php
+++ b/packages/core/config/pricing.php
@@ -11,6 +11,14 @@ return [
     */
     'stored_inclusive_of_tax' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Price formatter
+    |--------------------------------------------------------------------------
+    |
+    | Specify which class to use when formatting price data types
+    |
+    */
     'formatter' => \Lunar\Pricing\DefaultPriceFormatter::class,
 
     /*

--- a/packages/core/src/DataTypes/Price.php
+++ b/packages/core/src/DataTypes/Price.php
@@ -5,7 +5,6 @@ namespace Lunar\DataTypes;
 use Lunar\Exceptions\InvalidDataTypeValueException;
 use Lunar\Models\Currency;
 use Lunar\Pricing\DefaultPriceFormatter;
-use NumberFormatter;
 
 class Price
 {
@@ -24,9 +23,6 @@ class Price
                 'Value was "'.(gettype($value)).'" expected "int"'
             );
         }
-        $this->value = $value;
-        $this->currency = $currency;
-        $this->unitQty = $unitQty;
     }
 
     /**
@@ -66,22 +62,18 @@ class Price
 
     /**
      * Get the decimal value.
-     *
-     * @return float
      */
-    public function decimal($rounding = true)
+    public function decimal(...$arguments): float
     {
-        return $this->formatter()->decimal($rounding);
+        return $this->formatter()->decimal(...$arguments);
     }
 
     /**
      * Get the decimal unit value.
-     *
-     * @return float
      */
-    public function unitDecimal($rounding = true)
+    public function unitDecimal(...$arguments): float
     {
-        return $this->formatter()->unitDecimal($rounding);
+        return $this->formatter()->unitDecimal(...$arguments);
     }
 
     /**
@@ -89,14 +81,9 @@ class Price
      *
      * @return string
      */
-    public function formatted($locale = null, $formatterStyle = NumberFormatter::CURRENCY, $decimalPlaces = null, $trimTrailingZeros = true)
+    public function formatted(...$arguments): mixed
     {
-        return $this->formatter()->formatted(
-            locale: $locale,
-            formatterStyle: $formatterStyle,
-            decimalPlaces: $decimalPlaces,
-            trimTrailingZeros: $trimTrailingZeros,
-        );
+        return $this->formatter()->formatted(...$arguments);
     }
 
     /**
@@ -104,24 +91,13 @@ class Price
      *
      * @return string
      */
-    public function unitFormatted($locale = null, $formatterStyle = NumberFormatter::CURRENCY, $decimalPlaces = null, $trimTrailingZeros = true)
+    public function unitFormatted(...$arguments): mixed
     {
-        return $this->formatter()->unitFormatted(
-            locale: $locale,
-            formatterStyle: $formatterStyle,
-            decimalPlaces: $decimalPlaces,
-            trimTrailingZeros: $trimTrailingZeros
-        );
+        return $this->formatter()->unitFormatted(...$arguments);
     }
 
-    protected function formatValue($value, $locale = null, $formatterStyle = NumberFormatter::CURRENCY, $decimalPlaces = null, $trimTrailingZeros = true)
+    protected function formatValue(int|float $value, ...$arguments): mixed
     {
-        return $this->formatter()->formatValue(
-            value: $value,
-            locale: $locale,
-            formatterStyle: $formatterStyle,
-            decimalPlaces: $decimalPlaces,
-            trimLeadingZeros: $trimTrailingZeros
-        );
+        return $this->formatter()->formatValue($value, ...$arguments);
     }
 }

--- a/packages/core/src/Pricing/DefaultPriceFormatter.php
+++ b/packages/core/src/Pricing/DefaultPriceFormatter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Lunar\Pricing;
+
+use Illuminate\Support\Facades\App;
+use Lunar\Models\Currency;
+use NumberFormatter;
+
+class DefaultPriceFormatter implements PriceFormatterInterface
+{
+    public function __construct(
+        public int $value,
+        public ?Currency $currency = null,
+        public int $unitQty = 1
+    ) {
+        if (! $this->currency) {
+            $this->currency = Currency::getDefault();
+        }
+    }
+
+    public function decimal(bool $rounding = true): float
+    {
+        $convertedValue = $this->value / $this->currency->factor;
+
+        return $rounding ? round($convertedValue, $this->currency->decimal_places) : $convertedValue;
+    }
+
+    public function unitDecimal(bool $rounding = true): float
+    {
+        $convertedValue = $this->value / $this->currency->factor / $this->unitQty;
+
+        return $rounding ? round($convertedValue, $this->currency->decimal_places) : $convertedValue;
+    }
+
+    public function formatted(string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    {
+        return $this->formatValue($this->decimal(false), $locale, $formatterStyle, $decimalPlaces, $trimTrailingZeros);
+    }
+
+    public function unitFormatted(string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    {
+        return $this->formatValue($this->unitDecimal(false), $locale, $formatterStyle, $decimalPlaces, $trimTrailingZeros);
+    }
+
+    public function formatValue(int|float $value, string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    {
+        if (! $locale) {
+            $locale = App::currentLocale();
+        }
+
+        $formatter = new NumberFormatter($locale, $formatterStyle);
+
+        $formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $this->currency->code);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $decimalPlaces ?? $this->currency->decimal_places);
+
+        $formattedPrice = $formatter->format($value);
+
+        if ($trimTrailingZeros) {
+            $formattedPrice = preg_replace('/(\.\d{'.$this->currency->decimal_places.'}\d*?)0+$/', '$1', $formattedPrice);
+        }
+
+        return $formattedPrice;
+    }
+}

--- a/packages/core/src/Pricing/DefaultPriceFormatter.php
+++ b/packages/core/src/Pricing/DefaultPriceFormatter.php
@@ -42,7 +42,7 @@ class DefaultPriceFormatter implements PriceFormatterInterface
         return $this->formatValue($this->unitDecimal(false), $locale, $formatterStyle, $decimalPlaces, $trimTrailingZeros);
     }
 
-    public function formatValue(int|float $value, string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    protected function formatValue(int|float $value, string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
     {
         if (! $locale) {
             $locale = App::currentLocale();

--- a/packages/core/src/Pricing/PriceFormatterInterface.php
+++ b/packages/core/src/Pricing/PriceFormatterInterface.php
@@ -2,17 +2,13 @@
 
 namespace Lunar\Pricing;
 
-use NumberFormatter;
-
 interface PriceFormatterInterface
 {
-    public function decimal(bool $rounding = true): float;
+    public function decimal(): float;
 
-    public function unitDecimal(bool $rounding = true): float;
+    public function unitDecimal(): float;
 
-    public function formatted(string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed;
+    public function formatted(): mixed;
 
-    public function unitFormatted(string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed;
-
-    public function formatValue(int|float $value, string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed;
+    public function unitFormatted(): mixed;
 }

--- a/packages/core/src/Pricing/PriceFormatterInterface.php
+++ b/packages/core/src/Pricing/PriceFormatterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lunar\Pricing;
+
+use NumberFormatter;
+
+interface PriceFormatterInterface
+{
+    public function decimal(bool $rounding = true): float;
+
+    public function unitDecimal(bool $rounding = true): float;
+
+    public function formatted(string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed;
+
+    public function unitFormatted(string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed;
+
+    public function formatValue(int|float $value, string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed;
+}


### PR DESCRIPTION
This PR intends to move the price formatting into a separate class which you can swap out in the configuration.

Currently formatting of prices are tied to the Lunar implementation and we should be allowing developers to provide their own methods.

---

Currently I'm not too sure on the implementation 🤔 as it stands it's just a copy of the existing methods and moved to a class reference, but I'm not sure how correct...