### PR TITLE
Add GetTaxZoneCountry class to be able to use country based tax zones

### DIFF
--- a/packages/core/src/Actions/Taxes/GetTaxZone.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZone.php
@@ -23,6 +23,13 @@ class GetTaxZone
             }
         }
 
+        if ($address && $address->country_id) {
+            $countryZone = app(GetTaxZoneCountry::class)->execute($address->country_id);
+            if ($countryZone) {
+                return $countryZone->taxZone;
+            }
+        }
+
         return TaxZone::getDefault();
     }
 }

--- a/packages/core/src/Actions/Taxes/GetTaxZoneCountry.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZoneCountry.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lunar\Actions\Taxes;
+
+use Lunar\Models\TaxZoneCountry;
+
+class GetTaxZoneCountry
+{
+    public function execute($countryId)
+    {
+        $taxZone = $this->getZone($countryId);
+
+        if ($taxZone instanceof TaxZoneCountry) {
+            return $taxZone;
+        }
+
+        if (!$taxZone) {
+            return null;
+        }
+    }
+
+    /**
+     * Return the zone or zones which match this country.
+     *
+     * @param int $countryId
+     * @return TaxZoneCountry|null
+     */
+    protected function getZone(int $countryId)
+    {
+        return TaxZoneCountry::whereCountryId($countryId)->first();
+    }
+}

--- a/packages/core/tests/Unit/Actions/Taxes/GetTaxZoneCountryTest.php
+++ b/packages/core/tests/Unit/Actions/Taxes/GetTaxZoneCountryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Lunar\Tests\Unit\Actions\Taxes;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Actions\Taxes\GetTaxZoneCountry;
+use Lunar\Models\Country;
+use Lunar\Models\TaxZoneCountry;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group lunar.actions
+ */
+class GetTaxZoneCountryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_match_country_id()
+    {
+        $belgium = Country::factory()->create([
+            'name' => 'Belgium',
+        ]);
+
+        $uk = Country::factory()->create([
+            'name' => 'United Kingdom',
+        ]);
+
+        $taxZoneBelgium = TaxZoneCountry::factory()->create([
+            'country_id' => $belgium->id,
+        ]);
+
+        $taxZoneUk = TaxZoneCountry::factory()->create([
+            'country_id' => $uk->id,
+        ]);
+
+        $zone = app(GetTaxZoneCountry::class)->execute($uk->id);
+
+        $this->assertEquals($taxZoneUk->id, $zone->id);
+    }
+
+    /** @test */
+    public function can_mismatch_country_id()
+    {
+        $belgium = Country::factory()->create([
+            'name' => 'Belgium',
+        ]);
+
+        $uk = Country::factory()->create([
+            'name' => 'United Kingdom',
+        ]);
+
+        $taxZoneBelgium = TaxZoneCountry::factory()->create([
+            'country_id' => $belgium->id,
+        ]);
+
+        $zone = app(GetTaxZoneCountry::class)->execute($uk->id);
+
+        $this->assertNull($zone);
+    }
+}

--- a/packages/core/tests/Unit/Actions/Taxes/GetTaxZoneTest.php
+++ b/packages/core/tests/Unit/Actions/Taxes/GetTaxZoneTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Lunar\Tests\Unit\Actions\Taxes;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Actions\Taxes\GetTaxZone;
+use Lunar\Actions\Taxes\GetTaxZoneCountry;
+use Lunar\Models\Address;
+use Lunar\Models\Country;
+use Lunar\Models\State;
+use Lunar\Models\TaxZone;
+use Lunar\Models\TaxZoneCountry;
+use Lunar\Models\TaxZonePostcode;
+use Lunar\Models\TaxZoneState;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group lunar.actions
+ */
+class GetTaxZoneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_prioritize_taxzones()
+    {
+        $postcode = 'SW1A 0AA';
+
+        $state = State::factory()->create([
+            'code' => 'AL',
+            'name' => 'Alabama',
+        ]);
+
+        $country = Country::factory()->create([
+            'name' => 'Belgium',
+        ]);
+
+        $taxZonePostcode = TaxZonePostcode::factory()->create([
+            'tax_zone_id' => TaxZone::factory(['default' => false]),
+            'postcode' => $postcode,
+        ]);
+
+        $taxZoneState = TaxZoneState::factory()->create([
+            'tax_zone_id' => TaxZone::factory(['default' => false]),
+            'state_id' => $state->id,
+        ]);
+
+        $taxZoneCountry = TaxZoneCountry::factory()->create([
+            'tax_zone_id' => TaxZone::factory(['default' => false]),
+            'country_id' => $country->id,
+        ]);
+
+        $defaultTaxZone = TaxZone::factory(['default' => true])->create();
+
+        // postcode, state and country match => postcode tax zone should be returned
+        $addressWithAllMatching = Address::factory()->create([
+            'postcode' => $postcode,
+            'state' => $state->name,
+            'country_id' => $country->id,
+        ]);
+
+        $zone1 = app(GetTaxZone::class)->execute($addressWithAllMatching);
+
+        $this->assertEquals($taxZonePostcode->tax_zone_id, $zone1->id);
+
+        // only state and country match => state tax zone should be returned
+        $addressWithOnlyStateAndCountryMatching = Address::factory()->create([
+            'postcode' => '1234AB',
+            'state' => $state->name,
+            'country_id' => $country->id,
+        ]);
+
+        $zone2 = app(GetTaxZone::class)->execute($addressWithOnlyStateAndCountryMatching);
+
+        $this->assertEquals($taxZoneState->tax_zone_id, $zone2->id);
+
+        // only country matches => country tax zone should be returned
+        $addressWithOnlyCountryMatching = Address::factory()->create([
+            'postcode' => '1234AB',
+            'state' => 'Alaska',
+            'country_id' => $country->id,
+        ]);
+
+        $zone3 = app(GetTaxZone::class)->execute($addressWithOnlyCountryMatching);
+
+        $this->assertEquals($taxZoneCountry->tax_zone_id, $zone3->id);
+
+        // nothing matches => default tax zone should be returned
+        $addressWithOnlyCountryMatching = Address::factory()->create([
+            'postcode' => '1234AB',
+            'state' => 'Alaska',
+            'country_id' => 123,
+        ]);
+
+        $zone3 = app(GetTaxZone::class)->execute($addressWithOnlyCountryMatching);
+
+        $this->assertEquals($defaultTaxZone->id, $zone3->id);
+    }
+}


### PR DESCRIPTION
In the `GetTaxZone` class, there is logic for dealing with postcode-based and state-based tax zones, but not for country-based ones. This PR aims to fill this gap.

I've followed the general concept of the existing `GetTaxZonePostcode` and `GetTaxZoneState` classes for the new `GetTaxZoneCountry` class.

I've assumed that country comes at the bottom of the priority hierarchy: if an address has a postcode matching a `TaxZonePostcode`, that takes priority over state and country, after that, state takes priority over country, and only if there's no matching tax zone for postcode or state, we're gonna look for a `TaxZoneCountry`. This should also help ensure that this is not a breaking change.

I've also added some tests.