### PR TITLE
Fix unit decimal calculation

### DIFF
--- a/packages/core/src/Pipelines/Cart/CalculateLines.php
+++ b/packages/core/src/Pipelines/Cart/CalculateLines.php
@@ -26,19 +26,16 @@ class CalculateLines
 
                     return $cartLine;
                 });
-
-            $purchasable = $cartLine->purchasable;
-            $unitQuantity = $purchasable->getUnitQuantity();
-
+            
             $unitPrice = $cartLine->unitPrice->unitDecimal(false) * $cart->currency->factor;
 
             $subTotal = (int) round($unitPrice * $cartLine->quantity, $cart->currency->decimal_places);
 
-            $cartLine->subTotal = new Price($subTotal, $cart->currency, $unitQuantity);
-            $cartLine->taxAmount = new Price(0, $cart->currency, $unitQuantity);
-            $cartLine->total = new Price($subTotal, $cart->currency, $unitQuantity);
-            $cartLine->subTotalDiscounted = new Price($subTotal, $cart->currency, $unitQuantity);
-            $cartLine->discountTotal = new Price(0, $cart->currency, $unitQuantity);
+            $cartLine->subTotal = new Price($subTotal, $cart->currency, 1);
+            $cartLine->taxAmount = new Price(0, $cart->currency, 1);
+            $cartLine->total = new Price($subTotal, $cart->currency, 1);
+            $cartLine->subTotalDiscounted = new Price($subTotal, $cart->currency, 1);
+            $cartLine->discountTotal = new Price(0, $cart->currency, 1);
         }
 
         return $next($cart);

--- a/packages/core/tests/Unit/Pipelines/Cart/CalculateLinesTest.php
+++ b/packages/core/tests/Unit/Pipelines/Cart/CalculateLinesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Lunar\Tests\Unit\Pipelines\Cart;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Models\Cart;
+use Lunar\Models\Currency;
+use Lunar\Models\Price;
+use Lunar\Models\ProductVariant;
+use Lunar\Pipelines\Cart\CalculateLines;
+use Lunar\Tests\TestCase;
+
+/**
+ * @group lunar.carts.pipelines
+ */
+class CalculateLinesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     * @dataProvider providePurchasableData
+     */
+    public function can_calculate_lines($expectedUnitPrice, $incomingUnitPrice, $unitQuantity)
+    {
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $purchasable = ProductVariant::factory()->create([
+            'unit_quantity' => $unitQuantity,
+        ]);
+
+        Price::factory()->create([
+            'price' => $incomingUnitPrice,
+            'tier' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => get_class($purchasable),
+            'priceable_id' => $purchasable->id,
+        ]);
+
+        $cart->lines()->create([
+            'purchasable_type' => get_class($purchasable),
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 1,
+        ]);
+
+
+        $cart = app(CalculateLines::class)->handle($cart, function ($cart) {
+            return $cart;
+        });
+
+        $cartLine = $cart->lines->first();
+
+        $this->assertEquals($cartLine->subTotal->unitDecimal, $expectedUnitPrice);
+    }
+
+    public function providePurchasableData()
+    {
+        return [
+            'purchasable with 1 unit quantity' => [
+                '1.00',
+                '100',
+                '1',
+            ],
+            'purchasable with 10 unit quantity' => [
+                '0.10',
+                '100',
+                '10',
+            ],
+            'purchasable with 100 unit quantity' => [
+                '0.01',
+                '100',
+                '100',
+            ],
+            'another purchasable with 100 unit quantity' => [
+                '0.55',
+                '5503',
+                '100',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Currently when calculating the cart lines via the pipelines, we're getting the unit cost based on the unit quantity but then also applying the same unit quantity to the cart line, even though it's already been considered. The result is if a purchasable has a unit quantity over 1 it's being doubled e.g.

```php
ProductVariant::create([
    // ...
    'unit_quantity' => 100,
]);

$price = Price::create([
   'price' => 5503
]);

$price->price->unitDecimal; // 0.55

// After $cart->calculate();

$cartLine->subTotal->unitDecimal; // 0.01
```

This PR sets the `unitQuantity` to `1` on the `$cartLine` price data types, as the unit quantity has already been factored in.

