### PR TITLE
Feat - Improve order creation with shipping

### DIFF
--- a/packages/core/src/Base/Casts/ShippingBreakdown.php
+++ b/packages/core/src/Base/Casts/ShippingBreakdown.php
@@ -51,8 +51,12 @@ class ShippingBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        if (! is_a($value, \Lunar\Base\ValueObjects\Cart\ShippingBreakdown::class)) {
+        if ($value && ! is_a($value, \Lunar\Base\ValueObjects\Cart\ShippingBreakdown::class)) {
             throw new \Exception('Shipping breakdown must be instance of Lunar\Base\ValueObjects\Cart\ShippingBreakdown');
+        }
+
+        if (! $value) {
+            return [];
         }
 
         return [

--- a/packages/core/src/Pipelines/Order/Creation/FillOrderFromCart.php
+++ b/packages/core/src/Pipelines/Order/Creation/FillOrderFromCart.php
@@ -14,11 +14,7 @@ class FillOrderFromCart
      */
     public function handle(Order $order, Closure $next)
     {
-        $cart = $order->cart;
-
-        if (! $cart->subTotal) {
-            $cart->calculate();
-        }
+        $cart = $order->cart->calculate();
 
         $order->fill([
             'user_id' => $cart->user_id,
@@ -32,6 +28,7 @@ class FillOrderFromCart
             'discount_total' => $cart->discountTotal?->value,
             'discount_breakdown' => [],
             'shipping_total' => $cart->shippingTotal?->value ?: 0,
+            'shipping_breakdown' => $cart->shippingBreakdown,
             'tax_breakdown' => $cart->taxBreakdown->map(function ($tax) {
                 return [
                     'description' => $tax['description'],

--- a/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
@@ -122,7 +122,7 @@ class CreateOrderTest extends TestCase
         $this->assertTrue($orderA->updated_at->eq($updatedAt));
     }
 
-    /** @test  */
+    /** @test */
     public function can_create_order()
     {
         CustomerGroup::factory()->create([
@@ -146,8 +146,6 @@ class CreateOrderTest extends TestCase
             'city' => 'Lapland',
             'postcode' => 'SHIPP',
         ]);
-
-        $taxClass = TaxClass::factory()->create();
 
         $currency = Currency::factory()->create([
             'decimal_places' => 2,

--- a/packages/core/tests/Unit/Base/Casts/ShippingBreakdownTest.php
+++ b/packages/core/tests/Unit/Base/Casts/ShippingBreakdownTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Lunar\Tests\Unit\Base\Casts;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Base\Casts\ShippingBreakdown as ShippingBreakdownCasts;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdownItem;
+use Lunar\DataTypes\Price;
+use Lunar\Models\Currency;
+use Lunar\Models\Order;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group model.casts
+ */
+class ShippingBreakdownTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_set_from_value_object()
+    {
+        $currency = Currency::factory()->create();
+        $order = Order::factory()->create();
+
+        $shippingBreakdownValueObject = new ShippingBreakdown();
+
+        $shippingBreakdownValueObject->items->put('DELIV',
+            new ShippingBreakdownItem(
+                name: 'Basic Delivery',
+                identifier: 'DELIV',
+                price: new Price(700, $currency, 1),
+            )
+        );
+
+        $breakDown = new ShippingBreakdownCasts;
+
+        $result = $breakDown->set($order, 'shipping_breakdown', $shippingBreakdownValueObject, []);
+
+        $this->assertArrayHasKey('shipping_breakdown', $result);
+        $this->assertJson($result['shipping_breakdown']);
+    }
+
+    /** @test */
+    public function can_cast_to_and_from_model()
+    {
+        $currency = Currency::factory()->create();
+        $order = Order::factory()->create();
+
+        $shippingBreakdownValueObject = new ShippingBreakdown();
+
+        $shippingBreakdownValueObject->items->put('DELIV',
+            new ShippingBreakdownItem(
+                name: 'Basic Delivery',
+                identifier: 'DELIV',
+                price: new Price(700, $currency, 1),
+            )
+        );
+
+        $order->update([
+            'shipping_breakdown' => $shippingBreakdownValueObject,
+        ]);
+
+        $breakdown = $order->refresh()->shipping_breakdown;
+        $this->assertInstanceOf(ShippingBreakdown::class, $breakdown);
+    }
+}

--- a/packages/core/tests/Unit/Facades/TaxesTest.php
+++ b/packages/core/tests/Unit/Facades/TaxesTest.php
@@ -6,6 +6,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Base\TaxManagerInterface;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Facades\Taxes;
+use Lunar\Models\Currency;
+use Lunar\Models\ProductVariant;
 use Lunar\Tests\Stubs\TestTaxDriver;
 use Lunar\Tests\TestCase;
 
@@ -31,7 +33,11 @@ class TaxesTest extends TestCase
 
         $this->assertInstanceOf(TestTaxDriver::class, Taxes::driver('testing'));
 
-        $result = Taxes::driver('testing')->getBreakdown(123);
+        $result = Taxes::driver('testing')->setPurchasable(
+            ProductVariant::factory()->create()
+        )->setCurrency(
+            Currency::factory()->create()
+        )->getBreakdown(123);
 
         $this->assertInstanceOf(TaxBreakdown::class, $result);
     }

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -252,7 +252,7 @@ class OrderTest extends TestCase
                 new ShippingBreakdownItem(
                     name: 'Breakdown A',
                     identifier: 'BA',
-                    price: new Price(123, Currency::getDefault(), 1)
+                    price: $shippingPrice = new Price(123, $currency = Currency::getDefault(), 1)
                 ),
             ])
         );
@@ -265,15 +265,17 @@ class OrderTest extends TestCase
             'shipping_breakdown' => json_encode([[
                 'name' => 'Breakdown A',
                 'identifier' => 'BA',
-                'price' => 123,
+                'value' => 123,
+                'formatted' => $shippingPrice->formatted,
+                'currency' => $currency->toArray(),
             ]]),
         ]);
 
         $breakdown = $order->refresh()->shipping_breakdown;
 
-        $this->assertCount(1, $breakdown);
+        $this->assertCount(1, $breakdown->items);
 
-        $breakdownItem = $breakdown->first();
+        $breakdownItem = $breakdown->items->first();
 
         $this->assertEquals('Breakdown A', $breakdownItem->name);
         $this->assertEquals('BA', $breakdownItem->identifier);


### PR DESCRIPTION
This PR looks to improve/fix a couple of things when creating an order from a cart, mainly related to the shipping breakdown. I think this is technically a change to the API which is what it's targeting main.

- The cart is now `calculated` when we go to fill the order from the cart, instead of attempting to check if there was a sub total. This seemed a bit brittle as the sub total could have a `Price` data type value but still be zero or "uncalculated"
- `shipping_breakdown` wasn't being set and the casting class wasn't implemented fully.