### PR TITLE
Feat - Dummy addresses

### DIFF
--- a/docs/core/reference/carts.md
+++ b/docs/core/reference/carts.md
@@ -376,6 +376,16 @@ $cart->shippingAddress;
 $cart->billingAddress;
 ```
 
+In addition to this, you can also set dummy addresses for either shipping or billing. These can be useful if you need an address for things like calculating shipping costs, before the user has got to the checkout. Dummy addresses won't have any effect on the users checkout address and also won't be copied across when an order is created. They are completely optional.
+
+```php
+$cart->setBillingAddress([/* ... */], dummy: true);
+$cart->setShippingAddress([/* ... */], dummy: true);
+
+$cart->dummyBillingAddress;
+$cart->dummyShippingAddress;
+```
+
 ## Handling User Login
 
 When a user logs in, you will likely want to check if they have a cart

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -45,6 +45,22 @@ Before:
     {{ $tax->price->formatted }}
 @endforeach
 ```
+
+### Medium Impact
+
+The `setBillingAddress` or `setShippingAddress` methods on a cart have been changed, if you have used `$refresh` parameter you will need to update as follows:
+
+```php
+// Old
+$cart->setBillingAddress([/* .. */], true);
+// New
+$cart->setBillingAddress([/* .. */], false, true);
+// Or use named parameters
+$cart->setBillingAddress([/* .. */], refresh: true);
+```
+
+The same applies to the `setShippingAddress` and `addAddress` method.
+
 ## 0.6
 
 ### High Impact

--- a/packages/core/database/migrations/2023_10_24_100000_add_dummy_column_to_cart_addresses_table.php
+++ b/packages/core/database/migrations/2023_10_24_100000_add_dummy_column_to_cart_addresses_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class AddDummyColumnToCartAddressesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'cart_addresses', function (Blueprint $table) {
+            $table->boolean('dummy')->after('shipping_option')->default(false)->index();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'cart_addresses', function ($table) {
+            $table->dropColumn('dummy');
+        });
+    }
+}

--- a/packages/core/src/Actions/Carts/AddAddress.php
+++ b/packages/core/src/Actions/Carts/AddAddress.php
@@ -37,7 +37,8 @@ class AddAddress extends AbstractAction
     public function execute(
         Cart $cart,
         array|Addressable $address,
-        string $type
+        string $type,
+        bool $dummy = false
     ): self {
         // Do we already have an address for this type?
         $cart->addresses()->whereType($type)->delete();
@@ -54,6 +55,7 @@ class AddAddress extends AbstractAction
 
         // Force the type.
         $cartAddress->type = $type;
+        $cartAddress->dummy = $dummy;
         $cartAddress->cart_id = $cart->id;
         $cartAddress->save();
 

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -244,7 +244,17 @@ class Cart extends BaseModel
      */
     public function shippingAddress()
     {
-        return $this->hasOne(CartAddress::class, 'cart_id')->whereType('shipping');
+        return $this->hasOne(CartAddress::class, 'cart_id')->type('shipping')->real();
+    }
+
+    /**
+     * Return the dummy shipping address relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function dummyShippingAddress()
+    {
+        return $this->hasOne(CartAddress::class, 'cart_id')->type('shipping')->dummy();
     }
 
     /**
@@ -254,7 +264,17 @@ class Cart extends BaseModel
      */
     public function billingAddress()
     {
-        return $this->hasOne(CartAddress::class, 'cart_id')->whereType('billing');
+        return $this->hasOne(CartAddress::class, 'cart_id')->type('billing')->real();
+    }
+
+    /**
+     * Return the dummy billing address relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function dummyBillingAddress()
+    {
+        return $this->hasOne(CartAddress::class, 'cart_id')->type('billing')->dummy();
     }
 
     /**

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -519,7 +519,7 @@ class Cart extends BaseModel
     /**
      * Add an address to the Cart.
      */
-    public function addAddress(array|Addressable $address, string $type, bool $refresh = true): Cart
+    public function addAddress(array|Addressable $address, string $type, bool $dummy = false, bool $refresh = true): Cart
     {
         foreach (config('lunar.cart.validators.add_address', []) as $action) {
             app($action)->using(
@@ -531,7 +531,7 @@ class Cart extends BaseModel
 
         return app(
             config('lunar.cart.actions.add_address', AddAddress::class)
-        )->execute($this, $address, $type)
+        )->execute($this, $address, $type, $dummy)
             ->then(fn () => $refresh ? $this->refresh()->calculate() : $this);
     }
 
@@ -540,9 +540,9 @@ class Cart extends BaseModel
      *
      * @return \Lunar\Models\Cart
      */
-    public function setShippingAddress(array|Addressable $address)
+    public function setShippingAddress(array|Addressable $address, bool $dummy = false)
     {
-        return $this->addAddress($address, 'shipping');
+        return $this->addAddress($address, 'shipping', $dummy);
     }
 
     /**
@@ -550,9 +550,9 @@ class Cart extends BaseModel
      *
      * @return self
      */
-    public function setBillingAddress(array|Addressable $address)
+    public function setBillingAddress(array|Addressable $address, bool $dummy = false)
     {
-        return $this->addAddress($address, 'billing');
+        return $this->addAddress($address, 'billing', $dummy);
     }
 
     /**

--- a/packages/core/src/Models/CartAddress.php
+++ b/packages/core/src/Models/CartAddress.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\Addressable;
@@ -79,8 +80,6 @@ class CartAddress extends BaseModel implements Addressable
 
     /**
      * The tax breakdown.
-     *
-     * @var TaxBreakdown
      */
     public ?TaxBreakdown $taxBreakdown = null;
 
@@ -124,6 +123,7 @@ class CartAddress extends BaseModel implements Addressable
      * @var array
      */
     protected $casts = [
+        'dummy' => 'boolean',
         'meta' => AsArrayObject::class,
     ];
 
@@ -145,5 +145,20 @@ class CartAddress extends BaseModel implements Addressable
     public function country()
     {
         return $this->belongsTo(Country::class);
+    }
+
+    public function scopeDummy(Builder $builder)
+    {
+        return $builder->whereDummy(true);
+    }
+
+    public function scopeReal(Builder $builder)
+    {
+        return $builder->whereDummy(false);
+    }
+
+    public function scopeType(Builder $builder, $type)
+    {
+        return $builder->whereType($type);
     }
 }

--- a/packages/core/src/Pipelines/Cart/CalculateTax.php
+++ b/packages/core/src/Pipelines/Cart/CalculateTax.php
@@ -31,7 +31,7 @@ class CalculateTax
             }
 
             $taxBreakDownResult = Taxes::setShippingAddress($cart->shippingAddress)
-                ->setBillingAddress($cart->billingAddress)
+                ->setBillingAddress($cart->billingAddress ?: $cart->dummyBillingAddress)
                 ->setCurrency($cart->currency)
                 ->setPurchasable($cartLine->purchasable)
                 ->setCartLine($cartLine)

--- a/packages/core/tests/Unit/Actions/Carts/AddAddressTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/AddAddressTest.php
@@ -52,6 +52,30 @@ class AddAddressTest extends TestCase
     /**
      * @test
      */
+    public function can_add_dummy_address()
+    {
+        $address = Address::factory()->create();
+
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $action = new AddAddress;
+
+        $this->assertDatabaseMissing((new CartAddress)->getTable(), [
+            'cart_id' => $cart->id,
+        ]);
+
+        $action->execute($cart, $address, 'shipping', true);
+
+        $this->assertInstanceOf(CartAddress::class, $cart->refresh()->dummyShippingAddress);
+    }
+
+    /**
+     * @test
+     */
     public function can_add_address_from_array()
     {
         $address = Address::factory()->create();

--- a/packages/core/tests/Unit/Actions/Carts/AddAddressTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/AddAddressTest.php
@@ -76,6 +76,31 @@ class AddAddressTest extends TestCase
     /**
      * @test
      */
+    public function can_add_real_address_by_default()
+    {
+        $address = Address::factory()->create();
+
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $action = new AddAddress;
+
+        $this->assertDatabaseMissing((new CartAddress)->getTable(), [
+            'cart_id' => $cart->id,
+        ]);
+
+        $action->execute($cart, $address, 'shipping');
+
+        $this->assertNull($cart->refresh()->dummyShippingAddress);
+        $this->assertInstanceOf(CartAddress::class, $cart->refresh()->shippingAddress);
+    }
+
+    /**
+     * @test
+     */
     public function can_add_address_from_array()
     {
         $address = Address::factory()->create();


### PR DESCRIPTION
This PR looks to add the concept of dummy addresses to Carts. The idea is you can add these dummy addresses, whether shipping or billing, to a cart to aid with things like tax calculation, shipping estimates, etc without the user having to go to the checkout and enter an address.

If a user has gone to checkout and entered an address, then that will take priority, otherwise the system will fall back on to the dummy address if it exists. 