### PR TITLE
Enhancement `HasDefaultRecord`-trait

### DIFF
--- a/packages/core/database/migrations/2023_10_10_100000_add_default_to_collection_groups_table.php
+++ b/packages/core/database/migrations/2023_10_10_100000_add_default_to_collection_groups_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class AddDefaultToCollectionGroupsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'collection_groups', function (Blueprint $table) {
+            $table->boolean('default')->default(false);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'collection_groups', function ($table) {
+            $table->dropColumn('default');
+        });
+    }
+}

--- a/packages/core/database/migrations/2023_10_10_100001_add_default_to_product_types_table.php
+++ b/packages/core/database/migrations/2023_10_10_100001_add_default_to_product_types_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class AddDefaultToProductTypesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'product_types', function (Blueprint $table) {
+            $table->boolean('default')->default(false);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'product_types', function ($table) {
+            $table->dropColumn('default');
+        });
+    }
+}

--- a/packages/core/src/Base/Traits/HasDefaultRecord.php
+++ b/packages/core/src/Base/Traits/HasDefaultRecord.php
@@ -2,18 +2,52 @@
 
 namespace Lunar\Base\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Spatie\LaravelBlink\BlinkFacade as Blink;
 
 trait HasDefaultRecord
 {
+
+    /** 
+     * Method when trait is booted
+     *
+     * @return void
+     */
+    public static function bootedHasDefaultRecord(): void
+    {
+        static::saved(function (Model $model) {
+            if ($model->isDirty('default') && $model->default) {
+                $model->newModelQuery()
+                    ->default()
+                    ->where($model->getKeyName(), '!=', $model->getKey())
+                    ->update([
+                        'default' => false
+                    ]);
+            }
+        });
+    }
+
+    /**
+     * Method when trait is initialized.
+     *
+     * @return void
+     */
+    public function initializeHasDefaultRecord(): void
+    {
+        $this->mergeCasts([
+            'default' => 'boolean',
+        ]);
+        $this->attributes['default'] = false;
+    }
+
     /**
      * Return the default scope.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function scopeDefault($query, $default = true)
+    public function scopeDefault($query, $default = true): void
     {
         $query->whereDefault($default);
     }
@@ -23,12 +57,19 @@ trait HasDefaultRecord
      *
      * @return self
      */
-    public static function getDefault()
+    public static function getDefault(): ?self
     {
         $key = 'lunar_default_'.Str::snake(self::class);
 
-        return Blink::once($key, function () {
-            return self::query()->default(true)->first();
+        $value = Blink::once($key, function () {
+            return self::query()->default()->first();
         });
+
+        // Don't cache if default model is present
+        if (is_null($value)) {
+            Blink::forget($key);
+        }
+
+        return $value;
     }
 }

--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -229,6 +229,7 @@ class InstallLunar extends Command
 
                 $type = ProductType::create([
                     'name' => 'Stock',
+                    'default' => true,
                 ]);
 
                 $type->mappedAttributes()->attach(

--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -118,6 +118,7 @@ class InstallLunar extends Command
                 CollectionGroup::create([
                     'name' => 'Main',
                     'handle' => 'main',
+                    'default' => true
                 ]);
             }
 

--- a/packages/core/src/Models/CollectionGroup.php
+++ b/packages/core/src/Models/CollectionGroup.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\BaseModel;
+use Lunar\Base\Traits\HasDefaultRecord;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\CollectionGroupFactory;
 
@@ -18,6 +19,7 @@ class CollectionGroup extends BaseModel
 {
     use HasFactory;
     use HasMacros;
+    use HasDefaultRecord;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/ProductType.php
+++ b/packages/core/src/Models/ProductType.php
@@ -5,6 +5,7 @@ namespace Lunar\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasAttributes;
+use Lunar\Base\Traits\HasDefaultRecord;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\ProductTypeFactory;
 
@@ -19,6 +20,7 @@ class ProductType extends BaseModel
     use HasAttributes;
     use HasFactory;
     use HasMacros;
+    use HasDefaultRecord;
 
     /**
      * Return a new factory instance for the model.

--- a/packages/core/src/Models/TaxClass.php
+++ b/packages/core/src/Models/TaxClass.php
@@ -21,25 +21,6 @@ class TaxClass extends BaseModel
     use HasFactory;
     use HasMacros;
 
-    public static function booted()
-    {
-        static::updated(function ($taxClass) {
-            if ($taxClass->default) {
-                TaxClass::whereDefault(true)->where('id', '!=', $taxClass->id)->update([
-                    'default' => false,
-                ]);
-            }
-        });
-
-        static::created(function ($taxClass) {
-            if ($taxClass->default) {
-                TaxClass::whereDefault(true)->where('id', '!=', $taxClass->id)->update([
-                    'default' => false,
-                ]);
-            }
-        });
-    }
-
     /**
      * Return a new factory instance for the model.
      */

--- a/packages/core/src/Models/Url.php
+++ b/packages/core/src/Models/Url.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\BaseModel;
+use Lunar\Base\Traits\HasDefaultRecord;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\UrlFactory;
 
@@ -21,6 +22,7 @@ class Url extends BaseModel
 {
     use HasFactory;
     use HasMacros;
+    use HasDefaultRecord;
 
     /**
      * Return a new factory instance for the model.
@@ -37,15 +39,6 @@ class Url extends BaseModel
      * @var array
      */
     protected $guarded = [];
-
-    /**
-     * Define attribute casting.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'default' => 'boolean',
-    ];
 
     /**
      * Return the element relationship.
@@ -65,16 +58,5 @@ class Url extends BaseModel
     public function language()
     {
         return $this->belongsTo(Language::class);
-    }
-
-    /**
-     * Return the query scope for default.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Illuminate\Database\Query\Builder
-     */
-    public function scopeDefault($query)
-    {
-        return $query->whereDefault(true);
     }
 }


### PR DESCRIPTION
- All models that use a `default` field/record, now use the `HasDefaultRecord` trait.
- Add `default` field/record and `HasDefaultRecord` trait to `ProductType` and `CollectionGroup` .
- Cache with `Blink::once()` in `HasDefaultRecord::getDefault()` only if query returns a model.
- Remove some redundant code.