### PR TITLE
Fix phpunit coverage path and testsuites

### DIFF
--- a/packages/core/phpunit.xml
+++ b/packages/core/phpunit.xml
@@ -28,6 +28,9 @@
     <testsuite name="Database">
       <directory suffix="Test.php">./tests/Database</directory>
     </testsuite>
+    <testsuite name="Utils">
+      <directory suffix="Test.php">./tests/Utils</directory>
+    </testsuite>
   </testsuites>
   <php>
     <env name="DB_CONNECTION" value="testing"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,11 +20,17 @@
   </coverage>
   <testsuites>
     <testsuite name="Unit">
-      <directory suffix="Test.php">packages/**/tests</directory>
+      <directory suffix="Test.php">./packages/**/tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./packages/**/tests/Feature</directory>
+    </testsuite>
+    <testsuite name="Database">
+      <directory suffix="Test.php">./packages/**/tests/Database</directory>
     </testsuite>
     <testsuite name="Utils">
-      <directory suffix="Test.php">utils/**/tests</directory>
-      <exclude>utils/scout-database-engine/**</exclude>
+      <directory suffix="Test.php">packages/**/tests/Utils</directory>
+      <directory suffix="Test.php">utils/livewire-tables/tests</directory>
     </testsuite>
   </testsuites>
   <php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,7 +15,7 @@
 >
   <coverage>
     <include>
-      <directory suffix=".php">src/</directory>
+      <directory suffix=".php">./packages/**/src</directory>
     </include>
   </coverage>
   <testsuites>


### PR DESCRIPTION
1. Fix the path defined for code coverage inside the `phpunit.xml` file of the monorepo [lunarphp/lunar](https://github.com/lunarphp/lunar).
2. Add all testsuites of the [lunarphp/core](https://github.com/lunarphp/core) repo into its `phpunit.xml` file.
3. Collect all testsuites into the `phpunit.xml` file from the monorepo [lunarphp/lunar](https://github.com/lunarphp/lunar).