### PR TITLE
Load attribute's default_value in hub when no existing value exists

### DIFF
--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -66,7 +66,7 @@ trait WithAttributes
                 $existingData->first(fn ($value, $handle) => $handle == $attribute->handle)
                 : null;
 
-            $value = $data ? $data->getValue() : null;
+            $value = $data ? $data->getValue() : $attribute->default_value;
             // We need to make sure we give livewire all the languages if we're trying to translate.
             if ($attribute->type == TranslatedText::class) {
                 $value = $this->prepareTranslatedText($value);


### PR DESCRIPTION
This pull request makes use of the the `default_value` property of Attributes in the hub.

Currently, if an Attribute has a `default_value` set, when that Attribute is linked to a Model and displayed in the hub, the field displayed for that Attribute is blank on create and when no pre-existing value exists.

For example, if I have an Attribute Group called "Foo" that contains an Attribute call "Bar" that is an Attribute of type "Number" with a default value of 42, I will see the following on the Product Creation page (when that Attribute is linked to my Product Type):
![2023-10-13 at 15 34 01](https://github.com/lunarphp/lunar/assets/24831484/efff0c9d-5389-4880-bea5-ba11d6a0aed1)

With this pull request, when an Attribute has a `default_value` set, that value will be loaded into the field in the Hub. When applied to the previous example, this will now display the `default_value` (42, in this case) in the field:
![2023-10-13 at 15 35 55](https://github.com/lunarphp/lunar/assets/24831484/678c39f7-4771-496a-84fe-5236d330a8e3)

