### PR TITLE
Fix uniqueness constraint validation when attributeGroup is not persisted

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -76,9 +76,15 @@ class AttributeGroupEdit extends Component
         $handle = Str::handle("{$this->typeHandle}_{$this->attributeGroup->translate('name')}");
         $this->attributeGroup->handle = $handle;
 
+        $uniquenessConstraint = 'unique:' . get_class($this->attributeGroup) . ',handle';
+        if ($this->attributeGroup->id) {
+            $uniquenessConstraint .= ',' . $this->attributeGroup->id;
+        }
+
         $this->validate([
-            'attributeGroup.handle' => 'unique:'.get_class($this->attributeGroup).',handle,'.$this->attributeGroup->id,
+            'attributeGroup.handle' => $uniquenessConstraint,
         ]);
+
 
         if ($this->attributeGroup->id) {
             $this->attributeGroup->save();


### PR DESCRIPTION
This PR fixes a small bug in the admin package, where creation of new Attribute Groups would fail because the uniqueness validation would be missing an id, producing the following SQL statement.

```
select
  count(*) as aggregate
from
  "lunar_attribute_groups"
where
  "handle" = product_test
  and "id" <>
```

I've just changed the validation to only attempt to exclude the current id if it is set 