### PR TITLE
Added tests for BuyXGetY / fix edge cases

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -30,13 +30,13 @@ class BuyXGetY extends AbstractDiscountType
      */
     public function getRewardQuantity($linesQuantity, $minQty, $rewardQty, $maxRewardQty = null)
     {
-        $result = ($linesQuantity / ($minQty ?: 1)) * $rewardQty;
-
-        if ($maxRewardQty && $result > $maxRewardQty) {
-            return $maxRewardQty;
+        if ($linesQuantity < $minQty) {
+            return 0;
         }
 
-        return $result;
+        $result = floor(($linesQuantity / ($minQty ?: 1)) * $rewardQty);
+
+        return $maxRewardQty ? min($result, $maxRewardQty) : $result;
     }
 
     /**

--- a/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
@@ -95,13 +95,6 @@ class BuyXGetYTest extends TestCase
                 'expected' => 1,
             ],
             [
-                'linesQuantity' => 3,
-                'minQty' => 2,
-                'rewardQty' => 1,
-                'maxRewardQty' => 10,
-                'expected' => 1,
-            ],
-            [
                 'linesQuantity' => 0,
                 'minQty' => 1,
                 'rewardQty' => 1,

--- a/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/BuyXGetYTest.php
@@ -23,40 +23,61 @@ class BuyXGetYTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function can_determine_correct_reward_qty()
+    /**
+     * @dataProvider provideRewardChecks
+     * @test
+     */
+    public function can_determine_correct_reward_qty($linesQuantity, $minQty, $rewardQty, $maxRewardQty, $expected)
     {
         $driver = new BuyXGetY;
 
-        $checks = [
+        $this->assertEquals(
+            $expected,
+            $driver->getRewardQuantity(
+                $linesQuantity,
+                $minQty,
+                $rewardQty,
+                $maxRewardQty ?? null
+            )
+        );
+    }
+
+    public function provideRewardChecks()
+    {
+        return [
             [
                 'linesQuantity' => 1,
                 'minQty' => 1,
                 'rewardQty' => 1,
+                'maxRewardQty' =>  null,
                 'expected' => 1,
             ],
             [
                 'linesQuantity' => 2,
                 'minQty' => 1,
                 'rewardQty' => 1,
+                'maxRewardQty' =>  null,
                 'expected' => 2,
             ],
             [
                 'linesQuantity' => 2,
                 'minQty' => 2,
                 'rewardQty' => 1,
+                'maxRewardQty' =>  null,
                 'expected' => 1,
             ],
             [
                 'linesQuantity' => 10,
                 'minQty' => 10,
                 'rewardQty' => 1,
+                'maxRewardQty' =>  null,
                 'expected' => 1,
             ],
             [
                 'linesQuantity' => 10,
                 'minQty' => 1,
                 'rewardQty' => 1,
+                'maxRewardQty' =>  null,
                 'expected' => 10,
             ],
             [
@@ -66,20 +87,58 @@ class BuyXGetYTest extends TestCase
                 'maxRewardQty' => 5,
                 'expected' => 5,
             ],
+            [
+                'linesQuantity' => 3,
+                'minQty' => 2,
+                'rewardQty' => 1,
+                'maxRewardQty' => 10,
+                'expected' => 1,
+            ],
+            [
+                'linesQuantity' => 3,
+                'minQty' => 2,
+                'rewardQty' => 1,
+                'maxRewardQty' => 10,
+                'expected' => 1,
+            ],
+            [
+                'linesQuantity' => 0,
+                'minQty' => 1,
+                'rewardQty' => 1,
+                'maxRewardQty' =>  null,
+                'expected' => 0,
+            ],
+            [
+                'linesQuantity' => 4,
+                'minQty' => 5,
+                'rewardQty' => 3,
+                'maxRewardQty' =>  null,
+                'expected' => 0,
+            ],
+            [
+                'linesQuantity' => 5,
+                'minQty' => 5,
+                'rewardQty' => 3,
+                'maxRewardQty' =>  null,
+                'expected' => 3,
+            ],
+            [
+                'linesQuantity' => 10,
+                'minQty' => 5,
+                'rewardQty' => 3,
+                'maxRewardQty' =>  null,
+                'expected' => 6,
+            ],
+            [
+                'linesQuantity' => 10,
+                'minQty' => 5,
+                'rewardQty' => 3,
+                'maxRewardQty' => 5,
+                'expected' => 5,
+            ],
         ];
-
-        foreach ($checks as $check) {
-            $this->assertEquals(
-                $check['expected'],
-                $driver->getRewardQuantity(
-                    $check['linesQuantity'],
-                    $check['minQty'],
-                    $check['rewardQty'],
-                    $check['maxRewardQty'] ?? null
-                )
-            );
-        }
     }
+
 
     /** @test */
     public function can_discount_eligible_product()


### PR DESCRIPTION
Added test cases for BuyXGetY, initially for cases where `linesQuantity / minQty * rewardQty` would end up in a Floating point. Let's say: we have a 2+1 BuyXGetY and 3 in our Cart: `3 / 2 * 1 = 1.5 rewarded`, thus resulting in crashes and incorrect calculations. Also moved it to a DataProvider so we get a clear indicator of which check exactly fails, instead of the entire test failing.

Ran into this when testing the automatic reward BuyXGetY, since the invalid rewardQuantity messed with the modulus happening there to calculate how much to allocate and the DiscountBreakdownLine expects an integer as quantity.

Apologies if this description is incomplete.