### PR TITLE
Add serialization to Price cast

### DIFF
--- a/packages/core/src/Base/Casts/Price.php
+++ b/packages/core/src/Base/Casts/Price.php
@@ -3,11 +3,12 @@
 namespace Lunar\Base\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Illuminate\Support\Facades\Validator;
 use Lunar\DataTypes\Price as PriceDataType;
 use Lunar\Models\Currency;
 
-class Price implements CastsAttributes
+class Price implements CastsAttributes, SerializesCastableAttributes
 {
     /**
      * Cast the given value.
@@ -54,5 +55,18 @@ class Price implements CastsAttributes
         return [
             $key => $value,
         ];
+    }
+
+    /**
+     * Get the serialized representation of the value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  \Illuminate\Support\Collection  $value
+     * @param  array<string, mixed>  $attributes
+     */
+    public function serialize($model, $key, $value, $attributes)
+    {
+        return $value->toArray();
     }
 }

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -66,16 +66,7 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
     public function serialize($model, $key, $value, $attributes)
     {
         return $value->map(function ($rate) {
-            $rate = is_array($rate) ? (object) $rate : $rate;
-
-            if ($rate->total instanceof Price) {
-                $rate->total = (object) [
-                    'value' => $rate->total->value,
-                    'formatted' => $rate->total->formatted,
-                    'currency' => $rate->total->currency->toArray(),
-                ];
-            }
-
+            $rate->total = $rate->total->toArray();
             return $rate;
         })->toJson();
     }

--- a/packages/core/src/DataTypes/Price.php
+++ b/packages/core/src/DataTypes/Price.php
@@ -2,11 +2,12 @@
 
 namespace Lunar\DataTypes;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Lunar\Exceptions\InvalidDataTypeValueException;
 use Lunar\Models\Currency;
 use Lunar\Pricing\DefaultPriceFormatter;
 
-class Price
+class Price implements Arrayable
 {
     /**
      * Initialise the Price datatype.
@@ -99,5 +100,20 @@ class Price
     protected function formatValue(int|float $value, ...$arguments): mixed
     {
         return $this->formatter()->formatValue($value, ...$arguments);
+    }
+
+    /**
+     * Get the instance as an array.
+     *
+     * @return array<TKey, TValue>
+     */
+    public function toArray()
+    {
+        return [
+            'value' => $this->value,
+            'decimal' => $this->decimal,
+            'formatted' => $this->formatted,
+            'currency' => $this->currency->code,
+        ];
     }
 }

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -94,7 +94,7 @@ class OrderTest extends TestCase
 
         $data = $order->toArray();
 
-        $this->assertIsInt($order->total);
+        $this->assertIsInt($data['total']['value']);
     }
 
     /** @test */

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
 use Lunar\Base\ValueObjects\Cart\ShippingBreakdownItem;
+use Lunar\Base\OrderReferenceGenerator;
 use Lunar\DataTypes\Price;
 use Lunar\Models\Cart;
 use Lunar\Models\Currency;
@@ -17,6 +18,7 @@ use Lunar\Models\ProductVariant;
 use Lunar\Models\Transaction;
 use Lunar\Tests\Stubs\User;
 use Lunar\Tests\TestCase;
+use Ramsey\Uuid\Type\Integer;
 
 /**
  * @group lunar.orders
@@ -70,6 +72,29 @@ class OrderTest extends TestCase
         $data = $order->getRawOriginal();
 
         $this->assertDatabaseHas((new Order())->getTable(), $data);
+    }
+
+    /** @test */
+    public function can_serialize_an_order()
+    {
+        Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        $order = Order::factory()->create([
+            'user_id' => null,
+            'tax_breakdown' => [
+                [
+                    'description' => 'VAT',
+                    'total' => 99,
+                    'percentage' => 20,
+                ],
+            ],
+        ]);
+
+        $data = $order->toArray();
+
+        $this->assertIsInt($order->total);
     }
 
     /** @test */


### PR DESCRIPTION
Closes #1250 

Currently, when converting a model to an array, Price objects will be in the array. Ideally, these should also be converted to arrays so that they can be indexed etc.

- [x] Add failing test
- [ ] Implement serialization
- [ ] Determine what to do with Livewire as it appears to be using the Arrayable data now