### PR TITLE
Enhancement/translations

### DIFF
--- a/packages/admin/resources/views/partials/products/variants/basic-information.blade.php
+++ b/packages/admin/resources/views/partials/products/variants/basic-information.blade.php
@@ -9,8 +9,8 @@
       <div class="space-y-4">
 
         @foreach($variant->values as $value)
-          <x-hub::input.group :label="$value->option->name->en" for="sku">
-            {{ $value->name->en }}
+          <x-hub::input.group :label="$value->option->translate('name')" for="sku">
+            {{ $value->translate('name') }}
           </x-hub::input.group>
         @endforeach
       </div>

--- a/packages/core/src/Base/Casts/AsTranslated.php
+++ b/packages/core/src/Base/Casts/AsTranslated.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Lunar\Base\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Casts\Json;
+use Illuminate\Support\Collection;
+use Lunar\Models\Language;
+
+class AsTranslated implements Castable
+{
+    /**
+     * Get the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Illuminate\Support\Collection<array-key, mixed>, iterable>
+     */
+    public static function castUsing(array $arguments)
+    {
+        return new class($arguments) implements CastsAttributes
+        {
+            public function __construct(protected array $arguments)
+            {
+            }
+
+            public function get($model, $key, $value, $attributes)
+            {
+                $value = Json::decode($value);
+
+                if (is_array($value)) {
+                    return collect($value);
+                }
+
+                return $this->fromLocale($value);
+            }
+
+            public function set($model, $key, $value, $attributes)
+            {
+                if (is_array($value)) {
+                    $value = collect($value);
+                }
+
+                if (! $value instanceof Collection) {
+                    $value = $this->fromLocale($value);
+                }
+
+                return [$key => Json::encode($value)];
+            }
+
+            /**
+             * Create a collection with the default, first or current locale 
+             * as key with the given value
+             * 
+             * @param mixed $value
+             * @return \Illuminate\Support\Collection
+             */
+            private function fromLocale(mixed $value): Collection
+            {
+                $locale = Language::getDefault()?->code 
+                    ?? Language::first() 
+                    ?? app()->getLocale();
+                return collect([$locale => $value]);
+            }
+        };
+    }
+}

--- a/packages/core/src/Base/Casts/AsTranslated.php
+++ b/packages/core/src/Base/Casts/AsTranslated.php
@@ -4,7 +4,6 @@ namespace Lunar\Base\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Support\Collection;
 use Lunar\Models\Language;
 
@@ -26,7 +25,7 @@ class AsTranslated implements Castable
 
             public function get($model, $key, $value, $attributes)
             {
-                $value = Json::decode($value);
+                $value = json_decode($value, true);
 
                 if (is_array($value)) {
                     return collect($value);
@@ -45,7 +44,7 @@ class AsTranslated implements Castable
                     $value = $this->fromLocale($value);
                 }
 
-                return [$key => Json::encode($value)];
+                return [$key => json_encode($value)];
             }
 
             /**

--- a/packages/core/src/Models/Attribute.php
+++ b/packages/core/src/Models/Attribute.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasTranslations;
+use Lunar\Base\Casts\AsTranslated;
 use Lunar\Database\Factories\AttributeFactory;
 use Lunar\Facades\DB;
 
@@ -71,7 +72,7 @@ class Attribute extends BaseModel
      * @var array
      */
     protected $casts = [
-        'name' => AsCollection::class,
+        'name' => AsTranslated::class,
         'configuration' => AsCollection::class,
     ];
 

--- a/packages/core/src/Models/AttributeGroup.php
+++ b/packages/core/src/Models/AttributeGroup.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasTranslations;
+use Lunar\Base\Casts\AsTranslated;
 use Lunar\Database\Factories\AttributeGroupFactory;
 
 /**
@@ -46,7 +47,7 @@ class AttributeGroup extends BaseModel
      * @var array
      */
     protected $casts = [
-        'name' => AsCollection::class,
+        'name' => AsTranslated::class,
     ];
 
     /**

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -2,10 +2,9 @@
 
 namespace Lunar\Models;
 
-use Illuminate\Database\Eloquent\Casts\AsCollection;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunar\Base\BaseModel;
+use Lunar\Base\Casts\AsTranslated;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
 use Lunar\Base\Traits\HasTranslations;
@@ -36,8 +35,8 @@ class ProductOption extends BaseModel implements SpatieHasMedia
      * @var array
      */
     protected $casts = [
-        'name' => AsCollection::class,
-        'label' => AsCollection::class,
+        'name' => AsTranslated::class,
+        'label' => AsTranslated::class,
     ];
 
     /**
@@ -46,24 +45,6 @@ class ProductOption extends BaseModel implements SpatieHasMedia
     protected static function newFactory(): ProductOptionFactory
     {
         return ProductOptionFactory::new();
-    }
-
-    public function getNameAttribute($value)
-    {
-        return json_decode($value);
-    }
-
-    protected function setNameAttribute($value)
-    {
-        $this->attributes['name'] = json_encode($value);
-    }
-
-    protected function label(): Attribute
-    {
-        return Attribute::make(
-            get: fn (string $value) => json_decode($value),
-            set: fn ($value) => json_encode($value),
-        );
     }
 
     /**

--- a/packages/core/src/Models/ProductOptionValue.php
+++ b/packages/core/src/Models/ProductOptionValue.php
@@ -2,8 +2,8 @@
 
 namespace Lunar\Models;
 
-use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Lunar\Base\Casts\AsTranslated;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
@@ -32,7 +32,8 @@ class ProductOptionValue extends BaseModel implements SpatieHasMedia
      * @var array
      */
     protected $casts = [
-        'name' => AsCollection::class,
+        'name' => AsTranslated::class,
+        'label' => AsTranslated::class,
     ];
 
     /**
@@ -50,16 +51,6 @@ class ProductOptionValue extends BaseModel implements SpatieHasMedia
      * @var array
      */
     protected $guarded = [];
-
-    protected function setNameAttribute($value)
-    {
-        $this->attributes['name'] = json_encode($value);
-    }
-
-    public function getNameAttribute($value)
-    {
-        return json_decode($value);
-    }
 
     public function option()
     {

--- a/packages/core/tests/Unit/Search/ProductOptionIndexerTest.php
+++ b/packages/core/tests/Unit/Search/ProductOptionIndexerTest.php
@@ -21,8 +21,8 @@ class ProductOptionIndexerTest extends TestCase
         $productOption = ProductOption::factory()->create();
 
         $data = app(ProductOptionIndexer::class)->toSearchableArray($productOption);
-
-        $this->assertEquals($productOption->name->en, $data['name_en']);
-        $this->assertEquals($productOption->label->en, $data['label_en']);
+        
+        $this->assertEquals($productOption->translate('name', 'en'), $data['name_en']);
+        $this->assertEquals($productOption->translate('label', 'en'), $data['label_en']);
     }
 }


### PR DESCRIPTION
Commit 77673f0f4712d8fa70658fbebe0158feb3fb5773 adds two scopes `translation` and `attributeTranslation` to constraint queries on translated model attributes and lunar attributes/fields.

Commit 438f915b73e31c3b5bf86d7b421038c26a1a5943 adds a `AsTranslated` cast, applies it to all relevant models and refactors affected code.