### PR TITLE
Fix github action "Split Packages" on forks.

### DIFF
--- a/.github/workflows/split_packages.yml
+++ b/.github/workflows/split_packages.yml
@@ -1,4 +1,9 @@
 name: Split Packages
+env:
+  SPLIT_PACKAGES: ${{ vars.SPLIT_PACKAGES || '["admin","core","licensing"]' }}
+  SPLIT_PACKAGES_REPOSITORIES: ${{ vars.SPLIT_PACKAGES_REPOSITORIES || '{}' }}
+  SPLIT_UTILS: ${{ vars.SPLIT_UTILS || '["livewire-tables", "scout-database-engine"]' }}
+  SPLIT_UTILS_REPOSITORIES: ${{ vars.SPLIT_UTILS_REPOSITORIES || '{}' }}
 on:
   push:
     branches:
@@ -9,9 +14,10 @@ on:
 jobs:
   tag_split_packages:
     runs-on: ubuntu-latest
+    if: ${{ fromJSON(vars.SPLIT_PACKAGES)[0] != null }}
     strategy:
       matrix:
-        package: ["admin", "core", "licensing"]
+        package: ${{ fromJSON(vars.SPLIT_PACKAGES) }}
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -26,8 +32,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           package_directory: "packages/${{ matrix.package }}"
-          repository_organization: "lunarphp"
-          repository_name: "${{ matrix.package }}"
+          repository_organization: "${GITHUB_REPOSITORY_OWNER}"
+          repository_name: "${{ fromJSON(vars.SPLIT_PACKAGES_REPOSITORIES)[matrix.package] || matrix.package }}"
           user_name: "GitHub Action"
           user_email: "action@github.com"
           branch: ${GITHUB_REF#refs/heads/}
@@ -43,8 +49,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           package_directory: "packages/${{ matrix.package }}"
-          repository_organization: "lunarphp"
-          repository_name: "${{ matrix.package }}"
+          repository_organization: "${GITHUB_REPOSITORY_OWNER}"
+          repository_name: "${{ fromJSON(vars.SPLIT_PACKAGES_REPOSITORIES)[matrix.package] || matrix.package }}"
           user_name: "GitHub Action"
           user_email: "action@github.com"
           branch: ${GITHUB_TAG%.*}
@@ -57,17 +63,18 @@ jobs:
         with:
           tag: ${GITHUB_REF#refs/tags/}
           package_directory: "packages/${{ matrix.package }}"
-          repository_organization: "lunarphp"
-          repository_name: "${{ matrix.package }}"
+          repository_organization: "${GITHUB_REPOSITORY_OWNER}"
+          repository_name: "${{ fromJSON(vars.SPLIT_PACKAGES_REPOSITORIES)[matrix.package] || matrix.package }}"
           user_name: "GitHub Action"
           user_email: "action@github.com"
           branch: ${GITHUB_TAG%.*}
 
   split_utils:
     runs-on: ubuntu-latest
+    if: ${{ fromJSON(vars.SPLIT_UTILS)[0] != null }}
     strategy:
       matrix:
-        package: ["livewire-tables", "scout-database-engine"]
+        package: ${{ fromJSON(vars.SPLIT_UTILS) }}
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
@@ -82,8 +89,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           package_directory: "utils/${{ matrix.package }}"
-          repository_organization: "lunarphp"
-          repository_name: "${{ matrix.package }}"
+          repository_organization: "${GITHUB_REPOSITORY_OWNER}"
+          repository_name: "${{ fromJSON(vars.SPLIT_UTILS_REPOSITORIES)[matrix.package] || matrix.package }}"
           user_name: "GitHub Action"
           user_email: "action@github.com"
           branch: ${GITHUB_REF#refs/heads/}
@@ -99,8 +106,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           package_directory: "utils/${{ matrix.package }}"
-          repository_organization: "lunarphp"
-          repository_name: "${{ matrix.package }}"
+          repository_organization: "${GITHUB_REPOSITORY_OWNER}"
+          repository_name: "${{ fromJSON(vars.SPLIT_UTILS_REPOSITORIES)[matrix.package] || matrix.package }}"
           user_name: "GitHub Action"
           user_email: "action@github.com"
           branch: ${GITHUB_TAG%.*}
@@ -113,8 +120,8 @@ jobs:
         with:
           tag: ${GITHUB_REF#refs/tags/}
           package_directory: "utils/${{ matrix.package }}"
-          repository_organization: "lunarphp"
-          repository_name: "${{ matrix.package }}"
+          repository_organization: "${GITHUB_REPOSITORY_OWNER}"
+          repository_name: "${{ fromJSON(vars.SPLIT_UTILS_REPOSITORIES)[matrix.package] || matrix.package }}"
           user_name: "GitHub Action"
           user_email: "action@github.com"
           branch: ${GITHUB_TAG%.*}


### PR DESCRIPTION
After some trouble with the first version #1276 — it was quite late yesterday :sleeping: — now the second pull request with the expected result.

This commit adds variables for packages and repository mapping inside .github/workflows/split_packages.yml, to allow selective package splitting on a forked monorepo, with deviating repository names.

Available variables:
- SPLIT_PACKAGES
info: Defines the lunar packages to split into a separate repository from the monorepo.
type: JSON array literal as string
default: `'["admin", "core", "licensing"]'`

- SPLIT_PACKAGES_REPOSITORIES
info: Allows to map a lunar package to a specific repository by key/value assignment: `{"package": "repository"}`. If not given, the package name will be used. 
type: JSON object literal as string
default: `'{}'`

- SPLIT_UTILS
info: Defines the utility packages to split into a separate repository from the monorepo.
type: JSON array literal as string
default: `'["livewire-tables", "scout-database-engine"]'`

- SPLIT_UTILS_REPOSITORIES
info: Allows to map a utility package to a specific repository by key/value assignment: `{"package": "repository"}`. If not given, the package name will be used. 
type: JSON object literal as string
default: `'{}'`