### PR TITLE
Fixes storage disk when updating state

### DIFF
--- a/packages/core/database/state/EnsureBrandsAreUpgraded.php
+++ b/packages/core/database/state/EnsureBrandsAreUpgraded.php
@@ -33,7 +33,7 @@ class EnsureBrandsAreUpgraded
             $brands[$brand][] = $productId;
         }
 
-        Storage::put('tmp/state/legacy_brands.json', json_encode($brands));
+        Storage::disk('local')->put('tmp/state/legacy_brands.json', json_encode($brands));
     }
 
     public function run()
@@ -45,7 +45,7 @@ class EnsureBrandsAreUpgraded
         $brands = null;
 
         try {
-            $brands = Storage::get('tmp/state/legacy_brands.json');
+            $brands = Storage::disk('local')->get('tmp/state/legacy_brands.json');
         } catch (FileNotFoundException $e) {
         }
 


### PR DESCRIPTION
Instead of using the default driver, this updates the task to always use the local disk for storing tmp json files. One of the Storage already explicitly [uses the local disk](https://github.com/lunarphp/lunar/blob/0.6/packages/core/database/state/EnsureBrandsAreUpgraded.php#L66).

My default disk is an s3 disk. Instead of getting a `FileNotFoundException`, an `UnableToReadFile` exception is thrown instead when attempting to [get the file](https://github.com/lunarphp/lunar/blob/0.6/packages/core/database/state/EnsureBrandsAreUpgraded.php#L47-L49). We could additionally catch this exception (or any exception) but I think it's more reasonable to only use the local disk for storing the temporary state - especially considering there's already an explicit call to the local disk.  


