### PR TITLE
Feature: Add pipeline (for order creation) that deducts stock from inventory

### DIFF
--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -69,6 +69,7 @@ return [
             Lunar\Pipelines\Order\Creation\CreateShippingLine::class,
             Lunar\Pipelines\Order\Creation\CleanUpOrderLines::class,
             Lunar\Pipelines\Order\Creation\MapDiscountBreakdown::class,
+            // \Lunar\Pipelines\Order\Creation\DeductStockFromInventory::class
         ],
     ],
 ];

--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -66,10 +66,10 @@ return [
             Lunar\Pipelines\Order\Creation\FillOrderFromCart::class,
             Lunar\Pipelines\Order\Creation\CreateOrderLines::class,
             Lunar\Pipelines\Order\Creation\CreateOrderAddresses::class,
+            Lunar\Pipelines\Order\Creation\DeductStockFromInventory::class,
             Lunar\Pipelines\Order\Creation\CreateShippingLine::class,
             Lunar\Pipelines\Order\Creation\CleanUpOrderLines::class,
             Lunar\Pipelines\Order\Creation\MapDiscountBreakdown::class,
-            // \Lunar\Pipelines\Order\Creation\DeductStockFromInventory::class
         ],
     ],
 ];

--- a/packages/core/database/factories/OrderFactory.php
+++ b/packages/core/database/factories/OrderFactory.php
@@ -2,9 +2,11 @@
 
 namespace Lunar\Database\Factories;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Lunar\Models\Channel;
 use Lunar\Models\Order;
+use Lunar\Models\OrderLine;
 
 class OrderFactory extends Factory
 {
@@ -39,5 +41,16 @@ class OrderFactory extends Factory
             'exchange_rate' => 1,
             'meta' => ['foo' => 'bar'],
         ];
+    }
+
+    /**
+     * @param Collection<OrderLine> $lines
+     * @return self
+     */
+    public function withLines(Collection $lines): self
+    {
+        return $this->afterCreating(function (Order $order) use ($lines) {
+            $order->lines()->saveMany($lines);
+        });
     }
 }

--- a/packages/core/src/Base/Purchasable.php
+++ b/packages/core/src/Base/Purchasable.php
@@ -72,4 +72,12 @@ interface Purchasable
      * @return string
      */
     public function getThumbnail();
+
+    /**
+     * Deducts the stock for the purchasable item.
+     *
+     * @param int $amount
+     * @return void
+     */
+    public function deductStock(int $amount): void;
 }

--- a/packages/core/src/DataTypes/ShippingOption.php
+++ b/packages/core/src/DataTypes/ShippingOption.php
@@ -134,4 +134,9 @@ class ShippingOption implements Purchasable
     {
         return null;
     }
+
+    public function deductStock(int $amount): void
+    {
+        // Do nothing as we do not have a stock on this purchasable
+    }
 }

--- a/packages/core/src/Exceptions/InsufficientStockException.php
+++ b/packages/core/src/Exceptions/InsufficientStockException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lunar\Exceptions;
+
+use Exception;
+
+class InsufficientStockException extends Exception
+{
+
+}

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -213,8 +213,8 @@ class ProductVariant extends BaseModel implements Purchasable
      */
     public function deductStock(int $amount): void
     {
-        if ($this->stock - $amount < 0) {
-            throw new InsufficientStockException($this->product->translateAttribute('name'));
+        if ($this->stock - $amount < 0 && $this->purchasable === 'in_stock') {
+            throw new InsufficientStockException('Insufficient stock for product variant with EAN ' . $this->ean);
         }
 
         $this->stock -= $amount;

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -13,6 +13,7 @@ use Lunar\Base\Traits\HasPrices;
 use Lunar\Base\Traits\HasTranslations;
 use Lunar\Base\Traits\LogsActivity;
 use Lunar\Database\Factories\ProductVariantFactory;
+use Lunar\Exceptions\InsufficientStockException;
 use Spatie\LaravelBlink\BlinkFacade as Blink;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -207,8 +208,15 @@ class ProductVariant extends BaseModel implements Purchasable
         }) ?: $this->product->thumbnail;
     }
 
+    /**
+     * @throws InsufficientStockException
+     */
     public function deductStock(int $amount): void
     {
+        if ($this->stock - $amount < 0) {
+            throw new InsufficientStockException($this->product->translateAttribute('name'));
+        }
+
         $this->stock -= $amount;
         $this->save();
     }

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -206,4 +206,10 @@ class ProductVariant extends BaseModel implements Purchasable
             return (bool) $media->pivot?->primary;
         }) ?: $this->product->thumbnail;
     }
+
+    public function deductStock(int $amount): void
+    {
+        $this->stock -= $amount;
+        $this->save();
+    }
 }

--- a/packages/core/src/Pipelines/Order/Creation/DeductStockFromInventory.php
+++ b/packages/core/src/Pipelines/Order/Creation/DeductStockFromInventory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Lunar\Pipelines\Order\Creation;
+
+use Closure;
+use Lunar\Models\Order;
+use Lunar\Models\OrderLine;
+
+class DeductStockFromInventory
+{
+    /**
+     * @return Closure
+     */
+    public function handle(Order $order, Closure $next)
+    {
+        $order->lines->each(function (OrderLine $line) {
+            $line->purchasable->deductStock($line->quantity);
+        });
+
+        return $next($order->refresh());
+    }
+}

--- a/packages/core/tests/Unit/Models/ProductVariantTest.php
+++ b/packages/core/tests/Unit/Models/ProductVariantTest.php
@@ -248,6 +248,4 @@ class ProductVariantTest extends TestCase
         $this->assertEquals(416, $foodProductVariant->pricing()->currency($currency)->get()->matched->priceIncTax()->value);
         $this->assertEquals(9760, $genericProductVariant->pricing()->qty(20)->currency($currency)->get()->matched->priceIncTax()->value);
     }
-
-
 }

--- a/packages/core/tests/Unit/Models/ProductVariantTest.php
+++ b/packages/core/tests/Unit/Models/ProductVariantTest.php
@@ -248,4 +248,6 @@ class ProductVariantTest extends TestCase
         $this->assertEquals(416, $foodProductVariant->pricing()->currency($currency)->get()->matched->priceIncTax()->value);
         $this->assertEquals(9760, $genericProductVariant->pricing()->qty(20)->currency($currency)->get()->matched->priceIncTax()->value);
     }
+
+
 }

--- a/packages/core/tests/Unit/Pipelines/Order/Creation/DeductStockFromInventoryTest.php
+++ b/packages/core/tests/Unit/Pipelines/Order/Creation/DeductStockFromInventoryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Lunar\Tests\Unit\Pipelines\Order\Creation;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Models\Order;
+use Lunar\Models\OrderLine;
+use Lunar\Models\Product;
+use Lunar\Models\ProductType;
+use Lunar\Models\ProductVariant;
+use Lunar\Pipelines\Order\Creation\DeductStockFromInventory;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group lunar.orders.pipelines
+ */
+class DeductStockFromInventoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_run_pipeline()
+    {
+        $orderLines = OrderLine::factory(5)->make();
+
+        $order = Order::factory()->withLines($orderLines)->create();
+
+        app(DeductStockFromInventory::class)->handle($order, function ($order) {
+            return $order;
+        });
+
+        $this->assertNotNull($order->reference);
+    }
+
+    /** @test */
+    public function it_deducts_stock_from_inventory_when_available()
+    {
+        // Given
+        $product = Product::factory()->create();
+
+        $productVariant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+            'stock' => 10
+        ]);
+
+        $orderLines = OrderLine::factory(1)->make([
+            'purchasable_type' => ProductVariant::class,
+            'purchasable_id' => $productVariant->id,
+            'quantity' => 5,
+        ]);
+
+        $order = Order::factory()->withLines($orderLines)->create();
+
+        // When
+        app(DeductStockFromInventory::class)->handle($order, function ($order) {
+            return $order;
+        });
+
+        $productVariant->refresh();
+
+        // Then
+        $this->assertEquals(5, $productVariant->stock);
+    }
+}


### PR DESCRIPTION
This PR adds an order creation pipeline to the code base that deducts stock from the inventory (ProductVariant model). This is related to the discussion in https://github.com/lunarphp/lunar/discussions/1016. 

