### PR TITLE
Coupon validator should check BuyXGetY too

### DIFF
--- a/packages/core/src/Base/Validation/CouponValidator.php
+++ b/packages/core/src/Base/Validation/CouponValidator.php
@@ -3,13 +3,14 @@
 namespace Lunar\Base\Validation;
 
 use Lunar\DiscountTypes\AmountOff;
+use Lunar\DiscountTypes\BuyXGetY;
 use Lunar\Models\Discount;
 
 class CouponValidator implements CouponValidatorInterface
 {
     public function validate(string $coupon): bool
     {
-        return Discount::whereType(AmountOff::class)
+        return Discount::whereIn('type', [AmountOff::class, BuyXGetY::class])
             ->active()
             ->where(function ($query) {
                 $query->whereNull('max_uses')


### PR DESCRIPTION
Currently the default coupon validator only checks AmountOff - it doesnt check BuyXGetY when it should also be doing that.