### PR TITLE
Tweak tax breakdown state update

### DIFF
--- a/packages/core/tests/Database/State/ConvertTaxBreakdownTest.php
+++ b/packages/core/tests/Database/State/ConvertTaxBreakdownTest.php
@@ -57,7 +57,7 @@ class ConvertTaxBreakdownTest extends TestCase
         (new ConvertTaxbreakdown)->run();
 
         $this->assertDatabaseHas('lunar_orders', [
-            'tax_breakdown' => '[{"description":"VAT","identifier":"tax_rate_1","percentage":20,"value":333,"currency_code":"GBP"}]'
+            'tax_breakdown' => '[{"description":"VAT","identifier":"tax_rate_1","percentage":20,"value":333,"currency_code":"GBP"}]',
         ]);
 
     }


### PR DESCRIPTION
There was an issue where the tax breakdown state update was only partially running or not at all when it should be. This PR looks to improve the state update by trying to fetch all relevant rows between orders and lines, not just base the update on whether the first record has been updated (which didn't help if the data had partially updated)

The other change is to move away from Eloquent and use the DB facade, mainly to help with larger datasets and memory usage.