### PR TITLE
Check if the user is null when logging out

### DIFF
--- a/packages/core/src/Listeners/CartSessionAuthListener.php
+++ b/packages/core/src/Listeners/CartSessionAuthListener.php
@@ -57,7 +57,7 @@ class CartSessionAuthListener
      */
     public function logout(Logout $event)
     {
-        if (! is_lunar_user($event->user)) {
+        if (is_null($event->user) || ! is_lunar_user($event->user)) {
             return;
         }
 


### PR DESCRIPTION
Laravel Dusk passes null to the $event->user, so it throws an error. Adding a simple null check fixes this.