### PR TITLE
Fix dynamically applying discounts

### DIFF
--- a/packages/core/src/DiscountTypes/AmountOff.php
+++ b/packages/core/src/DiscountTypes/AmountOff.php
@@ -127,7 +127,9 @@ class AmountOff extends AbstractDiscountType
             $cart->discounts = collect();
         }
 
-        $cart->discounts->push($this);
+        if (! $cart->discounts->contains($this)) {
+            $cart->discounts->push($this);
+        }
 
         $this->addDiscountBreakdown($cart, new DiscountBreakdown(
             discount: $this->discount,

--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -183,7 +183,7 @@ class DiscountManager implements DiscountManagerInterface
 
     public function apply(Cart $cart): Cart
     {
-        if (! $this->discounts) {
+        if (! $this->discounts || $this->discounts?->isEmpty()) {
             $this->discounts = $this->getDiscounts($cart);
         }
 


### PR DESCRIPTION
I came across a situation when discounts were not applied, because the `calculate` method was already called on cart. It is called during `CartSession::use($cart)` and also during `CartSession::current()`. This ended up with a state in `DiscountManager`, when the `$discounts` property was set to empty collection. Then the check in DiscountManager became true every time, because it only checks for `null` value and not empty collection.

After changing the check to count with empty collection as follows: `! $this->discounts || $this->discounts?->isEmpty())`, there were multiple instances of the discounts added to `$cart->discounts` property. I mitigated this behavior by only adding discounts which are not already present in that property.

I also added a test which calls the `$cart->calculate()` method multiple times to make sure that discounts are added properly.

All tests are running green now, but this implementation is ofc open for discussion. Maybe there is a better solution.