### PR TITLE
Avoid deprecation notices on update to lunar 0.7

### DIFF
--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -21,7 +21,7 @@ class ConvertTaxbreakdown
     
             if ($this->canRunOnOrders()) {
                 DB::table("{$prefix}orders")
-                    ->whereJsonContainsKey("${prefix}orders.tax_breakdown->[0]->total")
+                    ->whereJsonContainsKey("{$prefix}orders.tax_breakdown->[0]->total")
                     ->orderBy('id')
                     ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                         foreach ($rows as $row) {
@@ -45,14 +45,14 @@ class ConvertTaxbreakdown
     
             if ($this->canRunOnOrderLines()) {
                 DB::table("{$prefix}order_lines")
-                    ->whereJsonContainsKey("${prefix}order_lines.tax_breakdown->[0]->total")
-                    ->orderBy("${prefix}order_lines.id")
+                    ->whereJsonContainsKey("{$prefix}order_lines.tax_breakdown->[0]->total")
+                    ->orderBy("{$prefix}order_lines.id")
                     ->select(
-                        "${prefix}order_lines.id",
-                        "${prefix}order_lines.tax_breakdown",
-                        "${prefix}orders.currency_code",
+                        "{$prefix}order_lines.id",
+                        "{$prefix}order_lines.tax_breakdown",
+                        "{$prefix}orders.currency_code",
                     )
-                    ->join("${prefix}orders", "${prefix}order_lines.order_id", '=', "${prefix}orders.id")
+                    ->join("{$prefix}orders", "{$prefix}order_lines.order_id", '=', "{$prefix}orders.id")
                     ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                         DB::transaction(function () use ($prefix, $updateTime, $rows) {
                             foreach ($rows as $row) {


### PR DESCRIPTION
${var} string interpolation is deprecated since php 8.2

https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation