### PR TITLE
Support blank and null coupons

### DIFF
--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -140,8 +140,8 @@ class DiscountManager implements DiscountManagerInterface
                 )
             )->when(
                 $cart?->coupon_code,
-                fn ($query, $value) => $query->where('coupon', '=', $value)->orWhereNull('coupon'),
-                fn ($query, $value) => $query->whereNull('coupon')
+                fn ($query, $value) => $query->where('coupon', '=', $value)->orWhere(fn ($query) => $query->whereNull('coupon')->orWhere('coupon', '')),
+                fn ($query, $value) => $query->whereNull('coupon')->orWhere('coupon', '')
             )->orderBy('priority', 'desc')
             ->orderBy('id')
             ->get();


### PR DESCRIPTION
If you enter a value in the coupon field, but then decide to blank it, it's no longer null, it's now blank, which means it wont automatically apply.

This PR fixes that behaviour.