### PR TITLE
Set section to nullable on attributes

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -76,7 +76,7 @@ class AttributeEdit extends Component
             'attribute.searchable' => 'nullable|boolean',
             'attribute.filterable' => 'nullable|boolean',
             'attribute.configuration' => 'nullable|array',
-            'attribute.section' => 'string',
+            'attribute.section' => 'nullable|string',
             'attribute.system' => 'boolean',
             'attribute.type' => 'required',
             'attribute.validation_rules' => 'nullable|string',

--- a/packages/core/database/migrations/2023_09_21_100000_set_section_to_nullable_on_attributes.php
+++ b/packages/core/database/migrations/2023_09_21_100000_set_section_to_nullable_on_attributes.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class SetSectionToNullableOnAttributes extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'attributes', function (Blueprint $table) {
+            $table->string('section')->nullable()->change();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'attributes', function ($table) {
+            $table->string('section')->nullable(false)->change();
+        });
+    }
+}


### PR DESCRIPTION
The table column `section` should be `nullable`, because it is not a required column e.G. model property. I think, it's only relevant if the hub is used but not required, too. Currently, it has to be set to nonsense or [space] string.

https://docs.lunarphp.io/core/reference/attributes.html#attributes-1

Field | Description
-- | --
section | An **optional** name to define where an attribute should be used.
