### PR TITLE
Implement paratest for local testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "orchestra/testbench": "^7.0|^8.0",
     "phpunit/phpunit": "^9.5",
     "symplify/monorepo-builder": "^10.0",
-    "nunomaduro/larastan": "^2.0"
+    "nunomaduro/larastan": "^2.0",
+    "brianium/paratest": "^6.11"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
It will be nice to have "paratest" as dev dependency by default for local testing, even if it's not used with github workflows #1265.