### PR TITLE
allow get existing cart line to be overridden

### DIFF
--- a/packages/core/config/cart.php
+++ b/packages/core/config/cart.php
@@ -91,6 +91,7 @@ return [
     */
     'actions' => [
         'add_to_cart' => \Lunar\Actions\Carts\AddOrUpdatePurchasable::class,
+        'get_existing_cart_line' => \Lunar\Actions\Carts\GetExistingCartLine::class,
         'update_cart_line' => \Lunar\Actions\Carts\UpdateCartLine::class,
         'remove_from_cart' => \Lunar\Actions\Carts\RemovePurchasable::class,
         'add_address' => \Lunar\Actions\Carts\AddAddress::class,

--- a/packages/core/src/Actions/Carts/AddOrUpdatePurchasable.php
+++ b/packages/core/src/Actions/Carts/AddOrUpdatePurchasable.php
@@ -24,7 +24,9 @@ class AddOrUpdatePurchasable extends AbstractAction
     ): self {
         throw_if(! $quantity, InvalidCartLineQuantityException::class);
 
-        $existing = app(GetExistingCartLine::class)->execute(
+        $existing = app(
+            config('lunar.cart.actions.get_existing_cart_line', GetExistingCartLine::class)
+        )->execute(
             cart: $cart,
             purchasable: $purchasable,
             meta: $meta


### PR DESCRIPTION
Allow the GetExistingCartLine to be overridden the same way the other actions in the cart are