### PR TITLE
Enhancement `HasPosition` trait

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -181,9 +181,6 @@ class AttributeEdit extends Component
         if (! $this->attribute->id) {
             $this->attribute->attribute_type = $this->group->attributable_type;
             $this->attribute->attribute_group_id = $this->group->id;
-            $this->attribute->position = Attribute::whereAttributeGroupId(
-                $this->group->id
-            )->count() + 1;
             $this->attribute->save();
             $this->notify(
                 __('adminhub::notifications.attribute-edit.created')

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -97,10 +97,6 @@ class AttributeGroupEdit extends Component
         }
 
         $this->attributeGroup->attributable_type = $this->attributableType;
-        $this->attributeGroup->position = AttributeGroup::whereAttributableType(
-            $this->attributableType
-        )->count() + 1;
-
         $this->attributeGroup->handle = $handle;
         $this->attributeGroup->save();
 

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionEdit.php
@@ -198,10 +198,6 @@ class OptionEdit extends Component
             return;
         }
 
-        if (! $this->productOption->position) {
-            $this->productOption->position = ProductOption::count() + 1;
-        }
-
         $this->productOption->save();
 
         $this->productOption = new ProductOption();

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionValueEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Options/OptionValueEdit.php
@@ -64,10 +64,6 @@ class OptionValueEdit extends Component
         $this->validate();
 
         if (! $this->optionValue->id) {
-            $this->optionValue->position = ProductOptionValue::whereProductOptionId(
-                $this->option->id
-            )->count() + 1;
-
             $this->optionValue->option()->associate($this->option);
             $this->optionValue->save();
             $this->notify(

--- a/packages/core/database/factories/AttributeFactory.php
+++ b/packages/core/database/factories/AttributeFactory.php
@@ -10,8 +10,6 @@ use Lunar\Models\Product;
 
 class AttributeFactory extends Factory
 {
-    private static $position = 1;
-
     protected $model = Attribute::class;
 
     public function definition(): array
@@ -19,7 +17,6 @@ class AttributeFactory extends Factory
         return [
             'attribute_group_id' => AttributeGroup::factory(),
             'attribute_type' => Product::class,
-            'position' => self::$position++,
             'name' => [
                 'en' => $this->faker->name(),
             ],

--- a/packages/core/database/factories/ProductOptionFactory.php
+++ b/packages/core/database/factories/ProductOptionFactory.php
@@ -8,8 +8,6 @@ use Lunar\Models\ProductOption;
 
 class ProductOptionFactory extends Factory
 {
-    private static $position = 1;
-
     protected $model = ProductOption::class;
 
     public function definition(): array
@@ -24,7 +22,6 @@ class ProductOptionFactory extends Factory
             'label' => [
                 'en' => $name,
             ],
-            'position' => self::$position++,
         ];
     }
 }

--- a/packages/core/database/migrations/2023_12_01_000000_add_unique_position_constraints_to_tables.php
+++ b/packages/core/database/migrations/2023_12_01_000000_add_unique_position_constraints_to_tables.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+use Lunar\Models\Attribute;
+use Lunar\Models\AttributeGroup;
+use Lunar\Models\ProductOption;
+use Lunar\Models\ProductOptionValue;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        /**
+         * Model's with position 
+         */
+        $models = [
+            Attribute::class,
+            AttributeGroup::class,
+            ProductOption::class,
+            ProductOptionValue::class,
+        ];
+        /**
+         * Ensure that all position values are unique 
+         */
+        foreach ($models as $model) {
+            $model = app($model);
+            Schema::table($model->getTable(), function (Blueprint $table) use ($model) {
+                DB::table($model->getTable())
+                    ->select(array_merge(
+                        [$model->getKeyName()], 
+                        $model->positionUniqueConstraints()
+                    ))
+                    ->orderBy('position')
+                    ->orderBy('id')
+                    ->get()
+                    ->groupBy(fn (stdClass $row, int $key) =>
+                        collect($row)
+                            ->only($model->positionUniqueConstraints())
+                            ->except('position')
+                            ->join('-')
+                    )->each
+                        ->each(fn(stdClass $row, int $key) => $row->position = $key + 1);
+            });
+        }
+        /**
+         * Add unique position index under consideration of 
+         * the model's position constraints
+         */
+        foreach ($models as $model) {
+            $model = app($model);
+            Schema::table($model->getTable(), function (Blueprint $table) use ($model) {
+                $schema = Schema::getConnection()
+                    ->getDoctrineSchemaManager()
+                    ->introspectTable($model->getTable());
+                $uniqueIndex = $this->prefix . $table->getTable() . '_unique_position';
+                $uniqueConstraints = array_merge($model->positionUniqueConstraints(), ['position']);
+                $table->unsignedBigInteger('position')->default(null)->index()->change();
+                if (!$schema->hasIndex($uniqueIndex)) {
+                    $table->unique($uniqueConstraints, $uniqueIndex);
+                }
+            });
+        }
+    }
+};

--- a/packages/core/src/Base/PositionManifest.php
+++ b/packages/core/src/Base/PositionManifest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Lunar\Base;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Str;
+
+class PositionManifest implements PositionManifestInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function saving(Model $model): void 
+    {
+        if (
+            $model->isDirty($this->constraints($model)) 
+            || !(intval($model->position) > 0)
+            || $model->query()
+                ->where($model->getKeyName(), '!=', $model->getKey())
+                ->wherePosition($model->position)
+                ->wherePositionUniqueConstraints($model->getAttributes())
+                ->exists()
+        ) {
+            $model->position = $model->query()
+                ->where($model->getKeyName(), '!=', $model->getKey())
+                ->wherePositionUniqueConstraints($model->getAttributes())
+                ->max('position') + 1;
+        }
+    }
+
+    /**
+     * 
+     * {@inheritDoc}
+     */
+    public function constraints(Model $model): array
+    {
+        return array_merge(
+            !property_exists($model, 'positionUniqueConstraints')
+                || !is_array($model->positionUniqueConstraints)
+                ? [] : $model->positionUniqueConstraints,
+            ['position']
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function query(Builder $query, int $position,  array $constraints = []): void
+    {
+        $query
+            ->wherePosition($position)
+            ->wherePositionUniqueConstraints($constraints);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function queryPosition(Builder $query, int $position): void
+    {
+        $query->where('position', $position);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function queryUniqueConstraints(Builder $query, array $constraints): void
+    {
+        $constraints = collect($constraints);
+        $modelConstraints = collect($this->constraints($query->getModel()))->reject('position');
+
+        if (count($modelConstraints) && !$constraints->hasAny($modelConstraints->toArray())) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Position constraints "%s" for "%s" not defined!',
+                    $modelConstraints->diff($constraints)->join('", "', '" and "'),
+                    get_class($query->getModel())
+                )
+            );
+        }
+
+        $modelConstraints->each(
+            function ($attribute) use ($query, $constraints) {
+                if (method_exists($query, Str::camel('scope_' . $attribute))) {
+                    $method = Str::camel($attribute);
+                } else {
+                    $method = Str::camel('where_' . $attribute);
+                }
+                $query->{$method}($constraints[$attribute]);
+            }
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function registerBlueprintMacros(): void
+    {
+        /**
+         * Add a `position` column to the table and define a unique positions index
+         * with the given constraints
+         * 
+         * The constraints can defined as array or assigned from the corsponding 
+         * model property `positionUniqueConstraints` if model object or  
+         * model classname is given. 
+         * 
+         * @param array|string|\Illuminate\Database\Eloquent\Model $constraints
+         * @return void
+         */
+        Blueprint::macro('position', function (array|string|Model $constraints = []) {
+            /** @var Blueprint $this */
+            if (is_string($constraints)) {
+                $constraints = app($constraints);
+            }
+            if (!is_array($constraints)) {
+                $constraints = \Lunar\Facades\PositionManifest::constraints($constraints);
+            } else {
+                $constraints = collect($constraints)
+                    ->push('position')
+                    ->unique()
+                    ->all();
+            }
+            $this->unsignedBigInteger('position');
+            $index = strtolower($this->prefix . $this->table . '_position_unique');
+            $this->unique($constraints, $index);
+        });
+
+        /**
+         * Remove the `position` column to the table and drop the unique positions index
+         * 
+         * @param array|string|\Illuminate\Database\Eloquent\Model $constraints
+         * @return void
+         */
+        Blueprint::macro('dropPosition', function () {
+            /** @var Blueprint $this */
+            $index = strtolower($this->prefix . $this->table . '_position_unique');
+            $this->dropUnique($index);
+            $this->dropColumn('position');
+        });
+    }
+}

--- a/packages/core/src/Base/PositionManifestInterface.php
+++ b/packages/core/src/Base/PositionManifestInterface.php
@@ -1,0 +1,62 @@
+<?php
+namespace Lunar\Base;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+interface PositionManifestInterface
+{
+    /**
+     * Before model gets saved, check if relevant model attributes has changed 
+     * and position value is greate than zero and unique and if not, set position 
+     * to next greatest value
+     * 
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return void
+     */
+    public function saving(Model $model): void;
+
+    /**
+     * Return the defined constraints from model's positionUniqueConstraints 
+     * property array 
+     * 
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return array
+     */
+    public function constraints(Model $model): array;
+
+    /**
+     * Scope the query to only include given position and constraints
+     * 
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param int $position
+     * @param array $constraints
+     * @return void
+     */
+    public function query(Builder $query, int $position, array $constraints = []): void;
+
+    /**
+     * Scope the query to only include given position
+     * 
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param int $position
+     * @return void
+     */
+    public function queryPosition(Builder $query, int $position): void;
+
+    /**
+     * Scope the query to only include given constraints
+     * 
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param array|\Illuminate\Support\Collection $constraints
+     * @return void
+     */
+    public function queryUniqueConstraints(Builder $query, array $constraints): void;
+
+    /**
+     * Regster blueprint macros to allow ease 
+     * ddefinition and removement from `position` columne
+     * @return void
+     */
+    public static function registerBlueprintMacros(): void;
+}

--- a/packages/core/src/Base/Traits/HasPosition.php
+++ b/packages/core/src/Base/Traits/HasPosition.php
@@ -1,0 +1,87 @@
+<?php
+namespace Lunar\Base\Traits;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+trait HasPosition
+{
+
+    final public static function initializeHasPosition(): void
+    {
+        static::saving(function (Model $model) {
+            if (
+                $model->isDirty($model->positionUniqueConstraints())
+                || !(intval($model->position) > 0)
+                || $model->query()
+                    ->where($model->getKeyName(), '!=', $model->getKey())
+                    ->wherePosition(
+                        $model->position,
+                        $model->getAttributes()
+                    )
+                    ->exists()
+            ) {
+                $model->position = $model->query()
+                    ->where($model->getKeyName(), '!=', $model->getKey())
+                    ->wherePositionUniqueConstraints(
+                        $model->getAttributes()
+                    )
+                    ->max('position') + 1;
+            }
+        });
+    }
+
+    final public function positionUniqueConstraints(): array
+    {
+        $constraints = ['position'];
+
+        if (!property_exists($this, 'positionUniqueConstraints') 
+            || !is_array($this->positionUniqueConstraints)) 
+        {
+            return $constraints;
+        }
+
+        return array_merge($this->positionUniqueConstraints, $constraints);
+    }
+
+    final public function scopeWherePosition(Builder $query, int $position, array|Collection $constraints = []): void
+    {
+        $query
+            ->where('position', $position)
+            ->wherePositionUniqueConstraints($constraints);
+    }
+
+    final public function scopeWherePositionUniqueConstraints(Builder $query, array|Collection $constraints = []): void
+    {
+        $constraints = collect($constraints)->except('position');
+        $modelConstraints = collect($this->positionUniqueConstraints())->reject('position');
+
+        if (count($modelConstraints) && !$constraints->hasAny($modelConstraints->toArray())) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Position constraints "%s" for "%s" not defined!',
+                    $modelConstraints->diff($constraints)->join('", "', '" and "'),
+                    get_class($this)
+                )
+            );
+        }
+
+        $modelConstraints->each(
+            function ($attribute) use ($query, $constraints) {
+                if (method_exists($query, Str::camel('scope_' . $attribute))) {
+                    $method = Str::camel($attribute);
+                } else {
+                    $method = Str::camel('where_' . $attribute);
+                }
+                $query->{$method}($constraints[$attribute]);
+            }
+        );
+    }
+
+    public function scopePosition(Builder $query, int $position, ...$constraints): void
+    {
+        $query->wherePosition($position, $constraints);
+    }
+
+}

--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -139,7 +139,6 @@ class InstallLunar extends Command
                         'en' => 'Details',
                     ]),
                     'handle' => 'details',
-                    'position' => 1,
                 ]);
 
                 $collectionGroup = AttributeGroup::create([
@@ -148,13 +147,11 @@ class InstallLunar extends Command
                         'en' => 'Details',
                     ]),
                     'handle' => 'collection_details',
-                    'position' => 1,
                 ]);
 
                 Attribute::create([
                     'attribute_type' => Product::class,
                     'attribute_group_id' => $group->id,
-                    'position' => 1,
                     'name' => [
                         'en' => 'Name',
                     ],
@@ -172,7 +169,6 @@ class InstallLunar extends Command
                 Attribute::create([
                     'attribute_type' => Collection::class,
                     'attribute_group_id' => $collectionGroup->id,
-                    'position' => 1,
                     'name' => [
                         'en' => 'Name',
                     ],
@@ -190,7 +186,6 @@ class InstallLunar extends Command
                 Attribute::create([
                     'attribute_type' => Product::class,
                     'attribute_group_id' => $group->id,
-                    'position' => 2,
                     'name' => [
                         'en' => 'Description',
                     ],
@@ -208,7 +203,6 @@ class InstallLunar extends Command
                 Attribute::create([
                     'attribute_type' => Collection::class,
                     'attribute_group_id' => $collectionGroup->id,
-                    'position' => 2,
                     'name' => [
                         'en' => 'Description',
                     ],

--- a/packages/core/src/Facades/PositionManifest.php
+++ b/packages/core/src/Facades/PositionManifest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Lunar\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Lunar\Base\PositionManifestInterface;
+
+/**
+ * Class PositionManifest.
+ *
+ * @method static void saving(\Illuminate\Database\Eloquent\Model $model)
+ * @method static array constraints(\Illuminate\Database\Eloquent\Model $model)
+ * @method static void query(\Illuminate\Database\Eloquent\Builder $query, int $position, array $constraints = [])
+ * @method static void queryPosition(\Illuminate\Database\Eloquent\Builder $query, int $position)
+ * @method static void queryUniqueConstraints(\Illuminate\Database\Eloquent\Builder $query, array $constraints)
+ * @method static void registerBlueprintMacros()
+ * 
+ * @see \Lunar\Base\PositionManifest
+ */
+class PositionManifest extends Facade
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected static function getFacadeAccessor()
+    {
+        return PositionManifestInterface::class;
+    }
+}

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -327,5 +327,23 @@ class LunarServiceProvider extends ServiceProvider
                     );
             }
         });
+
+        Blueprint::macro('position', function (string|array $uniqueConstraints = []) {
+            /** @var Blueprint $this */
+            if (is_string($uniqueConstraints)) {
+                $uniqueConstraints = app($uniqueConstraints)->positionUniqueConstraints();
+            }
+            $this->unsignedBigInteger('position')->index();
+            $this->unique(
+                array_merge($uniqueConstraints, ['position']),
+                $this->prefix . $this->table . '_unique_position'
+            );
+        });
+
+        Blueprint::macro('dropPosition', function () {
+            /** @var Blueprint $this */
+            $this->dropUnique($this->prefix . $this->table . '_unique_position');
+            $this->dropColumn('position');
+        });
     }
 }

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Lunar\Addons\Manifest;
@@ -29,6 +30,8 @@ use Lunar\Base\OrderModifiers;
 use Lunar\Base\OrderReferenceGenerator;
 use Lunar\Base\OrderReferenceGeneratorInterface;
 use Lunar\Base\PaymentManagerInterface;
+use Lunar\Base\PositionManifest;
+use Lunar\Base\PositionManifestInterface;
 use Lunar\Base\PricingManagerInterface;
 use Lunar\Base\ShippingManifest;
 use Lunar\Base\ShippingManifestInterface;
@@ -166,6 +169,10 @@ class LunarServiceProvider extends ServiceProvider
 
         $this->app->singleton(DiscountManagerInterface::class, function ($app) {
             return $app->make(DiscountManager::class);
+        });
+
+        $this->app->singleton(PositionManifestInterface::class, function ($app) {
+            return $app->make(PositionManifest::class);
         });
     }
 
@@ -328,22 +335,6 @@ class LunarServiceProvider extends ServiceProvider
             }
         });
 
-        Blueprint::macro('position', function (string|array $uniqueConstraints = []) {
-            /** @var Blueprint $this */
-            if (is_string($uniqueConstraints)) {
-                $uniqueConstraints = app($uniqueConstraints)->positionUniqueConstraints();
-            }
-            $this->unsignedBigInteger('position')->index();
-            $this->unique(
-                array_merge($uniqueConstraints, ['position']),
-                $this->prefix . $this->table . '_unique_position'
-            );
-        });
-
-        Blueprint::macro('dropPosition', function () {
-            /** @var Blueprint $this */
-            $this->dropUnique($this->prefix . $this->table . '_unique_position');
-            $this->dropColumn('position');
-        });
+        PositionManifest::registerBlueprintMacros();
     }
 }

--- a/packages/core/src/Models/Attribute.php
+++ b/packages/core/src/Models/Attribute.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
+use Lunar\Base\Traits\HasPosition;
 use Lunar\Base\Traits\HasTranslations;
 use Lunar\Database\Factories\AttributeFactory;
 use Lunar\Facades\DB;
@@ -37,6 +38,7 @@ class Attribute extends BaseModel
 {
     use HasFactory;
     use HasMacros;
+    use HasPosition;
     use HasTranslations;
 
     public static function boot()
@@ -73,6 +75,17 @@ class Attribute extends BaseModel
     protected $casts = [
         'name' => AsCollection::class,
         'configuration' => AsCollection::class,
+    ];
+
+    /**
+     * Define which attributes should be used 
+     * to define the unique position constraint.
+     *
+     * @var array
+     */
+    protected $positionUniqueConstraints = [
+        'attribute_type',
+        'attribute_group_id',
     ];
 
     /**

--- a/packages/core/src/Models/AttributeGroup.php
+++ b/packages/core/src/Models/AttributeGroup.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
+use Lunar\Base\Traits\HasPosition;
 use Lunar\Base\Traits\HasTranslations;
 use Lunar\Database\Factories\AttributeGroupFactory;
 
@@ -23,6 +24,7 @@ class AttributeGroup extends BaseModel
 {
     use HasFactory;
     use HasMacros;
+    use HasPosition;
     use HasTranslations;
 
     /**
@@ -48,6 +50,16 @@ class AttributeGroup extends BaseModel
      */
     protected $casts = [
         'name' => AsCollection::class,
+    ];
+
+    /**
+     * Define which attributes should be used 
+     * to define the unique position constraint.
+     *
+     * @var array
+     */
+    protected $positionUniqueConstraints = [
+        'attributable_type',
     ];
 
     /**

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
+use Lunar\Base\Traits\HasPosition;
 use Lunar\Base\Traits\HasTranslations;
 use Lunar\Base\Traits\Searchable;
 use Lunar\Database\Factories\ProductOptionFactory;
@@ -28,6 +29,7 @@ class ProductOption extends BaseModel implements SpatieHasMedia
     use HasFactory;
     use HasMacros;
     use HasMedia;
+    use HasPosition;
     use HasTranslations;
     use Searchable;
 
@@ -49,7 +51,7 @@ class ProductOption extends BaseModel implements SpatieHasMedia
         return ProductOptionFactory::new();
     }
 
-    public function getNameAttribute(string $value): mixed
+    public function getNameAttribute(?string $value): mixed
     {
         return json_decode($value);
     }

--- a/packages/core/src/Models/ProductOptionValue.php
+++ b/packages/core/src/Models/ProductOptionValue.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
+use Lunar\Base\Traits\HasPosition;
 use Lunar\Base\Traits\HasTranslations;
 use Lunar\Database\Factories\ProductOptionValueFactory;
 use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
@@ -26,6 +27,7 @@ class ProductOptionValue extends BaseModel implements SpatieHasMedia
     use HasFactory;
     use HasMacros;
     use HasMedia;
+    use HasPosition;
     use HasTranslations;
 
     /**
@@ -53,7 +55,17 @@ class ProductOptionValue extends BaseModel implements SpatieHasMedia
      */
     protected $guarded = [];
 
-    public function getNameAttribute(string $value): mixed
+    /**
+     * Define which attributes should be used 
+     * to define the unique position constraint.
+     *
+     * @var array
+     */
+    protected $positionUniqueConstraints = [
+        'product_option_id',
+    ];
+
+    public function getNameAttribute(?string $value): mixed
     {
         return json_decode($value);
     }

--- a/packages/core/tests/Unit/Models/AttributeGroupTest.php
+++ b/packages/core/tests/Unit/Models/AttributeGroupTest.php
@@ -20,12 +20,12 @@ class AttributeGroupTest extends TestCase
                 'en' => 'SEO',
             ],
             'handle' => 'seo',
-            'position' => 5,
         ]);
 
         $this->assertEquals('SEO', $attributeGroup->name->get('en'));
         $this->assertEquals('seo', $attributeGroup->handle);
-        $this->assertEquals(5, $attributeGroup->position);
+        $this->assertIsInt($attributeGroup->position);
+        $this->assertGreaterThan(0, $attributeGroup->position);
     }
 
     /** @test */
@@ -37,7 +37,6 @@ class AttributeGroupTest extends TestCase
                 'en' => 'SEO',
             ],
             'handle' => 'seo',
-            'position' => 5,
         ]);
 
         $this->assertCount(0, $attributeGroup->attributes);

--- a/packages/core/tests/Unit/Models/AttributeTest.php
+++ b/packages/core/tests/Unit/Models/AttributeTest.php
@@ -23,7 +23,6 @@ class AttributeTest extends TestCase
         $attribute = Attribute::factory()
             ->for(AttributeGroup::factory())
             ->create([
-                'position' => 4,
                 'name' => [
                     'en' => 'Meta Description',
                 ],
@@ -42,7 +41,8 @@ class AttributeTest extends TestCase
         $this->assertEquals('meta_description', $attribute->handle);
         $this->assertEquals(\Lunar\FieldTypes\Text::class, $attribute->type);
         $this->assertTrue($attribute->system);
-        $this->assertEquals(4, $attribute->position);
+        $this->assertIsInt($attribute->position);
+        $this->assertGreaterThan(0, $attribute->position);
         $this->assertEquals($options, $attribute->configuration->get('options'));
     }
 }


### PR DESCRIPTION
Adds a `HasPosition` trait for models that require a (manual) sort key, using a numeric `position` column in the model's table.

**Features:**
- [x] Automatic assignment of the next sort key value if not explicitly defined
- [x] Automatic checking and, if necessary, correction of invalid sort key values
- [x] Limiting the validation and correcting the sort key values ​​based on the data of other columns in the table
- [x] `Blueprint` macro to add `position` columns with the required unique constriants in migration files
- [x] Convert current position columns and values ​​to work with the trait

**To do:**
- [ ] Add tests
- [ ] If necessary, consider `position` columns in `pivot` tables.
- [ ] Documentation