### PR TITLE
Support status override and custom meta for OfflinePayment type

### DIFF
--- a/packages/core/src/PaymentTypes/OfflinePayment.php
+++ b/packages/core/src/PaymentTypes/OfflinePayment.php
@@ -19,9 +19,16 @@ class OfflinePayment extends AbstractPayment
                 $this->order = $this->cart->createOrder();
             }
         }
+        $orderMeta = array_merge(
+            (array) $this->order->meta,
+            $this->data['meta'] ?? []
+        );
+
+        $status = $this->data['authorized'] ?? null;
 
         $this->order->update([
-            'status' => $this->config['authorized'] ?? null,
+            'status' => $status ?? ($this->config['authorized'] ?? null),
+            'meta' => $orderMeta,
             'placed_at' => now(),
         ]);
 

--- a/packages/core/tests/Unit/PaymentTypes/OfflinePaymentTypeTest.php
+++ b/packages/core/tests/Unit/PaymentTypes/OfflinePaymentTypeTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Lunar\Tests\Unit\PaymentTypes;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Lunar\Base\DataTransferObjects\PaymentAuthorize;
+use Lunar\Facades\Payments;
+use Lunar\Models\Cart;
+use Lunar\Models\CartAddress;
+use Lunar\Models\Country;
+use Lunar\Models\Order;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group lunar.payment-types
+ */
+class OfflinePaymentTypeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_authorize_payment()
+    {
+        $cart = Cart::factory()->create();
+
+        Config::set('lunar.payments.types.offline', [
+            'authorized' => 'offline-payment',
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'BILL',
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'SHIPP',
+        ]);
+
+        $result = Payments::driver('offline')->cart($cart->refresh())->authorize();
+
+        $this->assertInstanceOf(PaymentAuthorize::class, $result);
+        $this->assertTrue($result->success);
+
+        $this->assertInstanceOf(Order::class, $cart->refresh()->completedOrder);
+    }
+
+    /** @test */
+    public function can_override_status()
+    {
+        $cart = Cart::factory()->create();
+
+        Config::set('lunar.payments.types.offline', [
+            'authorized' => 'offline-payment',
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'BILL',
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'SHIPP',
+        ]);
+
+        Payments::driver('offline')->cart($cart->refresh())->withData([
+            'authorized' => 'custom-status',
+        ])->authorize();
+
+        $order = $cart->refresh()->completedOrder;
+
+        $this->assertSame('custom-status', $order->status);
+    }
+
+    /** @test */
+    public function can_set_additional_meta()
+    {
+        $cart = Cart::factory()->create();
+
+        Config::set('lunar.payments.types.offline', [
+            'authorized' => 'offline-payment',
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'BILL',
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping',
+            'country_id' => Country::factory(),
+            'first_name' => 'Santa',
+            'line_one' => '123 Elf Road',
+            'city' => 'Lapland',
+            'postcode' => 'SHIPP',
+        ]);
+
+        Payments::driver('offline')->cart($cart->refresh())->withData([
+            'meta' => [
+                'foo' => 'bar',
+            ],
+        ])->authorize();
+
+        $order = $cart->refresh()->completedOrder;
+
+        $meta = (array) $order->meta;
+
+        $this->assertEquals('bar', $meta['foo']);
+    }
+}


### PR DESCRIPTION
This PR looks to add support for adding custom meta and status to an order when authorizing. This can be useful if you want to use the same driver for different types, such as collection, on account etc and they need their own status.