### PR TITLE
Pass order object to mailer class during preview

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Orders/OrderStatus.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrderStatus.php
@@ -133,7 +133,7 @@ class OrderStatus extends Component
     {
         $mailer = $this->availableMailers[$this->previewTemplate] ?? null;
 
-        if (! $mailer) {
+        if (!$mailer) {
             return 'Unable to load preview';
         }
 
@@ -142,7 +142,7 @@ class OrderStatus extends Component
 
     public function buildMailer($class)
     {
-        $mailer = new $class;
+        $mailer = new $class($this->order);
 
         return $mailer
             ->with('order', $this->order)
@@ -169,7 +169,7 @@ class OrderStatus extends Component
 
                 if (method_exists($mailable, 'render')) {
                 }
-                $storedPath = 'orders/activity/'.Str::random().'.html';
+                $storedPath = 'orders/activity/' . Str::random() . '.html';
 
                 $storedMailer = Storage::put(
                     $storedPath,


### PR DESCRIPTION
The Laravel docs suggest passing data to mailables via the constructor, currently the preview functionality in the hub doesn't do this when building the class and will therefore throw an exception. This PR simply passes the order into the constructor to fix this.