### PR TITLE
Fix naming conflict of `ProductType` model for `mappedAttributes` and `attributables` relations

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeCreate.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeCreate.php
@@ -45,7 +45,7 @@ class ProductTypeCreate extends AbstractProductType
 
         $this->productType->save();
 
-        $this->productType->mappedAttributes()->sync(
+        $this->productType->attributables()->sync(
             array_merge(
                 $this->selectedProductAttributes->pluck('id')->toArray(),
                 $this->selectedVariantAttributes->pluck('id')->toArray()

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
@@ -16,11 +16,11 @@ class ProductTypeShow extends AbstractProductType
     {
         $systemProductAttributes = Attribute::system(Product::class)->get();
         $systemVariantAttribues = Attribute::system(ProductVariant::class)->get();
-        $this->selectedProductAttributes = $this->productType->mappedAttributes
+        $this->selectedProductAttributes = $this->productType->attributables
             ->filter(fn ($att) => $att->attribute_type == Product::class)
             ->merge($systemProductAttributes);
 
-        $this->selectedVariantAttributes = $this->productType->mappedAttributes
+        $this->selectedVariantAttributes = $this->productType->attributables
             ->filter(fn ($att) => $att->attribute_type == ProductVariant::class)
             ->merge($systemVariantAttribues);
     }
@@ -52,7 +52,7 @@ class ProductTypeShow extends AbstractProductType
 
         $this->productType->save();
 
-        $this->productType->mappedAttributes()->sync(
+        $this->productType->attributables()->sync(
             array_merge(
                 $this->selectedProductAttributes->pluck('id')->toArray(),
                 $this->selectedVariantAttributes->pluck('id')->toArray()

--- a/packages/admin/src/Tables/Builders/ProductTypesTableBuilder.php
+++ b/packages/admin/src/Tables/Builders/ProductTypesTableBuilder.php
@@ -14,7 +14,7 @@ class ProductTypesTableBuilder extends TableBuilder
      */
     public function getData(): iterable
     {
-        $query = ProductType::query()->withCount(['products', 'mappedAttributes']);
+        $query = ProductType::query()->withCount(['products', 'attributables']);
 
         if ($this->searchTerm) {
             $query->where('name', 'LIKE', '%'.$this->searchTerm.'%');

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Brands/BrandShowTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Brands/BrandShowTest.php
@@ -79,7 +79,7 @@ class BrandShowTest extends TestCase
 
         $brand = Brand::factory()->create();
 
-        $brand->mappedAttributes()->attach(Attribute::get());
+        $brand->mappedAttributes()->saveMany(Attribute::get());
 
         $component = LiveWire::actingAs($staff, 'staff')
             ->test(BrandShow::class, [

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Customers/CustomerShowTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Customers/CustomerShowTest.php
@@ -140,7 +140,7 @@ class CustomerShowTest extends TestCase
 
         $customer = Customer::factory()->create();
 
-        $customer->mappedAttributes()->attach(Attribute::get());
+        $customer->mappedAttributes()->saveMany(Attribute::get());
 
         $component = LiveWire::actingAs($staff, 'staff')
             ->test(CustomerShow::class, [

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -206,7 +206,7 @@ class ProductCreateTest extends TestCase
 
         $productType = ProductType::first();
 
-        $productType->mappedAttributes()->attach($attribute);
+        $productType->attributables()->attach($attribute);
 
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductCreate::class)
@@ -237,7 +237,7 @@ class ProductCreateTest extends TestCase
 
         $productType = ProductType::first();
 
-        $productType->mappedAttributes()->attach($attribute);
+        $productType->attributables()->attach($attribute);
 
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductCreate::class)
@@ -265,7 +265,7 @@ class ProductCreateTest extends TestCase
 
         $productType = ProductType::first();
 
-        $productType->mappedAttributes()->attach($attribute);
+        $productType->attributables()->attach($attribute);
 
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductCreate::class)
@@ -299,7 +299,7 @@ class ProductCreateTest extends TestCase
 
         $productType = ProductType::first();
 
-        $productType->mappedAttributes()->attach($attribute);
+        $productType->attributables()->attach($attribute);
 
         // it is not required for realsies
         LiveWire::actingAs($staff, 'staff')
@@ -343,7 +343,7 @@ class ProductCreateTest extends TestCase
 
         $productType = ProductType::first();
 
-        $productType->mappedAttributes()->attach($attribute);
+        $productType->attributables()->attach($attribute);
 
         // fail the required rule
         LiveWire::actingAs($staff, 'staff')
@@ -378,7 +378,7 @@ class ProductCreateTest extends TestCase
 
         $productType = ProductType::first();
 
-        $productType->mappedAttributes()->attach($attribute);
+        $productType->attributables()->attach($attribute);
 
         // fail the configuration rules
         LiveWire::actingAs($staff, 'staff')

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductShowTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductShowTest.php
@@ -272,7 +272,7 @@ class ProductShowTest extends TestCase
             ]);
         }
 
-        $product->productType->mappedAttributes()->attach(Attribute::get());
+        $product->productType->attributables()->attach(Attribute::get());
 
         $component = LiveWire::actingAs($staff, 'staff')
             ->test(ProductShow::class, [
@@ -542,7 +542,7 @@ class ProductShowTest extends TestCase
             ]);
         }
 
-        $product->productType->mappedAttributes()->attach(Attribute::get());
+        $product->productType->attributables()->attach(Attribute::get());
 
         $component = LiveWire::actingAs($staff, 'staff')
             ->test(ProductShow::class, [
@@ -605,7 +605,7 @@ class ProductShowTest extends TestCase
             ]);
         }
 
-        $product->productType->mappedAttributes()->attach(Attribute::get());
+        $product->productType->attributables()->attach(Attribute::get());
 
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductShow::class, [
@@ -669,7 +669,7 @@ class ProductShowTest extends TestCase
             ]);
         }
 
-        $product->productType->mappedAttributes()->attach(Attribute::get());
+        $product->productType->attributables()->attach(Attribute::get());
 
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductShow::class, [
@@ -733,7 +733,7 @@ class ProductShowTest extends TestCase
             ]);
         }
 
-        $product->productType->mappedAttributes()->attach(Attribute::get());
+        $product->productType->attributables()->attach(Attribute::get());
 
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductShow::class, [

--- a/packages/core/database/factories/ProductTypeFactory.php
+++ b/packages/core/database/factories/ProductTypeFactory.php
@@ -4,6 +4,7 @@ namespace Lunar\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Lunar\Models\ProductType;
+use Lunar\FieldTypes\Text;
 
 class ProductTypeFactory extends Factory
 {
@@ -13,6 +14,9 @@ class ProductTypeFactory extends Factory
     {
         return [
             'name' => $this->faker->name(),
+            'attribute_data' => collect([
+                'description' => new Text($this->faker->sentence),
+            ]),
         ];
     }
 }

--- a/packages/core/database/migrations/2023_11_30_000000_add_attribute_data_to_product_types_table.php
+++ b/packages/core/database/migrations/2023_11_30_000000_add_attribute_data_to_product_types_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table($this->prefix.'product_types', function (Blueprint $table) {
+            $table->attributeData();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table($this->prefix.'product_types', function (Blueprint $table) {
+            $table->dropColumn('attribute_data');
+        });
+    }
+};

--- a/packages/core/database/migrations/2023_11_30_000001_set_attribute_data_to_nullable_on_collections_table.php
+++ b/packages/core/database/migrations/2023_11_30_000001_set_attribute_data_to_nullable_on_collections_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table($this->prefix.'collections', function (Blueprint $table) {
+            $table->attributeData()->change();
+        });
+    }
+};

--- a/packages/core/database/migrations/2023_11_30_000002_set_attribute_data_to_nullable_on_products_table.php
+++ b/packages/core/database/migrations/2023_11_30_000002_set_attribute_data_to_nullable_on_products_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table($this->prefix.'products', function (Blueprint $table) {
+            $table->attributeData()->change();
+        });
+    }
+};

--- a/packages/core/src/Base/Traits/HasAttributes.php
+++ b/packages/core/src/Base/Traits/HasAttributes.php
@@ -3,10 +3,23 @@
 namespace Lunar\Base\Traits;
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Models\Attribute;
 
 trait HasAttributes
 {
+    /**
+     * Method when trait is initialized.
+     *
+     * @return void
+     */
+    public function initializeHasAttributes(): void
+    {
+        $this->mergeCasts([
+            'attribute_data' => AsAttributeData::class,
+        ]);
+    }
+
     /**
      * Getter to return the class name used with attribute relationships.
      *

--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -231,7 +231,7 @@ class InstallLunar extends Command
                     'name' => 'Stock',
                 ]);
 
-                $type->mappedAttributes()->attach(
+                $type->attributables()->attach(
                     Attribute::whereAttributeType(Product::class)->get()->pluck('id')
                 );
             }

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -304,6 +304,11 @@ class LunarServiceProvider extends ServiceProvider
             }
         });
 
+        Blueprint::macro('attributeData', function () {
+            /** @var Blueprint $this */
+            return $this->json('attribute_data');
+        });
+
         Blueprint::macro('userForeignKey', function ($field_name = 'user_id', $nullable = false) {
             /** @var Blueprint $this */
             $userModel = config('auth.providers.users.model');

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -306,7 +306,7 @@ class LunarServiceProvider extends ServiceProvider
 
         Blueprint::macro('attributeData', function () {
             /** @var Blueprint $this */
-            return $this->json('attribute_data');
+            return $this->json('attribute_data')->nullable();
         });
 
         Blueprint::macro('userForeignKey', function ($field_name = 'user_id', $nullable = false) {

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -4,7 +4,6 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasAttributes;
@@ -53,20 +52,6 @@ class Brand extends BaseModel implements SpatieHasMedia
     protected static function newFactory(): BrandFactory
     {
         return BrandFactory::new();
-    }
-
-    /**
-     * Get the mapped attributes relation.
-     */
-    public function mappedAttributes(): MorphToMany
-    {
-        $prefix = config('lunar.database.table_prefix');
-
-        return $this->morphToMany(
-            Attribute::class,
-            'attributable',
-            "{$prefix}attributables"
-        )->withTimestamps();
     }
 
     /**

--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasAttributes;
@@ -103,17 +102,4 @@ class Customer extends BaseModel
         return $this->hasMany(Order::class);
     }
 
-    /**
-     * Get the mapped attributes relation.
-     */
-    public function mappedAttributes(): MorphToMany
-    {
-        $prefix = config('lunar.database.table_prefix');
-
-        return $this->morphToMany(
-            Attribute::class,
-            'attributable',
-            "{$prefix}attributables"
-        )->withTimestamps();
-    }
 }

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Lunar\Base\BaseModel;
-use Lunar\Base\Casts\AsAttributeData;
+use Lunar\Base\Traits\HasAttributes;
 use Lunar\Base\Traits\HasChannels;
 use Lunar\Base\Traits\HasCustomerGroups;
 use Lunar\Base\Traits\HasMacros;
@@ -39,6 +39,7 @@ use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
  */
 class Product extends BaseModel implements SpatieHasMedia
 {
+    use HasAttributes;
     use HasChannels;
     use HasCustomerGroups;
     use HasFactory;
@@ -73,20 +74,12 @@ class Product extends BaseModel implements SpatieHasMedia
     ];
 
     /**
-     * Define which attributes should be cast.
-     *
-     * @var array
+     * Returns the attributes to be stored against this model
+     * restricted by the assigned `ProductType`.
      */
-    protected $casts = [
-        'attribute_data' => AsAttributeData::class,
-    ];
-
-    /**
-     * Returns the attributes to be stored against this model.
-     */
-    public function mappedAttributes(): Collection
+    public function attributables(): Collection
     {
-        return $this->productType->mappedAttributes;
+        return $this->productType->attributables;
     }
 
     /**

--- a/packages/core/src/Models/ProductType.php
+++ b/packages/core/src/Models/ProductType.php
@@ -39,9 +39,9 @@ class ProductType extends BaseModel
     protected $guarded = [];
 
     /**
-     * Get the mapped attributes relation.
+     * Get the attributables relation.
      */
-    public function mappedAttributes(): MorphToMany
+    public function attributables(): MorphToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -57,7 +57,7 @@ class ProductType extends BaseModel
      */
     public function productAttributes(): MorphToMany
     {
-        return $this->mappedAttributes()->whereAttributeType(Product::class);
+        return $this->attributables()->whereAttributeType(Product::class);
     }
 
     /**
@@ -65,7 +65,7 @@ class ProductType extends BaseModel
      */
     public function variantAttributes(): MorphToMany
     {
-        return $this->mappedAttributes()->whereAttributeType(ProductVariant::class);
+        return $this->attributables()->whereAttributeType(ProductVariant::class);
     }
 
     /**

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
 use Lunar\Base\BaseModel;
-use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Purchasable;
+use Lunar\Base\Traits\HasAttributes;
 use Lunar\Base\Traits\HasDimensions;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasPrices;
@@ -49,6 +49,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
  */
 class ProductVariant extends BaseModel implements Purchasable
 {
+    use HasAttributes;
     use HasDimensions;
     use HasFactory;
     use HasMacros;
@@ -68,7 +69,6 @@ class ProductVariant extends BaseModel implements Purchasable
      */
     protected $casts = [
         'requires_shipping' => 'bool',
-        'attribute_data' => AsAttributeData::class,
     ];
 
     /**

--- a/packages/core/tests/Unit/Models/ProductTypeTest.php
+++ b/packages/core/tests/Unit/Models/ProductTypeTest.php
@@ -3,6 +3,7 @@
 namespace Lunar\Tests\Unit\Models;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\FieldTypes\Text;
 use Lunar\Models\Attribute;
 use Lunar\Models\AttributeGroup;
 use Lunar\Models\ProductType;
@@ -15,12 +16,10 @@ class ProductTypeTest extends TestCase
     /** @test */
     public function can_make_a_product_type()
     {
-        
-        $productType = ProductType::factory()->create([
-            'name' => 'Bob',
-        ]);
+        $productType = ProductType::factory()->create();
 
-        $this->assertEquals('Bob', $productType->name);
+        $this->assertModelExists($productType);
+        $this->assertInstanceOf(Text::class, $productType->attribute_data['description']);
     }
 
     /** @test */

--- a/packages/core/tests/Unit/Models/ProductTypeTest.php
+++ b/packages/core/tests/Unit/Models/ProductTypeTest.php
@@ -15,15 +15,49 @@ class ProductTypeTest extends TestCase
     /** @test */
     public function can_make_a_product_type()
     {
-        $productType = ProductType::factory()
-            ->has(
-                Attribute::factory()->for(AttributeGroup::factory())->count(1),
-                'attributables',
-            )
-            ->create([
-                'name' => 'Bob',
-            ]);
+        
+        $productType = ProductType::factory()->create([
+            'name' => 'Bob',
+        ]);
 
         $this->assertEquals('Bob', $productType->name);
+    }
+
+    /** @test */
+    public function product_type_can_have_mapped_attributes()
+    {   
+        $attributes = Attribute::factory()
+            ->has(AttributeGroup::factory()->state([
+                'attributable_type' => ProductType::class
+            ]), 'attributeGroup')
+            ->count(1)
+            ->create([
+                'attribute_type' => ProductType::class
+            ]);
+
+        $productType = ProductType::factory()->create();
+        $productType->mappedAttributes()->saveMany($attributes);
+
+        $this->assertEquals(
+            $productType->mappedAttributes->pluck('id'), 
+            $attributes->pluck('id')
+        );
+    }
+
+    /** @test */
+    public function product_type_can_have_attributables()
+    {   
+        $attributes = Attribute::factory()
+            ->has(AttributeGroup::factory(), 'attributeGroup')
+            ->count(1)
+            ->create();
+
+        $productType = ProductType::factory()->create();
+        $productType->attributables()->sync($attributes);
+
+        $this->assertEquals(
+            $productType->attributables->pluck('id'), 
+            $attributes->pluck('id')
+        );
     }
 }

--- a/packages/core/tests/Unit/Models/ProductTypeTest.php
+++ b/packages/core/tests/Unit/Models/ProductTypeTest.php
@@ -18,7 +18,7 @@ class ProductTypeTest extends TestCase
         $productType = ProductType::factory()
             ->has(
                 Attribute::factory()->for(AttributeGroup::factory())->count(1),
-                'mappedAttributes',
+                'attributables',
             )
             ->create([
                 'name' => 'Bob',


### PR DESCRIPTION
1. Fixes the naming conflict of `ProductType` model for `mappedAttributes` and `attributables` relation and removes some code redundancy by the use of the `HasAttributes` trait. 
2. Extends `ProductTypeTest` to check `attribute_data` cast,  `mappedAttributes` and `attributables` relations.
3. Also includes some rework of the Attributes reference.

See:  #1346 
