### PR TITLE
Fix taxbreakdown casting

### DIFF
--- a/docs/core/extending/discounts.md
+++ b/docs/core/extending/discounts.md
@@ -36,7 +36,7 @@ class MyCustomDiscountType extends AbstractDiscountType
     /**
      * Called just before cart totals are calculated.
      *
-     * @return CartLine
+     * @return Cart
      */
     public function apply(Cart $cart): Cart
     {

--- a/docs/core/reference/discounts.md
+++ b/docs/core/reference/discounts.md
@@ -15,7 +15,7 @@ Lunar\Models\Discount
 | `id`         |                                                              |                                       |
 | `name`       | The given name for the discount                              |                                       |
 | `handle`     | The unique handle for the discount                           |                                       |
-| `type`       | The type of discount                                         | `Lunar\DiscountTypes\Coupon`          |
+| `type`       | The type of discount                                         | `Lunar\DiscountTypes\BuyXGetY`          |
 | `data`       | JSON                                                         | Any data to be used by the type class 
 | `starts_at`  | The datetime the discount starts (required)                  |
 | `ends_at`    | The datetime the discount expires, if `NULL` it won't expire |
@@ -94,31 +94,15 @@ Lunar\Models\DiscountPurchasable
 ### Adding your own Discount type
 
 ```php
-namespace App\Discounts;
+<?php
 
-use Lunar\Base\DataTransferObjects\CartDiscount;
-use Lunar\DataTypes\Price;
-use Lunar\Facades\Discounts;
-use Lunar\Models\CartLine;
-use Lunar\Models\Discount;
+namespace App\DiscountTypes;
 
-class CustomDiscount
+use Lunar\Models\Cart;
+use Lunar\DiscountTypes\AbstractDiscountType;
+
+class MyCustomDiscountType extends AbstractDiscountType
 {
-    protected Discount $discount;
-
-    /**
-     * Set the data for the discount to user.
-     *
-     * @param  array  $data
-     * @return self
-     */
-    public function with(Discount $discount): self
-    {
-        $this->discount = $discount;
-
-        return $this;
-    }
-
     /**
      * Return the name of the discount.
      *
@@ -126,46 +110,25 @@ class CustomDiscount
      */
     public function getName(): string
     {
-        return 'Custom Discount';
+        return 'Custom Discount Type';
     }
 
     /**
      * Called just before cart totals are calculated.
      *
-     * @return CartLine
+     * @return Cart
      */
-    public function execute(CartLine $cartLine): CartLine
+    public function apply(Cart $cart): Cart
     {
-        $data = $this->discount->data;
-
-        // Return the unaltered cart line back
-        if (! $conditionIsMet) {
-            return $cartLine;
-        }
-
-        $cartLine->discount = $this->discount;
-        
-        $discountTotal = $cartLine->unitPrice->value * $discountQuantity;
-
-        $cartLine->discountTotal = new Price(
-            $discountTotal,
-            $cartLine->cart->currency,
-            1
-        );
-
-        $cartLine->subTotalDiscounted = new Price(
-            $line->subTotal->value - $discountTotal,
-            $cart->currency,
-            1
-        );
+        // ...
+        return $cart;
     }
 }
-
 ```
 
 ```php
-Discounts::addType(
-    CustomDiscount::class
-);
+use Lunar\Facades\Discounts;
+
+Discounts::addType(MyCustomDiscountType::class);
 ```
 

--- a/docs/core/reference/orders.md
+++ b/docs/core/reference/orders.md
@@ -44,15 +44,14 @@ $order = \Lunar\Models\Order::create([/** .. */]);
 
 // Recommended way
 $order = Cart::first()->createOrder(
-    allowMultiple: false,
-    draftOrderId: null,
+    allowMultipleOrders: false,
+    orderIdToUpdate: null,
 );
 ```
 
-- `allowMultiple` - Generally carts will only have one draft order associated, however if you want to allow carts to
+- `allowMultipleOrders` - Generally carts will only have one draft order associated, however if you want to allow carts to
   have multiple, you can pass `true` here.
-- `draftOrderId` - If you want to be sure you're going to get the existing/correct order back, you can pass an ID of a
-  draft order here to use, note it does have to relate to this cart already.
+- `orderIdToUpdate` - You can optionally pass the ID of an order to update instead of attempting to create a new order, this must be a draft order i.e. a null `placed_at` and related to the cart.
 
 The underlying class for creating an order is `Lunar\Actions\Carts\CreateOrder`, you are free to override this in the
 config file `config/cart.php`

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -24,6 +24,27 @@ php artisan lunar:hub:install
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.6`.
 
+## [Unreleased]
+
+### High Impact
+
+#### TaxBreakdown casting has been refactored
+
+Database columns which have `tax_breakdown` casting will now actually cast back into the `TaxBreakdown` object. This means you will need to update any storefront views or API transformers to accomodate this.
+
+Before:
+
+```php
+@foreach ($order->tax_breakdown as $tax)
+    {{ $tax->total->formatted }}
+@endforeach
+```
+
+```php
+@foreach ($order->tax_breakdown->amounts as $tax)
+    {{ $tax->price->formatted }}
+@endforeach
+```
 ## 0.6
 
 ### High Impact

--- a/packages/admin/resources/views/partials/orders/lines.blade.php
+++ b/packages/admin/resources/views/partials/orders/lines.blade.php
@@ -189,7 +189,7 @@
                                     </td>
 
                                     <td class="p-2 text-gray-700 whitespace-nowrap">
-                                        {{ $tax->total->formatted }}
+                                        {{ $tax->price->formatted }}
                                     </td>
                                 </tr>
                             @endforeach

--- a/packages/admin/resources/views/partials/orders/lines.blade.php
+++ b/packages/admin/resources/views/partials/orders/lines.blade.php
@@ -182,7 +182,7 @@
                                 </td>
                             </tr>
 
-                            @foreach ($line->tax_breakdown as $tax)
+                            @foreach ($line->tax_breakdown->amounts as $tax)
                                 <tr class="divide-x divide-gray-200">
                                     <td class="p-2 font-medium text-gray-900 whitespace-nowrap">
                                         {{ $tax->description }}

--- a/packages/admin/resources/views/partials/orders/totals.blade.php
+++ b/packages/admin/resources/views/partials/orders/totals.blade.php
@@ -59,7 +59,7 @@
           <dd>{{ $order->shipping_total->formatted }}</dd>
         </div>
 
-        @foreach ($order->tax_breakdown as $tax)
+        @foreach ($order->tax_breakdown->amounts as $tax)
           <div class="flex justify-between">
             <dt>{{ $tax->description }}</dt>
             <dd>{{ $tax->total->formatted }}</dd>

--- a/packages/admin/resources/views/partials/orders/totals.blade.php
+++ b/packages/admin/resources/views/partials/orders/totals.blade.php
@@ -62,7 +62,7 @@
         @foreach ($order->tax_breakdown->amounts as $tax)
           <div class="flex justify-between">
             <dt>{{ $tax->description }}</dt>
-            <dd>{{ $tax->total->formatted }}</dd>
+            <dd>{{ $tax->price->formatted }}</dd>
           </div>
         @endforeach
 

--- a/packages/admin/src/Http/Livewire/Components/Orders/OrderStatus.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrderStatus.php
@@ -142,7 +142,7 @@ class OrderStatus extends Component
 
     public function buildMailer($class)
     {
-        $mailer = new $class;
+        $mailer = new $class($this->order);
 
         return $mailer
             ->with('order', $this->order)

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -476,7 +476,7 @@ abstract class AbstractProduct extends Component
                     return;
                 }
 
-                ProductAssociation::create([
+                ProductAssociation::firstOrCreate([
                     'product_target_id' => $assoc['inverse'] ? $this->product->id : $assoc['target_id'],
                     'product_parent_id' => $assoc['inverse'] ? $assoc['target_id'] : $this->product->id,
                     'type' => $assoc['type'],
@@ -502,6 +502,7 @@ abstract class AbstractProduct extends Component
             $this->variantsEnabled = $this->getVariantsCount() > 1;
 
             $this->syncAvailability();
+            $this->syncAssociations();
 
             $this->dispatchBrowserEvent('remove-images');
 

--- a/packages/admin/tests/Unit/Http/Livewire/Components/ActivityLogFeedTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/ActivityLogFeedTest.php
@@ -45,9 +45,6 @@ class ActivityLogFeedTest extends TestCase
             'meta' => [
                 'foo' => 'bar',
             ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         $staff = Staff::factory()->create([
@@ -69,9 +66,6 @@ class ActivityLogFeedTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Orders/OrderShowTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Orders/OrderShowTest.php
@@ -51,10 +51,7 @@ class OrderShowTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
+            ]
         ]);
 
         $this->assertCount(0, $order->lines);
@@ -85,9 +82,6 @@ class OrderShowTest extends TestCase
             'status' => 'awaiting-payment',
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 
@@ -136,9 +130,6 @@ class OrderShowTest extends TestCase
             'meta' => [
                 'foo' => 'bar',
             ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         $shipping = OrderAddress::factory()->create([
@@ -181,9 +172,6 @@ class OrderShowTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 
@@ -230,9 +218,6 @@ class OrderShowTest extends TestCase
             'meta' => [
                 'foo' => 'bar',
             ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         LiveWire::actingAs($staff, 'staff')
@@ -250,9 +235,6 @@ class OrderShowTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 
@@ -288,9 +270,6 @@ class OrderShowTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'placed_at' => null,
             'status' => 'awaiting-payment',
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         LiveWire::actingAs($staff, 'staff')

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Orders/OrderStatusTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Orders/OrderStatusTest.php
@@ -52,9 +52,6 @@ class OrderStatusTest extends TestCase
             'meta' => [
                 'foo' => 'bar',
             ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         $this->assertCount(0, $order->lines);
@@ -84,9 +81,6 @@ class OrderStatusTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 
@@ -127,9 +121,6 @@ class OrderStatusTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 
@@ -185,9 +176,6 @@ class OrderStatusTest extends TestCase
             'meta' => [
                 'foo' => 'bar',
             ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         $this->assertCount(0, $order->lines);
@@ -240,9 +228,6 @@ class OrderStatusTest extends TestCase
             'currency_code' => Currency::getDefault()->code,
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
             ],
         ]);
 

--- a/packages/core/database/factories/OrderFactory.php
+++ b/packages/core/database/factories/OrderFactory.php
@@ -3,6 +3,7 @@
 namespace Lunar\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Models\Channel;
 use Lunar\Models\Order;
 
@@ -24,13 +25,7 @@ class OrderFactory extends Factory
             'sub_total' => $total - $taxTotal,
             'discount_total' => 0,
             'shipping_total' => 0,
-            'tax_breakdown' => [
-                [
-                    'description' => 'VAT',
-                    'total' => 200,
-                    'percentage' => 20,
-                ],
-            ],
+            'tax_breakdown' => new TaxBreakdown(),
             'tax_total' => $taxTotal,
             'total' => $total,
             'notes' => null,

--- a/packages/core/database/factories/OrderLineFactory.php
+++ b/packages/core/database/factories/OrderLineFactory.php
@@ -4,6 +4,7 @@ namespace Lunar\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Models\Order;
 use Lunar\Models\OrderLine;
 use Lunar\Models\ProductVariant;
@@ -27,13 +28,7 @@ class OrderLineFactory extends Factory
             'quantity' => 1,
             'sub_total' => $this->faker->numberBetween(1, 5000),
             'discount_total' => $this->faker->numberBetween(1, 5000),
-            'tax_breakdown' => [
-                [
-                    'description' => 'VAT',
-                    'total' => 200,
-                    'percentage' => 20,
-                ],
-            ],
+            'tax_breakdown' => new TaxBreakdown,
             'tax_total' => $this->faker->numberBetween(1, 5000),
             'total' => $this->faker->numberBetween(1, 5000),
             'notes' => null,

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Lunar\Database\State;
+
+use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdownAmount;
+use Lunar\DataTypes\Price;
+use Lunar\Models\Order;
+use Lunar\Models\OrderLine;
+
+class ConvertTaxbreakdown
+{
+    public function prepare()
+    {
+        //
+    }
+
+    public function run()
+    {
+        Order::chunk(500, function ($orders) {
+           foreach ($orders as $order) {
+               if (is_a($order->tax_breakdown, TaxBreakdown::class)) {
+                   continue;
+               }
+               // Get the raw tax_breakdown
+               $breakdown = json_decode($order->getRawOriginal('tax_breakdown'), true);
+
+
+               $amounts = collect($breakdown)->map(function ($row) use ($order) {
+                  return new TaxBreakdownAmount(
+                      price: new Price($row['total'], $order->currency),
+                      identifier: $row['identifier'] ?? $row['description'],
+                      description: $row['description'],
+                      percentage: $row['percentage'],
+                  );
+               });
+
+               $order->updateQuietly([
+                   'tax_breakdown' => new \Lunar\Base\ValueObjects\Cart\TaxBreakdown($amounts),
+               ]);
+           }
+        });
+
+        OrderLine::chunk(500, function ($orderLines) {
+            foreach ($orderLines as $orderLine) {
+                // Get the raw tax_breakdown
+                $breakdown = json_decode($orderLine->getRawOriginal('tax_breakdown'), true);
+                
+                $amounts = collect($breakdown)->map(function ($row) use ($orderLine) {
+                    return new TaxBreakdownAmount(
+                        price: new Price($row['total'], $orderLine->order->currency),
+                        identifier: $row['identifier'] ?? $row['description'],
+                        description: $row['description'],
+                        percentage: $row['percentage'],
+                    );
+                });
+
+                $orderLine->updateQuietly([
+                    'tax_breakdown' => new \Lunar\Base\ValueObjects\Cart\TaxBreakdown($amounts),
+                ]);
+            }
+        });
+    }
+
+    protected function canRun()
+    {
+        return true;
+    }
+}

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -25,7 +25,6 @@ class ConvertTaxbreakdown
                // Get the raw tax_breakdown
                $breakdown = json_decode($order->getRawOriginal('tax_breakdown'), true);
 
-
                $amounts = collect($breakdown)->map(function ($row) use ($order) {
                   return new TaxBreakdownAmount(
                       price: new Price($row['total'], $order->currency),
@@ -43,6 +42,10 @@ class ConvertTaxbreakdown
 
         OrderLine::chunk(500, function ($orderLines) {
             foreach ($orderLines as $orderLine) {
+                if (is_a($orderLine->tax_breakdown, TaxBreakdown::class)) {
+                    continue;
+                }
+
                 // Get the raw tax_breakdown
                 $breakdown = json_decode($orderLine->getRawOriginal('tax_breakdown'), true);
                 

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Database\State;
 
+use Illuminate\Support\Facades\Schema;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Base\ValueObjects\Cart\TaxBreakdownAmount;
 use Lunar\DataTypes\Price;
@@ -17,6 +18,10 @@ class ConvertTaxbreakdown
 
     public function run()
     {
+        if (! $this->canRun()) {
+            return;
+        }
+
         Order::chunk(500, function ($orders) {
            foreach ($orders as $order) {
                if (is_a($order->tax_breakdown, TaxBreakdown::class)) {
@@ -67,6 +72,8 @@ class ConvertTaxbreakdown
 
     protected function canRun()
     {
-        return true;
+        $prefix = config('lunar.database.table_prefix');
+
+        return Schema::hasTable("{$prefix}orders") && Schema::hasTable("{$prefix}order_lines");
     }
 }

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -18,12 +18,10 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @return \Illuminate\Support\Collection
+     * @return \Lunar\Base\ValueObjects\Cart\TaxBreakdown
      */
     public function get($model, $key, $value, $attributes)
     {
-        $currency = $model->currency ?: Currency::getDefault();
-
         $breakdown = new \Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 
         $breakdown->amounts = collect(
@@ -36,8 +34,8 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
             return [
                 $key => new TaxBreakdownAmount(
                     price: new Price($amount->value, $currency),
-                    description: $amount->description,
                     identifier: $amount->identifier,
+                    description: $amount->description,
                     percentage: $amount->percentage,
                 ),
             ];
@@ -51,8 +49,9 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
-     * @param  \Lunar\DataTypes\Price  $value
+     * @param  Price  $value
      * @param  array  $attributes
+     * @throws \Exception
      * @return array
      */
     public function set($model, $key, $value, $attributes)
@@ -72,7 +71,6 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
                     'identifier' => $item->identifier,
                     'percentage' => $item->percentage,
                     'value' => $item->price->value,
-                    'formatted' => $item->price->formatted,
                     'currency_code' => $item->price->currency->code,
                 ];
             })->toJson(),
@@ -84,7 +82,7 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  string  $key
-     * @param  \Illuminate\Support\Collection  $value
+     * @param  mixed $value
      * @param  array<string, mixed>  $attributes
      */
     public function serialize($model, $key, $value, $attributes)

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -4,8 +4,10 @@ namespace Lunar\Base\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdownAmount;
 use Lunar\DataTypes\Price;
 use Lunar\Models\Currency;
+use Spatie\LaravelBlink\BlinkFacade;
 
 class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
 {
@@ -22,13 +24,27 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
     {
         $currency = $model->currency ?: Currency::getDefault();
 
-        return collect(
-            json_decode($value, false)
-        )->map(function ($rate) use ($currency) {
-            $rate->total = new Price($rate->total, $currency, 1);
+        $breakdown = new \Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 
-            return $rate;
+        $breakdown->amounts = collect(
+            json_decode($value, false)
+        )->mapWithKeys(function ($amount, $key) {
+
+            $currency = BlinkFacade::once("currency_{$amount->currency_code}", function () use ($amount) {
+              return Currency::whereCode($amount->currency_code)->first();
+            });
+
+            return [
+                $key => new TaxBreakdownAmount(
+                    price: new Price($amount->value, $currency),
+                    description: $amount->description,
+                    identifier: $amount->identifier,
+                    percentage: $amount->percentage,
+                ),
+            ];
         });
+
+        return $breakdown;
     }
 
     /**
@@ -42,16 +58,25 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        return [
-            $key => json_encode(collect($value)->map(function ($rate) {
-                if (! is_array($rate)) {
-                    if ($rate->total instanceof Price) {
-                        $rate->total = $rate->total->value;
-                    }
-                }
+        if ($value && ! is_a($value, \Lunar\Base\ValueObjects\Cart\TaxBreakdown::class)) {
+            throw new \Exception('Tax breakdown must be instance of Lunar\Base\ValueObjects\Cart\TaxBreakdown');
+        }
 
-                return $rate;
-            })->values()),
+        if (! $value) {
+            return [];
+        }
+
+        return [
+            $key => $value->amounts->map(function ($item) {
+                return [
+                    'description' => $item->description,
+                    'identifier' => $item->identifier,
+                    'percentage' => $item->percentage,
+                    'value' => $item->price->value,
+                    'formatted' => $item->price->formatted,
+                    'currency_code' => $item->price->currency->code,
+                ];
+            })->toJson(),
         ];
     }
 
@@ -65,18 +90,8 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
      */
     public function serialize($model, $key, $value, $attributes)
     {
-        return $value->map(function ($rate) {
-            $rate = is_array($rate) ? (object) $rate : $rate;
-
-            if ($rate->total instanceof Price) {
-                $rate->total = (object) [
-                    'value' => $rate->total->value,
-                    'formatted' => $rate->total->formatted,
-                    'currency' => $rate->total->currency->toArray(),
-                ];
-            }
-
-            return $rate;
-        })->toJson();
+        return json_encode(
+            $this->set($model, $key, $value, $attributes)
+        );
     }
 }

--- a/packages/core/src/Base/Casts/TaxBreakdown.php
+++ b/packages/core/src/Base/Casts/TaxBreakdown.php
@@ -28,8 +28,7 @@ class TaxBreakdown implements CastsAttributes, SerializesCastableAttributes
 
         $breakdown->amounts = collect(
             json_decode($value, false)
-        )->mapWithKeys(function ($amount, $key) {
-
+        )->mapWithKeys(function ($amount, $key) use ($model) {
             $currency = BlinkFacade::once("currency_{$amount->currency_code}", function () use ($amount) {
               return Currency::whereCode($amount->currency_code)->first();
             });

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -42,6 +42,7 @@ use Lunar\Console\Commands\Orders\SyncNewCustomerOrders;
 use Lunar\Console\Commands\ScoutIndexerCommand;
 use Lunar\Console\InstallLunar;
 use Lunar\Database\State\ConvertProductTypeAttributesToProducts;
+use Lunar\Database\State\ConvertTaxbreakdown;
 use Lunar\Database\State\EnsureBrandsAreUpgraded;
 use Lunar\Database\State\EnsureDefaultTaxClassExists;
 use Lunar\Database\State\EnsureMediaCollectionsAreRenamed;
@@ -246,6 +247,7 @@ class LunarServiceProvider extends ServiceProvider
             EnsureMediaCollectionsAreRenamed::class,
             PopulateProductOptionLabelWithName::class,
             MigrateCartOrderRelationship::class,
+            ConvertTaxbreakdown::class,
         ];
 
         foreach ($states as $state) {

--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -149,8 +149,8 @@ class DiscountManager implements DiscountManagerInterface
                 }
             )->when(
                 $cart?->coupon_code,
-                fn ($query, $value) => $query->where('coupon', '=', $value)->orWhereNull('coupon'),
-                fn ($query, $value) => $query->whereNull('coupon')
+                fn ($query, $value) => $query->where('coupon', '=', $value)->orWhere(fn ($query) => $query->whereNull('coupon')->orWhere('coupon', '')),
+                fn ($query, $value) => $query->whereNull('coupon')->orWhere('coupon', '')
             )->orderBy('priority', 'desc')
             ->orderBy('id')
             ->get();

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -133,7 +133,7 @@ class Cart extends BaseModel
      *
      * @var null|Collection<TaxBreakdown>
      */
-    public ?Collection $taxBreakdown = null;
+    public ?TaxBreakdown $taxBreakdown = null;
 
     /**
      * The cart-level promotions.

--- a/packages/core/src/Models/Tag.php
+++ b/packages/core/src/Models/Tag.php
@@ -34,8 +34,9 @@ class Tag extends BaseModel
      */
     protected $guarded = [];
 
-    public function taggables()
+    public function taggable()
     {
         return $this->morphTo();
     }
+    
 }

--- a/packages/core/src/Pipelines/Order/Creation/CreateOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateOrderLines.php
@@ -40,14 +40,7 @@ class CreateOrderLines
                 'quantity' => $cartLine->quantity,
                 'sub_total' => $cartLine->subTotal->value,
                 'discount_total' => $cartLine->discountTotal?->value,
-                'tax_breakdown' => $cartLine->taxBreakdown->amounts->map(function ($amount) {
-                    return [
-                        'description' => $amount->description,
-                        'identifier' => $amount->identifier,
-                        'percentage' => $amount->percentage,
-                        'total' => $amount->price->value,
-                    ];
-                })->values(),
+                'tax_breakdown' => $cartLine->taxBreakdown,
                 'tax_total' => $cartLine->taxAmount->value,
                 'total' => $cartLine->total->value,
                 'notes' => null,

--- a/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
@@ -39,14 +39,7 @@ class CreateShippingLine
                 'quantity' => 1,
                 'sub_total' => $shippingAddress->shippingSubTotal->value,
                 'discount_total' => $shippingAddress->shippingSubTotal->discountTotal?->value ?: 0,
-                'tax_breakdown' => $shippingAddress->taxBreakdown->amounts->map(function ($amount) {
-                    return [
-                        'description' => $amount->description,
-                        'identifier' => $amount->identifier,
-                        'percentage' => $amount->percentage,
-                        'total' => $amount->price->value,
-                    ];
-                })->values(),
+                'tax_breakdown' => $shippingAddress->taxBreakdown,
                 'tax_total' => $shippingAddress->shippingTaxTotal->value,
                 'total' => $shippingAddress->shippingTotal->value,
                 'notes' => null,

--- a/packages/core/src/Pipelines/Order/Creation/FillOrderFromCart.php
+++ b/packages/core/src/Pipelines/Order/Creation/FillOrderFromCart.php
@@ -29,14 +29,7 @@ class FillOrderFromCart
             'discount_breakdown' => [],
             'shipping_total' => $cart->shippingTotal?->value ?: 0,
             'shipping_breakdown' => $cart->shippingBreakdown,
-            'tax_breakdown' => $cart->taxBreakdown->map(function ($tax) {
-                return [
-                    'description' => $tax['description'],
-                    'identifier' => $tax['identifier'],
-                    'percentage' => $tax['amounts']->min('percentage'),
-                    'total' => $tax['total']->value,
-                ];
-            })->values(),
+            'tax_breakdown' => $cart->taxBreakdown,
             'tax_total' => $cart->taxTotal->value,
             'currency_code' => $cart->currency->code,
             'exchange_rate' => $cart->currency->exchange_rate,

--- a/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
@@ -58,7 +58,10 @@ class CreateOrderTest extends TestCase
         (new CreateOrder)->execute($cart);
     }
 
-    /** @test  */
+    /**
+     * @test
+     * @group thisone
+     */
     public function can_create_order_if_multiple_enabled()
     {
         TaxClass::factory()->create([
@@ -122,7 +125,10 @@ class CreateOrderTest extends TestCase
         $this->assertTrue($orderA->updated_at->eq($updatedAt));
     }
 
-    /** @test */
+    /**
+     * @test
+     *  @group noonoo
+     */
     public function can_create_order()
     {
         CustomerGroup::factory()->create([
@@ -208,14 +214,16 @@ class CreateOrderTest extends TestCase
 
         $order = $cart->createOrder();
 
-        $breakdown = $cart->taxBreakdown->map(function ($tax) {
-            return [
-                'description' => $tax['description'],
-                'identifier' => $tax['identifier'],
-                'percentage' => $tax['amounts']->min('percentage'),
-                'total' => $tax['total']->value,
-            ];
-        })->values();
+        $breakdown = $cart->taxBreakdown->amounts->mapWithKeys(function ($tax, $key) {
+            return [$key => [
+                'description' => $tax->description,
+                'identifier' => $tax->identifier,
+                'percentage' => $tax->percentage,
+                'value' => $tax->price->value,
+                'formatted' => $tax->price->formatted,
+                'currency_code' => $tax->price->currency->code,
+            ]];
+        });
 
         $datacheck = [
             'user_id' => $cart->user_id,
@@ -716,14 +724,16 @@ class CreateOrderTest extends TestCase
 
         $order = $cart->createOrder();
 
-        $breakdown = $cart->taxBreakdown->map(function ($tax) {
-            return [
-                'description' => $tax['description'],
-                'identifier' => $tax['identifier'],
-                'percentage' => $tax['amounts']->min('percentage'),
-                'total' => $tax['total']->value,
-            ];
-        })->values();
+        $breakdown = $cart->taxBreakdown->amounts->mapWithKeys(function ($tax, $key) {
+            return [$key => [
+                'description' => $tax->description,
+                'identifier' => $tax->identifier,
+                'percentage' => $tax->percentage,
+                'value' => $tax->price->value,
+                'formatted' => $tax->price->formatted,
+                'currency_code' => $tax->price->currency->code,
+            ]];
+        });
 
         $datacheck = [
             'user_id' => $cart->user_id,

--- a/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
@@ -214,7 +214,6 @@ class CreateOrderTest extends TestCase
                 'identifier' => $tax->identifier,
                 'percentage' => $tax->percentage,
                 'value' => $tax->price->value,
-                'formatted' => $tax->price->formatted,
                 'currency_code' => $tax->price->currency->code,
             ]];
         });
@@ -724,7 +723,6 @@ class CreateOrderTest extends TestCase
                 'identifier' => $tax->identifier,
                 'percentage' => $tax->percentage,
                 'value' => $tax->price->value,
-                'formatted' => $tax->price->formatted,
                 'currency_code' => $tax->price->currency->code,
             ]];
         });

--- a/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CreateOrderTest.php
@@ -58,10 +58,7 @@ class CreateOrderTest extends TestCase
         (new CreateOrder)->execute($cart);
     }
 
-    /**
-     * @test
-     * @group thisone
-     */
+    /** @test */
     public function can_create_order_if_multiple_enabled()
     {
         TaxClass::factory()->create([
@@ -125,10 +122,7 @@ class CreateOrderTest extends TestCase
         $this->assertTrue($orderA->updated_at->eq($updatedAt));
     }
 
-    /**
-     * @test
-     *  @group noonoo
-     */
+    /** @test */
     public function can_create_order()
     {
         CustomerGroup::factory()->create([

--- a/packages/core/tests/Unit/Base/Casts/TaxBreakdownTest.php
+++ b/packages/core/tests/Unit/Base/Casts/TaxBreakdownTest.php
@@ -3,9 +3,12 @@
 namespace Lunar\Tests\Unit\Base\Casts;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Lunar\Base\Casts\TaxBreakdown;
-use Lunar\Models\CartLine;
+use Lunar\Base\Casts\TaxBreakdown as TaxBreakdownCasts;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdownAmount;
+use Lunar\DataTypes\Price;
 use Lunar\Models\Currency;
+use Lunar\Models\Order;
 use Lunar\Tests\TestCase;
 
 /**
@@ -16,29 +19,52 @@ class TaxBreakdownTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function can_serialize_from_array()
+    public function can_set_from_value_object()
     {
-        $breakDown = new TaxBreakdown;
+        $currency = Currency::factory()->create();
+        $order = Order::factory()->create();
 
-        $result = $breakDown->serialize(
-            new CartLine,
-            'foo',
-            collect([
-                [
-                    'total' => [
-                        'value' => 123,
-                        'formatted' => '£1.23',
-                        'currency' => Currency::factory()->create()->toArray(),
-                    ],
-                ],
-            ]),
-            []
+        $taxBreakdownValueObject = new TaxBreakdown();
+
+        $taxBreakdownValueObject->addAmount(
+            new TaxBreakdownAmount(
+                price: new Price(100, $currency),
+                identifier: 'TAX_AMOUNT_1',
+                description: 'Test Tax Breakdown Amount',
+                percentage: 20
+            )
         );
 
-        $this->assertJson($result);
-        $json = json_decode($result);
+        $breakDown = new TaxBreakdownCasts;
 
-        $this->assertCount(1, $json);
-        $this->assertIsObject($json[0]);
+        $result = $breakDown->set($order, 'tax_breakdown', $taxBreakdownValueObject, []);
+
+        $this->assertArrayHasKey('tax_breakdown', $result);
+        $this->assertJson($result['tax_breakdown']);
+    }
+
+    /** @test */
+    public function can_cast_to_and_from_model()
+    {
+        $currency = Currency::factory()->create();
+        $order = Order::factory()->create();
+
+        $taxBreakdownValueObject = new TaxBreakdown();
+
+        $taxBreakdownValueObject->addAmount(
+            new TaxBreakdownAmount(
+                price: new Price(100, $currency),
+                identifier: 'TAX_AMOUNT_1',
+                description: 'Test Tax Breakdown Amount',
+                percentage: 20
+            )
+        );
+
+        $order->update([
+            'tax_breakdown' => $taxBreakdownValueObject,
+        ]);
+
+        $breakdown = $order->refresh()->tax_breakdown;
+        $this->assertInstanceOf(TaxBreakdown::class, $breakdown);
     }
 }

--- a/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
+++ b/packages/core/tests/Unit/DiscountTypes/AmountOffTest.php
@@ -940,11 +940,7 @@ class AmountOffTest extends TestCase
         $this->assertEquals(2000, $cart->subTotal->value);
     }
 
-    /**
-     * @test
-     *
-     * @group thisone
-     */
+    /** @test */
     public function can_apply_discount_with_min_spend()
     {
         $currency = Currency::getDefault();

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -487,7 +487,7 @@ class CartTest extends TestCase
         $this->assertEquals('$0.015800', $cart->lines[1]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6, false));
         $this->assertEquals(103, $cart->subTotal->value);
         $this->assertEquals(124, $cart->total->value);
-        $this->assertCount(2, $cart->taxBreakdown);
+        $this->assertCount(2, $cart->taxBreakdown->amounts);
     }
 
     /** @test */
@@ -559,7 +559,7 @@ class CartTest extends TestCase
         $this->assertEquals('$0.015800', $cart->lines[1]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6, false));
         $this->assertEquals(103, $cart->subTotal->value);
         $this->assertEquals(103, $cart->total->value);
-        $this->assertCount(2, $cart->taxBreakdown);
+        $this->assertCount(2, $cart->taxBreakdown->amounts);
     }
 
     /**

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
 use Lunar\Base\ValueObjects\Cart\ShippingBreakdownItem;
+use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\DataTypes\Price;
 use Lunar\Models\Cart;
 use Lunar\Models\Currency;
@@ -85,13 +86,10 @@ class OrderTest extends TestCase
             'meta' => [
                 'foo' => 'bar',
             ],
-            'tax_breakdown' => [
-                ['name' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
         ]);
 
         $this->assertIsObject($order->meta);
-        $this->assertIsIterable($order->tax_breakdown);
+        $this->assertInstanceOf(TaxBreakdown::class, $order->tax_breakdown);
         $this->assertInstanceOf(DateTime::class, $order->placed_at);
     }
 
@@ -107,10 +105,7 @@ class OrderTest extends TestCase
             'placed_at' => now(),
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
+            ]
         ]);
 
         $this->assertCount(0, $order->lines);

--- a/packages/core/tests/Unit/Search/OrderIndexerTest.php
+++ b/packages/core/tests/Unit/Search/OrderIndexerTest.php
@@ -29,10 +29,7 @@ class OrderIndexerTest extends TestCase
             'placed_at' => now(),
             'meta' => [
                 'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['name' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
+            ]
         ]);
 
         $data = app(OrderIndexer::class)->toSearchableArray($order);


### PR DESCRIPTION
Arguably this is an API change, however as it stands I think Taxbreakdown casting is a bit broken.

The current problem is when we save the data to the database, it doesn't have the same structure as the `TaxBreakdown` value object which it's meant to represent.

The other problem is when populating the `tax_breakdown` column we just map what we think the casting object is expecting and it will JSON encode it after some mapping. I think this is fairly inconsistent and not obvious to developers what they should be doing, should they want to populate a `tax_breakdown` column manually. This PR would enable a developer to simply pass a `Taxbreakdown` value object to any database column which uses the `Taxbreakdown` casting.

Furthermore this PR looks to make the `Taxbreakdown` casting actually cast back in the value object it represents so it's consistent. 