### PR TITLE
Don’t reset user on pricing manager

### DIFF
--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -241,7 +241,6 @@ class PricingManager implements PricingManagerInterface
     private function reset()
     {
         $this->qty = 1;
-        $this->user = null;
         $this->customerGroups = null;
     }
 }


### PR DESCRIPTION
We set the initial user on the pricing manage in the `__construct()` method, but then after we fetch the price we set the `user` to `null`. I think resetting the user is wrong as we're implying the user should be set when the class is instantiated and not just when the user is set explicitly. This PR removes the user reset.