### PR TITLE
Tax breakdown state update should use the specified DB connection

### DIFF
--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -14,7 +14,7 @@ class ConvertTaxbreakdown
 
     public function run()
     {
-        DB::usingConnection(config('lunar.database.connection', DB::getDefaultConnection()), function () {
+        DB::usingConnection(config('lunar.database.connection') ?: DB::getDefaultConnection(), function () {
                 
             $prefix = config('lunar.database.table_prefix');
             $updateTime = now();

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -14,49 +14,20 @@ class ConvertTaxbreakdown
 
     public function run()
     {
-        $prefix = config('lunar.database.table_prefix');
-        $updateTime = now();
-
-        if ($this->canRunOnOrders()) {
-            DB::table("{$prefix}orders")
-                ->whereJsonContainsKey("{$prefix}orders.tax_breakdown->[0]->total")
-                ->orderBy('id')
-                ->chunk(500, function ($rows) use ($prefix, $updateTime) {
-                    foreach ($rows as $row) {
-                        $originalBreakdown = json_decode($row->tax_breakdown, true);
-
-                        DB::table("{$prefix}orders")->where('id', '=', $row->id)->update([
-                            'tax_breakdown' => collect($originalBreakdown)->map(function ($breakdown) use ($row) {
-                                return [
-                                    'description' => $breakdown['description'],
-                                    'identifier' => $breakdown['identifier'] ?? $breakdown['description'],
-                                    'percentage' => $breakdown['percentage'],
-                                    'value' => $breakdown['total'],
-                                    'currency_code' => $row->currency_code,
-                                ];
-                            })->toJson(),
-                            'updated_at' => $updateTime,
-                        ]);
-                    }
-                });
-        }
-
-        if ($this->canRunOnOrderLines()) {
-            DB::table("{$prefix}order_lines")
-                ->whereJsonContainsKey("{$prefix}order_lines.tax_breakdown->[0]->total")
-                ->orderBy("{$prefix}order_lines.id")
-                ->select(
-                    "{$prefix}order_lines.id",
-                    "{$prefix}order_lines.tax_breakdown",
-                    "{$prefix}orders.currency_code",
-                )
-                ->join("{$prefix}orders", "{$prefix}order_lines.order_id", '=', "{$prefix}orders.id")
-                ->chunk(500, function ($rows) use ($prefix, $updateTime) {
-                    DB::transaction(function () use ($prefix, $updateTime, $rows) {
+        DB::usingConnection(config('lunar.database.connection', DB::getDefaultConnection()), function () {
+                
+            $prefix = config('lunar.database.table_prefix');
+            $updateTime = now();
+    
+            if ($this->canRunOnOrders()) {
+                DB::table("{$prefix}orders")
+                    ->whereJsonContainsKey("${prefix}orders.tax_breakdown->[0]->total")
+                    ->orderBy('id')
+                    ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                         foreach ($rows as $row) {
                             $originalBreakdown = json_decode($row->tax_breakdown, true);
 
-                            DB::table("{$prefix}order_lines")->where('id', '=', $row->id)->update([
+                            DB::table("{$prefix}orders")->where('id', '=', $row->id)->update([
                                 'tax_breakdown' => collect($originalBreakdown)->map(function ($breakdown) use ($row) {
                                     return [
                                         'description' => $breakdown['description'],
@@ -70,8 +41,41 @@ class ConvertTaxbreakdown
                             ]);
                         }
                     });
-                });
-        }
+            }
+    
+            if ($this->canRunOnOrderLines()) {
+                DB::table("{$prefix}order_lines")
+                    ->whereJsonContainsKey("${prefix}order_lines.tax_breakdown->[0]->total")
+                    ->orderBy("${prefix}order_lines.id")
+                    ->select(
+                        "${prefix}order_lines.id",
+                        "${prefix}order_lines.tax_breakdown",
+                        "${prefix}orders.currency_code",
+                    )
+                    ->join("${prefix}orders", "${prefix}order_lines.order_id", '=', "${prefix}orders.id")
+                    ->chunk(500, function ($rows) use ($prefix, $updateTime) {
+                        DB::transaction(function () use ($prefix, $updateTime, $rows) {
+                            foreach ($rows as $row) {
+                                $originalBreakdown = json_decode($row->tax_breakdown, true);
+    
+                                DB::table("{$prefix}order_lines")->where('id', '=', $row->id)->update([
+                                    'tax_breakdown' => collect($originalBreakdown)->map(function ($breakdown) use ($row) {
+                                        return [
+                                            'description' => $breakdown['description'],
+                                            'identifier' => $breakdown['identifier'] ?? $breakdown['description'],
+                                            'percentage' => $breakdown['percentage'],
+                                            'value' => $breakdown['total'],
+                                            'currency_code' => $row->currency_code,
+                                        ];
+                                    })->toJson(),
+                                    'updated_at' => $updateTime,
+                                ]);
+                            }
+                        });
+                    });
+            }
+            
+        });
     }
 
     protected function canRunOnOrders()


### PR DESCRIPTION
When I updated to 0.7 the state update didnt run as it was assuming the default database connection, even though we allow this to be specified in a config.