### PR TITLE
Fix espace query on DatabaseEngine (#1355)

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
@@ -134,13 +134,6 @@ abstract class AbstractDiscount extends Component
             ->map(function ($limitation) {
                 return array_merge($this->mapProductVariantToArray($limitation->purchasable), ['type' => $limitation->type]);
             });
-            
-        $this->selectedProductVariants = $this->discount->purchasableLimitations()
-            ->wherePurchasableType(ProductVariant::class)
-            ->get()
-            ->map(function ($limitation) {
-                return $this->mapProductVariantToArray($limitation->purchasable);
-            });
 
         $this->selectedConditions = $this->discount->purchasableConditions()
             ->wherePurchasableType(Product::class)
@@ -453,20 +446,6 @@ abstract class AbstractDiscount extends Component
                         'type' => $variant['type'],
                     ])
                     ->save();
-            }
-            
-            $this->discount->purchasableLimitations()
-                ->where('purchasable_type', ProductVariant::class)
-                ->whereNotIn('purchasable_id', $this->selectedProductVariants->pluck('id'))
-                ->delete();
-
-            foreach ($this->selectedProductVariants as $variant) {
-                $this->discount->purchasableLimitations()->firstOrCreate([
-                    'discount_id' => $this->discount->id,
-                    'type' => 'limitation',
-                    'purchasable_type' => ProductVariant::class,
-                    'purchasable_id' => $variant['id'],
-                ]);
             }
         });
 

--- a/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
+++ b/packages/admin/src/Http/Livewire/Components/Discounts/AbstractDiscount.php
@@ -51,7 +51,7 @@ abstract class AbstractDiscount extends Component
      * @var array
      */
     public Collection $selectedProducts;
-    
+
     /**
      * The product variants to restrict the coupon for.
      *
@@ -122,14 +122,16 @@ abstract class AbstractDiscount extends Component
         $this->selectedProducts = $this->discount->purchasables()
             ->whereIn('type', ['limitation', 'exclusion'])
             ->wherePurchasableType(Product::class)
+            ->whereHas('purchasable')
             ->get()
             ->map(function ($limitation) {
                 return array_merge($this->mapProductToArray($limitation->purchasable), ['type' => $limitation->type]);
             });
-            
+
         $this->selectedProductVariants = $this->discount->purchasables()
             ->whereIn('type', ['limitation', 'exclusion'])
             ->wherePurchasableType(ProductVariant::class)
+            ->whereHas('purchasable')
             ->get()
             ->map(function ($limitation) {
                 return array_merge($this->mapProductVariantToArray($limitation->purchasable), ['type' => $limitation->type]);
@@ -137,10 +139,12 @@ abstract class AbstractDiscount extends Component
 
         $this->selectedConditions = $this->discount->purchasableConditions()
             ->wherePurchasableType(Product::class)
+            ->whereHas('purchasable')
             ->pluck('purchasable_id')->values()->toArray();
 
         $this->selectedRewards = $this->discount->purchasableRewards()
             ->wherePurchasableType(Product::class)
+            ->whereHas('purchasable')
             ->pluck('purchasable_id')->values()->toArray();
 
         $this->syncAvailability();
@@ -251,7 +255,7 @@ abstract class AbstractDiscount extends Component
             ? $this->selectedProducts->merge($selectedProducts)
             : $selectedProducts;
     }
-    
+
     /**
      * Select product variants given an array of IDs
      *
@@ -338,7 +342,7 @@ abstract class AbstractDiscount extends Component
     {
         $this->selectedProducts->forget($index);
     }
-    
+
     /**
      * Remove the product variant by it's index.
      *
@@ -407,7 +411,7 @@ abstract class AbstractDiscount extends Component
             $this->discount->collections()->sync(
                 $this->selectedCollections->mapWithKeys(fn ($collection) => [$collection['id'] => ['type' => $collection['type']]])
             );
-            
+
             $this->discount->purchasables()
                 ->whereIn('type', ['exclusion', 'limitation'])
                 ->where('purchasable_type', Product::class)
@@ -427,7 +431,7 @@ abstract class AbstractDiscount extends Component
                     ])
                     ->save();
             }
-                        
+
             $this->discount->purchasables()
                 ->whereIn('type', ['exclusion', 'limitation'])
                 ->where('purchasable_type', ProductVariant::class)
@@ -558,7 +562,7 @@ abstract class AbstractDiscount extends Component
             'thumbnail' => optional($product->thumbnail)->getUrl('small'),
         ];
     }
-    
+
     /**
      * Return the data we need from a product variant
      *

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -19,7 +19,7 @@ class ConvertTaxbreakdown
 
         if ($this->canRunOnOrders()) {
             DB::table("{$prefix}orders")
-                ->whereJsonContainsKey("${prefix}orders.tax_breakdown->[0]->total")
+                ->whereJsonContainsKey("{$prefix}orders.tax_breakdown->[0]->total")
                 ->orderBy('id')
                 ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                     foreach ($rows as $row) {
@@ -43,14 +43,14 @@ class ConvertTaxbreakdown
 
         if ($this->canRunOnOrderLines()) {
             DB::table("{$prefix}order_lines")
-                ->whereJsonContainsKey("${prefix}order_lines.tax_breakdown->[0]->total")
-                ->orderBy("${prefix}order_lines.id")
+                ->whereJsonContainsKey("{$prefix}order_lines.tax_breakdown->[0]->total")
+                ->orderBy("{$prefix}order_lines.id")
                 ->select(
-                    "${prefix}order_lines.id",
-                    "${prefix}order_lines.tax_breakdown",
-                    "${prefix}orders.currency_code",
+                    "{$prefix}order_lines.id",
+                    "{$prefix}order_lines.tax_breakdown",
+                    "{$prefix}orders.currency_code",
                 )
-                ->join("${prefix}orders", "${prefix}order_lines.order_id", '=', "${prefix}orders.id")
+                ->join("{$prefix}orders", "{$prefix}order_lines.order_id", '=', "{$prefix}orders.id")
                 ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                     DB::transaction(function () use ($prefix, $updateTime, $rows) {
                         foreach ($rows as $row) {

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -14,49 +14,20 @@ class ConvertTaxbreakdown
 
     public function run()
     {
-        $prefix = config('lunar.database.table_prefix');
-        $updateTime = now();
-
-        if ($this->canRunOnOrders()) {
-            DB::table("{$prefix}orders")
-                ->whereJsonContainsKey("{$prefix}orders.tax_breakdown->[0]->total")
-                ->orderBy('id')
-                ->chunk(500, function ($rows) use ($prefix, $updateTime) {
-                    foreach ($rows as $row) {
-                        $originalBreakdown = json_decode($row->tax_breakdown, true);
-
-                        DB::table("{$prefix}orders")->where('id', '=', $row->id)->update([
-                            'tax_breakdown' => collect($originalBreakdown)->map(function ($breakdown) use ($row) {
-                                return [
-                                    'description' => $breakdown['description'],
-                                    'identifier' => $breakdown['identifier'] ?? $breakdown['description'],
-                                    'percentage' => $breakdown['percentage'],
-                                    'value' => $breakdown['total'],
-                                    'currency_code' => $row->currency_code,
-                                ];
-                            })->toJson(),
-                            'updated_at' => $updateTime,
-                        ]);
-                    }
-                });
-        }
-
-        if ($this->canRunOnOrderLines()) {
-            DB::table("{$prefix}order_lines")
-                ->whereJsonContainsKey("{$prefix}order_lines.tax_breakdown->[0]->total")
-                ->orderBy("{$prefix}order_lines.id")
-                ->select(
-                    "{$prefix}order_lines.id",
-                    "{$prefix}order_lines.tax_breakdown",
-                    "{$prefix}orders.currency_code",
-                )
-                ->join("{$prefix}orders", "{$prefix}order_lines.order_id", '=', "{$prefix}orders.id")
-                ->chunk(500, function ($rows) use ($prefix, $updateTime) {
-                    DB::transaction(function () use ($prefix, $updateTime, $rows) {
+        DB::usingConnection(config('lunar.database.connection') ?: DB::getDefaultConnection(), function () {
+                
+            $prefix = config('lunar.database.table_prefix');
+            $updateTime = now();
+    
+            if ($this->canRunOnOrders()) {
+                DB::table("{$prefix}orders")
+                    ->whereJsonContainsKey("${prefix}orders.tax_breakdown->[0]->total")
+                    ->orderBy('id')
+                    ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                         foreach ($rows as $row) {
                             $originalBreakdown = json_decode($row->tax_breakdown, true);
 
-                            DB::table("{$prefix}order_lines")->where('id', '=', $row->id)->update([
+                            DB::table("{$prefix}orders")->where('id', '=', $row->id)->update([
                                 'tax_breakdown' => collect($originalBreakdown)->map(function ($breakdown) use ($row) {
                                     return [
                                         'description' => $breakdown['description'],
@@ -70,8 +41,41 @@ class ConvertTaxbreakdown
                             ]);
                         }
                     });
-                });
-        }
+            }
+    
+            if ($this->canRunOnOrderLines()) {
+                DB::table("{$prefix}order_lines")
+                    ->whereJsonContainsKey("${prefix}order_lines.tax_breakdown->[0]->total")
+                    ->orderBy("${prefix}order_lines.id")
+                    ->select(
+                        "${prefix}order_lines.id",
+                        "${prefix}order_lines.tax_breakdown",
+                        "${prefix}orders.currency_code",
+                    )
+                    ->join("${prefix}orders", "${prefix}order_lines.order_id", '=', "${prefix}orders.id")
+                    ->chunk(500, function ($rows) use ($prefix, $updateTime) {
+                        DB::transaction(function () use ($prefix, $updateTime, $rows) {
+                            foreach ($rows as $row) {
+                                $originalBreakdown = json_decode($row->tax_breakdown, true);
+    
+                                DB::table("{$prefix}order_lines")->where('id', '=', $row->id)->update([
+                                    'tax_breakdown' => collect($originalBreakdown)->map(function ($breakdown) use ($row) {
+                                        return [
+                                            'description' => $breakdown['description'],
+                                            'identifier' => $breakdown['identifier'] ?? $breakdown['description'],
+                                            'percentage' => $breakdown['percentage'],
+                                            'value' => $breakdown['total'],
+                                            'currency_code' => $row->currency_code,
+                                        ];
+                                    })->toJson(),
+                                    'updated_at' => $updateTime,
+                                ]);
+                            }
+                        });
+                    });
+            }
+            
+        });
     }
 
     protected function canRunOnOrders()

--- a/packages/core/database/state/ConvertTaxbreakdown.php
+++ b/packages/core/database/state/ConvertTaxbreakdown.php
@@ -21,7 +21,7 @@ class ConvertTaxbreakdown
     
             if ($this->canRunOnOrders()) {
                 DB::table("{$prefix}orders")
-                    ->whereJsonContainsKey("${prefix}orders.tax_breakdown->[0]->total")
+                    ->whereJsonContainsKey("{$prefix}orders.tax_breakdown->[0]->total")
                     ->orderBy('id')
                     ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                         foreach ($rows as $row) {
@@ -45,14 +45,14 @@ class ConvertTaxbreakdown
     
             if ($this->canRunOnOrderLines()) {
                 DB::table("{$prefix}order_lines")
-                    ->whereJsonContainsKey("${prefix}order_lines.tax_breakdown->[0]->total")
-                    ->orderBy("${prefix}order_lines.id")
+                    ->whereJsonContainsKey("{$prefix}order_lines.tax_breakdown->[0]->total")
+                    ->orderBy("{$prefix}order_lines.id")
                     ->select(
-                        "${prefix}order_lines.id",
-                        "${prefix}order_lines.tax_breakdown",
-                        "${prefix}orders.currency_code",
+                        "{$prefix}order_lines.id",
+                        "{$prefix}order_lines.tax_breakdown",
+                        "{$prefix}orders.currency_code",
                     )
-                    ->join("${prefix}orders", "${prefix}order_lines.order_id", '=', "${prefix}orders.id")
+                    ->join("{$prefix}orders", "{$prefix}order_lines.order_id", '=', "{$prefix}orders.id")
                     ->chunk(500, function ($rows) use ($prefix, $updateTime) {
                         DB::transaction(function () use ($prefix, $updateTime, $rows) {
                             foreach ($rows as $row) {

--- a/packages/core/src/Base/Traits/CanScheduleAvailability.php
+++ b/packages/core/src/Base/Traits/CanScheduleAvailability.php
@@ -83,11 +83,8 @@ trait CanScheduleAvailability
 
     /**
      * Returns the data for the sync update.
-     *
-     * @param  \Illuminate\Support\Collection  $models
-     * @return \Illuminate\Support\Collection
      */
-    private function getScheduleMapping($models, array $pivotData = null)
+    private function getScheduleMapping(Collection $models, array $pivotData = null): Collection
     {
         return $models->mapWithKeys(function ($model) use ($pivotData) {
             return [

--- a/packages/core/src/Base/Traits/HasPrices.php
+++ b/packages/core/src/Base/Traits/HasPrices.php
@@ -2,7 +2,9 @@
 
 namespace Lunar\Base\Traits;
 
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Lunar\Facades\Pricing;
+use Lunar\Managers\PricingManager;
 use Lunar\Models\Price;
 
 trait HasPrices
@@ -10,7 +12,7 @@ trait HasPrices
     /**
      * Get all of the models prices.
      */
-    public function prices()
+    public function prices(): MorphMany
     {
         return $this->morphMany(
             Price::class,
@@ -20,20 +22,16 @@ trait HasPrices
 
     /**
      * Return base prices query.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    public function basePrices()
+    public function basePrices(): MorphMany
     {
         return $this->prices()->whereTier(1)->whereNull('customer_group_id');
     }
 
     /**
      * Return a PricingManager for this model.
-     *
-     * @return \Lunar\Managers\PricingManager
      */
-    public function pricing()
+    public function pricing(): PricingManager
     {
         return Pricing::for($this);
     }

--- a/packages/core/src/Base/Traits/HasTags.php
+++ b/packages/core/src/Base/Traits/HasTags.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Base\Traits;
 
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Collection;
 use Lunar\Jobs\SyncTags;
 use Lunar\Models\Tag;
@@ -10,10 +11,8 @@ trait HasTags
 {
     /**
      * Get the tags
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<Tag>
      */
-    public function tags()
+    public function tags(): MorphToMany
     {
         $prefix = config('lunar.database.table_prefix');
 

--- a/packages/core/src/Base/Traits/HasUrls.php
+++ b/packages/core/src/Base/Traits/HasUrls.php
@@ -3,6 +3,8 @@
 namespace Lunar\Base\Traits;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Lunar\Models\Url;
 
 trait HasUrls
@@ -31,7 +33,7 @@ trait HasUrls
     /**
      * Get all of the models urls.
      */
-    public function urls()
+    public function urls(): MorphMany
     {
         return $this->morphMany(
             Url::class,
@@ -39,7 +41,7 @@ trait HasUrls
         );
     }
 
-    public function defaultUrl()
+    public function defaultUrl(): MorphOne
     {
         return $this->morphOne(
             Url::class,

--- a/packages/core/src/Base/Traits/LunarUser.php
+++ b/packages/core/src/Base/Traits/LunarUser.php
@@ -2,20 +2,21 @@
 
 namespace Lunar\Base\Traits;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Models\Customer;
 use Lunar\Models\Order;
 
 trait LunarUser
 {
-    public function customers()
+    public function customers(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
         return $this->belongsToMany(Customer::class, "{$prefix}customer_user");
     }
 
-    public function latestCustomer()
+    public function latestCustomer(): ?Customer
     {
         return $this->customers()->orderBy('created_at', 'desc')->orderBy('id', 'desc')->first();
     }

--- a/packages/core/src/Models/Address.php
+++ b/packages/core/src/Models/Address.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\Addressable;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
@@ -66,20 +67,16 @@ class Address extends BaseModel implements Addressable
 
     /**
      * Return the country relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function country()
+    public function country(): BelongsTo
     {
         return $this->belongsTo(Country::class);
     }
 
     /**
      * Return the customer relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function customer()
+    public function customer(): BelongsTo
     {
         return $this->belongsTo(Customer::class);
     }

--- a/packages/core/src/Models/Asset.php
+++ b/packages/core/src/Models/Asset.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Models;
 
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMedia as TraitsHasMedia;
 use Spatie\MediaLibrary\HasMedia;
@@ -25,10 +26,8 @@ class Asset extends BaseModel implements HasMedia
 
     /**
      * Get the associated file.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphOne
      */
-    public function file()
+    public function file(): MorphOne
     {
         return $this->morphOne(config('media-library.media_model'), 'model');
     }

--- a/packages/core/src/Models/AttributeGroup.php
+++ b/packages/core/src/Models/AttributeGroup.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasTranslations;
@@ -51,10 +52,8 @@ class AttributeGroup extends BaseModel
 
     /**
      * Return the attributes relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function attributes()
+    public function attributes(): HasMany
     {
         return $this->hasMany(Attribute::class)->orderBy('position');
     }

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasAttributes;
@@ -56,10 +57,8 @@ class Brand extends BaseModel implements SpatieHasMedia
 
     /**
      * Get the mapped attributes relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function mappedAttributes()
+    public function mappedAttributes(): MorphToMany
     {
         $prefix = config('lunar.database.table_prefix');
 

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -6,6 +6,9 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
@@ -194,40 +197,32 @@ class Cart extends BaseModel
 
     /**
      * Return the cart lines relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function lines()
+    public function lines(): HasMany
     {
         return $this->hasMany(CartLine::class, 'cart_id', 'id');
     }
 
     /**
      * Return the currency relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function currency()
+    public function currency(): BelongsTo
     {
         return $this->belongsTo(Currency::class);
     }
 
     /**
      * Return the user relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(config('auth.providers.users.model'));
     }
 
     /**
      * Return the customer relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function customer()
+    public function customer(): BelongsTo
     {
         return $this->belongsTo(Customer::class);
     }
@@ -239,40 +234,32 @@ class Cart extends BaseModel
 
     /**
      * Return the addresses relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function addresses()
+    public function addresses(): HasMany
     {
         return $this->hasMany(CartAddress::class, 'cart_id');
     }
 
     /**
      * Return the shipping address relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function shippingAddress()
+    public function shippingAddress(): HasOne
     {
         return $this->hasOne(CartAddress::class, 'cart_id')->whereType('shipping');
     }
 
     /**
      * Return the billing address relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function billingAddress()
+    public function billingAddress(): HasOne
     {
         return $this->hasOne(CartAddress::class, 'cart_id')->whereType('billing');
     }
 
     /**
      * Return the order relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function orders()
+    public function orders(): HasMany
     {
         return $this->hasMany(Order::class);
     }
@@ -291,10 +278,8 @@ class Cart extends BaseModel
 
     /**
      * Return the draft order relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function draftOrder(int $draftOrderId = null)
+    public function draftOrder(int $draftOrderId = null): HasOne
     {
         return $this->hasOne(Order::class)
             ->when($draftOrderId, function (Builder $query, int $draftOrderId) {
@@ -304,10 +289,8 @@ class Cart extends BaseModel
 
     /**
      * Return the completed order relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function completedOrder(int $completedOrderId = null)
+    public function completedOrder(int $completedOrderId = null): HasOne
     {
         return $this->hasOne(Order::class)
             ->when($completedOrderId, function (Builder $query, int $completedOrderId) {
@@ -317,10 +300,8 @@ class Cart extends BaseModel
 
     /**
      * Return the carts completed order.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function completedOrders()
+    public function completedOrders(): HasMany
     {
         return $this->hasMany(Order::class)
             ->whereNotNull('placed_at');
@@ -328,10 +309,8 @@ class Cart extends BaseModel
 
     /**
      * Return whether the cart has any completed order.
-     *
-     * @return bool
      */
-    public function hasCompletedOrders()
+    public function hasCompletedOrders(): bool
     {
         return (bool) $this->completedOrders()->count();
     }
@@ -375,10 +354,8 @@ class Cart extends BaseModel
 
     /**
      * Add cart lines.
-     *
-     * @return bool
      */
-    public function addLines(iterable $lines)
+    public function addLines(iterable $lines): Cart
     {
         DB::transaction(function () use ($lines) {
             collect($lines)->each(function ($line) {
@@ -414,10 +391,8 @@ class Cart extends BaseModel
 
     /**
      * Update cart line
-     *
-     * @param  array  $meta
      */
-    public function updateLine(int $cartLineId, int $quantity, $meta = null, bool $refresh = true): Cart
+    public function updateLine(int $cartLineId, int $quantity, array $meta = null, bool $refresh = true): Cart
     {
         foreach (config('lunar.cart.validators.update_cart_line', []) as $action) {
             app($action)->using(
@@ -436,10 +411,8 @@ class Cart extends BaseModel
 
     /**
      * Update cart lines.
-     *
-     * @return \Lunar\Models\Cart
      */
-    public function updateLines(Collection $lines)
+    public function updateLines(Collection $lines): Cart
     {
         DB::transaction(function () use ($lines) {
             $lines->each(function ($line) {
@@ -458,7 +431,7 @@ class Cart extends BaseModel
     /**
      * Deletes all cart lines.
      */
-    public function clear()
+    public function clear(): Cart
     {
         $this->lines()->delete();
 
@@ -467,12 +440,8 @@ class Cart extends BaseModel
 
     /**
      * Associate a user to the cart
-     *
-     * @param  string  $policy
-     * @param  bool  $refresh
-     * @return Cart
      */
-    public function associate(User $user, $policy = 'merge', $refresh = true)
+    public function associate(User $user, string $policy = 'merge', bool $refresh = true): Cart
     {
         if ($this->customer()->exists()) {
             if (! $user->query()
@@ -527,20 +496,16 @@ class Cart extends BaseModel
 
     /**
      * Set the shipping address.
-     *
-     * @return \Lunar\Models\Cart
      */
-    public function setShippingAddress(array|Addressable $address)
+    public function setShippingAddress(array|Addressable $address): Cart
     {
         return $this->addAddress($address, 'shipping');
     }
 
     /**
      * Set the billing address.
-     *
-     * @return self
      */
-    public function setBillingAddress(array|Addressable $address)
+    public function setBillingAddress(array|Addressable $address): Cart
     {
         return $this->addAddress($address, 'billing');
     }
@@ -548,7 +513,7 @@ class Cart extends BaseModel
     /**
      * Set the shipping option to the shipping address.
      */
-    public function setShippingOption(ShippingOption $option, $refresh = true): Cart
+    public function setShippingOption(ShippingOption $option, bool $refresh = true): Cart
     {
         foreach (config('lunar.cart.validators.set_shipping_option', []) as $action) {
             app($action)->using(
@@ -573,10 +538,8 @@ class Cart extends BaseModel
 
     /**
      * Returns whether the cart has shippable items.
-     *
-     * @return bool
      */
-    public function isShippable()
+    public function isShippable(): bool
     {
         return (bool) $this->lines->filter(function ($line) {
             return $line->purchasable->isShippable();
@@ -585,8 +548,6 @@ class Cart extends BaseModel
 
     /**
      * Create an order from the Cart.
-     *
-     * @return Cart
      */
     public function createOrder(
         bool $allowMultipleOrders = false,
@@ -611,10 +572,8 @@ class Cart extends BaseModel
 
     /**
      * Returns whether a cart has enough info to create an order.
-     *
-     * @return bool
      */
-    public function canCreateOrder()
+    public function canCreateOrder(): bool
     {
         $passes = true;
 
@@ -635,10 +594,8 @@ class Cart extends BaseModel
 
     /**
      * Get a unique fingerprint for the cart to identify if the contents have changed.
-     *
-     * @return string
      */
-    public function fingerprint()
+    public function fingerprint(): string
     {
         $generator = config('lunar.cart.fingerprint_generator', GenerateFingerprint::class);
 
@@ -648,12 +605,9 @@ class Cart extends BaseModel
     /**
      * Check whether a given fingerprint matches the one being generated for the cart.
      *
-     * @param  string  $fingerprint
-     * @return bool
-     *
      * @throws FingerprintMismatchException
      */
-    public function checkFingerprint($fingerprint)
+    public function checkFingerprint(string $fingerprint): bool
     {
         return tap($fingerprint == $this->fingerprint(), function ($result) {
             throw_unless(

--- a/packages/core/src/Models/CartAddress.php
+++ b/packages/core/src/Models/CartAddress.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\Addressable;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\CachesProperties;
@@ -79,8 +80,6 @@ class CartAddress extends BaseModel implements Addressable
 
     /**
      * The tax breakdown.
-     *
-     * @var TaxBreakdown
      */
     public ?TaxBreakdown $taxBreakdown = null;
 
@@ -129,20 +128,16 @@ class CartAddress extends BaseModel implements Addressable
 
     /**
      * Return the cart relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function cart()
+    public function cart(): BelongsTo
     {
         return $this->belongsTo(Cart::class);
     }
 
     /**
      * Return the country relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function country()
+    public function country(): BelongsTo
     {
         return $this->belongsTo(Country::class);
     }

--- a/packages/core/src/Models/CartLine.php
+++ b/packages/core/src/Models/CartLine.php
@@ -4,6 +4,10 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\CachesProperties;
 use Lunar\Base\Traits\HasMacros;
@@ -112,20 +116,16 @@ class CartLine extends BaseModel
 
     /**
      * Return the cart relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function cart()
+    public function cart(): BelongsTo
     {
         return $this->belongsTo(Cart::class);
     }
 
     /**
      * Return the tax class relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function taxClass()
+    public function taxClass(): HasOneThrough
     {
         return $this->hasOneThrough(
             TaxClass::class,
@@ -135,7 +135,10 @@ class CartLine extends BaseModel
         );
     }
 
-    public function discounts()
+    /**
+     * Return the cart line discount.
+     */
+    public function discounts(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -147,10 +150,8 @@ class CartLine extends BaseModel
 
     /**
      * Return the polymorphic relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function purchasable()
+    public function purchasable(): MorphTo
     {
         return $this->morphTo();
     }

--- a/packages/core/src/Models/Channel.php
+++ b/packages/core/src/Models/Channel.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 use Lunar\Base\BaseModel;
@@ -47,11 +48,8 @@ class Channel extends BaseModel
 
     /**
      * Mutator for formatting the handle to a slug.
-     *
-     * @param  string  $val
-     * @return void
      */
-    public function setHandleAttribute($val)
+    public function setHandleAttribute(?string $val): void
     {
         $this->attributes['handle'] = Str::slug($val);
     }
@@ -59,7 +57,7 @@ class Channel extends BaseModel
     /**
      * Get the parent channelable model.
      */
-    public function channelable()
+    public function channelable(): MorphTo
     {
         return $this->morphTo();
     }

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Kalnoy\Nestedset\NodeTrait;
 use Lunar\Base\BaseModel;
@@ -66,25 +67,21 @@ class Collection extends BaseModel implements SpatieHasMedia
 
     /**
      * Return the group relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function group()
+    public function group(): BelongsTo
     {
         return $this->belongsTo(CollectionGroup::class, 'collection_group_id');
     }
 
-    public function scopeInGroup(Builder $builder, $id)
+    public function scopeInGroup(Builder $builder, int $id): Builder
     {
         return $builder->where('collection_group_id', $id);
     }
 
     /**
      * Return the products relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function products()
+    public function products(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -98,10 +95,8 @@ class Collection extends BaseModel implements SpatieHasMedia
 
     /**
      * Get the translated name of ancestor collections.
-     *
-     * @return Illuminate\Support\Collection
      */
-    public function getBreadcrumbAttribute()
+    public function getBreadcrumbAttribute(): \Illuminate\Support\Collection
     {
         return $this->ancestors->map(function ($ancestor) {
             return $ancestor->translateAttribute('name');

--- a/packages/core/src/Models/CollectionGroup.php
+++ b/packages/core/src/Models/CollectionGroup.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\CollectionGroupFactory;
@@ -29,7 +30,10 @@ class CollectionGroup extends BaseModel
         return CollectionGroupFactory::new();
     }
 
-    public function collections()
+    /**
+     * Return the collections relationship.
+     */
+    public function collections(): HasMany
     {
         return $this->hasMany(Collection::class);
     }

--- a/packages/core/src/Models/Country.php
+++ b/packages/core/src/Models/Country.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\CountryFactory;
@@ -44,10 +45,8 @@ class Country extends BaseModel
 
     /**
      * Return the states relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function states()
+    public function states(): HasMany
     {
         return $this->hasMany(State::class);
     }

--- a/packages/core/src/Models/Currency.php
+++ b/packages/core/src/Models/Currency.php
@@ -46,10 +46,8 @@ class Currency extends BaseModel
 
     /**
      * Return the prices relationship
-     *
-     * @return HasMany
      */
-    public function prices()
+    public function prices(): HasMany
     {
         return $this->hasMany(Price::class);
     }
@@ -57,10 +55,8 @@ class Currency extends BaseModel
     /**
      * Returns the amount we need to multiply or divide the price
      * for the cents/pence.
-     *
-     * @return string
      */
-    public function getFactorAttribute()
+    public function getFactorAttribute(): string
     {
         /**
          * If we figure out how many decimal places we need, we can work

--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -4,6 +4,9 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasAttributes;
@@ -60,10 +63,8 @@ class Customer extends BaseModel
 
     /**
      * Return the customer group relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function customerGroups()
+    public function customerGroups(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -75,10 +76,8 @@ class Customer extends BaseModel
 
     /**
      * Return the customer group relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function users()
+    public function users(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -90,25 +89,24 @@ class Customer extends BaseModel
 
     /**
      * Return the addresses relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function addresses()
+    public function addresses(): HasMany
     {
         return $this->hasMany(Address::class);
     }
 
-    public function orders()
+    /**
+     * Return the orders relationship.
+     */
+    public function orders(): HasMany
     {
         return $this->hasMany(Order::class);
     }
 
     /**
      * Get the mapped attributes relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function mappedAttributes()
+    public function mappedAttributes(): MorphToMany
     {
         $prefix = config('lunar.database.table_prefix');
 

--- a/packages/core/src/Models/CustomerGroup.php
+++ b/packages/core/src/Models/CustomerGroup.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasDefaultRecord;
 use Lunar\Base\Traits\HasMacros;
@@ -37,10 +38,8 @@ class CustomerGroup extends BaseModel
 
     /**
      * Return the customer's relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function customers()
+    public function customers(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -55,7 +55,7 @@ class Discount extends BaseModel
         return DiscountFactory::new();
     }
 
-    public function users()
+    public function users(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -67,30 +67,40 @@ class Discount extends BaseModel
 
     /**
      * Return the purchasables relationship.
-     *
-     * @return HasMany
      */
-    public function purchasables()
+    public function purchasables(): HasMany
     {
         return $this->hasMany(DiscountPurchasable::class);
     }
 
-    public function purchasableConditions()
+    /**
+     * Return the purchasable conditions relationship.
+     */
+    public function purchasableConditions(): HasMany
     {
         return $this->hasMany(DiscountPurchasable::class)->whereType('condition');
     }
-    
-    public function purchasableExclusions()
+
+    /**
+     * Return the purchasable exclusions relationship.
+     */
+    public function purchasableExclusions(): HasMany
     {
         return $this->hasMany(DiscountPurchasable::class)->whereType('exclusion');
     }
 
-    public function purchasableLimitations()
+    /**
+     * Return the purchasable limitations relationship.
+     */
+    public function purchasableLimitations(): HasMany
     {
         return $this->hasMany(DiscountPurchasable::class)->whereType('limitation');
     }
 
-    public function purchasableRewards()
+    /**
+     * Return the purchasable rewards relationship.
+     */
+    public function purchasableRewards(): HasMany
     {
         return $this->hasMany(DiscountPurchasable::class)->whereType('reward');
     }
@@ -102,10 +112,8 @@ class Discount extends BaseModel
 
     /**
      * Return the collections relationship.
-     *
-     * @return HasMany
      */
-    public function collections()
+    public function collections(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -133,7 +141,7 @@ class Discount extends BaseModel
         ])->withTimestamps();
     }
 
-    public function brands()
+    public function brands(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -145,10 +153,8 @@ class Discount extends BaseModel
 
     /**
      * Return the active scope.
-     *
-     * @return Builder
      */
-    public function scopeActive(Builder $query)
+    public function scopeActive(Builder $query): Builder
     {
         return $query->whereNotNull('starts_at')
             ->where('starts_at', '<=', now())
@@ -160,10 +166,8 @@ class Discount extends BaseModel
 
     /**
      * Return the products scope.
-     *
-     * @return Builder
      */
-    public function scopeProducts(Builder $query, iterable $productIds = [], string $type = null)
+    public function scopeProducts(Builder $query, iterable $productIds = [], string $type = null): Builder
     {
         if (is_array($productIds)) {
             $productIds = collect($productIds);
@@ -181,13 +185,11 @@ class Discount extends BaseModel
                 )
         );
     }
-    
+
     /**
      * Return the product variants scope.
-     *
-     * @return Builder
      */
-    public function scopeProductVariants(Builder $query, iterable $variantIds = [], string $type = null)
+    public function scopeProductVariants(Builder $query, iterable $variantIds = [], string $type = null): Builder
     {
         if (is_array($variantIds)) {
             $variantIds = collect($variantIds);
@@ -206,7 +208,10 @@ class Discount extends BaseModel
         );
     }
 
-    public function scopeUsable(Builder $query)
+    /**
+     * Return when the discount is usable.
+     */
+    public function scopeUsable(Builder $query): Builder
     {
         return $query->where(function ($subQuery) {
             $subQuery->whereRaw('uses < max_uses')

--- a/packages/core/src/Models/DiscountCollection.php
+++ b/packages/core/src/Models/DiscountCollection.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Database\Factories\DiscountPurchasableFactory;
-use Lunar\Discounts\Database\Factories\DiscountFactory;
 
 class DiscountCollection extends BaseModel
 {
@@ -26,8 +25,6 @@ class DiscountCollection extends BaseModel
 
     /**
      * Return a new factory instance for the model.
-     *
-     * @return DiscountFactory
      */
     protected static function newFactory(): DiscountPurchasableFactory
     {
@@ -36,15 +33,16 @@ class DiscountCollection extends BaseModel
 
     /**
      * Return the discount relationship.
-     *
-     * @return BelongsTo
      */
-    public function discount()
+    public function discount(): BelongsTo
     {
         return $this->belongsTo(Discount::class);
     }
 
-    public function collection()
+    /**
+     * Return the collection relationship.
+     */
+    public function collection(): BelongsTo
     {
         return $this->belongsTo(Collection::class);
     }

--- a/packages/core/src/Models/DiscountPurchasable.php
+++ b/packages/core/src/Models/DiscountPurchasable.php
@@ -4,9 +4,10 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Database\Factories\DiscountPurchasableFactory;
-use Lunar\Discounts\Database\Factories\DiscountFactory;
 
 /**
  * @property int $id
@@ -36,8 +37,6 @@ class DiscountPurchasable extends BaseModel
 
     /**
      * Return a new factory instance for the model.
-     *
-     * @return DiscountFactory
      */
     protected static function newFactory(): DiscountPurchasableFactory
     {
@@ -46,25 +45,24 @@ class DiscountPurchasable extends BaseModel
 
     /**
      * Return the discount relationship.
-     *
-     * @return BelongsTo
      */
-    public function discount()
+    public function discount(): BelongsTo
     {
         return $this->belongsTo(Discount::class);
     }
 
     /**
      * Return the priceable relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function purchasable()
+    public function purchasable(): MorphTo
     {
         return $this->morphTo();
     }
 
-    public function scopeCondition(Builder $query)
+    /**
+     * Scope a query where type is condition.
+     */
+    public function scopeCondition(Builder $query): void
     {
         $query->whereType('condition');
     }

--- a/packages/core/src/Models/Language.php
+++ b/packages/core/src/Models/Language.php
@@ -41,10 +41,8 @@ class Language extends BaseModel
 
     /**
      * Return the URLs relationship
-     *
-     * @return HasMany
      */
-    public function urls()
+    public function urls(): HasMany
     {
         return $this->hasMany(Url::class);
     }

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -4,6 +4,9 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\DiscountBreakdown;
 use Lunar\Base\Casts\Price;
@@ -80,10 +83,8 @@ class Order extends BaseModel
 
     /**
      * Getter for status label.
-     *
-     * @return string
      */
-    public function getStatusLabelAttribute()
+    public function getStatusLabelAttribute(): string
     {
         $statuses = config('lunar.orders.statuses');
 
@@ -92,170 +93,136 @@ class Order extends BaseModel
 
     /**
      * Return the channel relationship.
-     *
-     * @return void
      */
-    public function channel()
+    public function channel(): BelongsTo
     {
         return $this->belongsTo(Channel::class);
     }
 
     /**
      * Return the cart relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function cart()
+    public function cart(): BelongsTo
     {
         return $this->belongsTo(Cart::class);
     }
 
     /**
      * Return the lines relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function lines()
+    public function lines(): HasMany
     {
         return $this->hasMany(OrderLine::class);
     }
 
     /**
      * Return physical product lines relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function physicalLines()
+    public function physicalLines(): HasMany
     {
         return $this->lines()->whereType('physical');
     }
 
     /**
      * Return digital product lines relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function digitalLines()
+    public function digitalLines(): HasMany
     {
         return $this->lines()->whereType('digital');
     }
 
     /**
      * Return shipping lines relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function shippingLines()
+    public function shippingLines(): HasMany
     {
         return $this->lines()->whereType('shipping');
     }
 
     /**
      * Return product lines relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function productLines()
+    public function productLines(): HasMany
     {
         return $this->lines()->where('type', '!=', 'shipping');
     }
 
     /**
      * Return the currency relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function currency()
+    public function currency(): BelongsTo
     {
         return $this->belongsTo(Currency::class, 'currency_code', 'code');
     }
 
     /**
      * Return the addresses relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function addresses()
+    public function addresses(): HasMany
     {
         return $this->hasMany(OrderAddress::class, 'order_id');
     }
 
     /**
      * Return the shipping address relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function shippingAddress()
+    public function shippingAddress(): HasOne
     {
         return $this->hasOne(OrderAddress::class, 'order_id')->whereType('shipping');
     }
 
     /**
      * Return the billing address relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
      */
-    public function billingAddress()
+    public function billingAddress(): HasOne
     {
         return $this->hasOne(OrderAddress::class, 'order_id')->whereType('billing');
     }
 
     /**
      * Return the transactions relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function transactions()
+    public function transactions(): HasMany
     {
         return $this->hasMany(Transaction::class);
     }
 
     /**
      * Return the charges relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function captures()
+    public function captures(): HasMany
     {
         return $this->transactions()->whereType('capture');
     }
 
     /**
      * Return the charges relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function intents()
+    public function intents(): HasMany
     {
         return $this->transactions()->whereType('intent');
     }
 
     /**
      * Return the refunds relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function refunds()
+    public function refunds(): HasMany
     {
         return $this->transactions()->whereType('refund');
     }
 
     /**
      * Return the customer relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function customer()
+    public function customer(): BelongsTo
     {
         return $this->belongsTo(Customer::class);
     }
 
     /**
      * Return the user relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(
             config('auth.providers.users.model')

--- a/packages/core/src/Models/OrderAddress.php
+++ b/packages/core/src/Models/OrderAddress.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\Addressable;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
@@ -86,20 +87,16 @@ class OrderAddress extends BaseModel implements Addressable
 
     /**
      * Return the order relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function order()
+    public function order(): BelongsTo
     {
         return $this->belongsTo(Order::class);
     }
 
     /**
      * Return the country relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function country()
+    public function country(): BelongsTo
     {
         return $this->belongsTo(Country::class);
     }

--- a/packages/core/src/Models/OrderLine.php
+++ b/packages/core/src/Models/OrderLine.php
@@ -4,6 +4,9 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\Price;
 use Lunar\Base\Casts\TaxBreakdown;
@@ -74,30 +77,24 @@ class OrderLine extends BaseModel
 
     /**
      * Return the order relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function order()
+    public function order(): BelongsTo
     {
         return $this->belongsTo(Order::class);
     }
 
     /**
      * Return the polymorphic relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function purchasable()
+    public function purchasable(): MorphTo
     {
         return $this->morphTo();
     }
 
     /**
      * Return the currency relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function currency()
+    public function currency(): HasOneThrough
     {
         return $this->hasOneThrough(
             Currency::class,

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -3,6 +3,8 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\Price as CastsPrice;
 use Lunar\Base\Traits\HasMacros;
@@ -49,40 +51,32 @@ class Price extends BaseModel
 
     /**
      * Return the priceable relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function priceable()
+    public function priceable(): MorphTo
     {
         return $this->morphTo();
     }
 
     /**
      * Return the currency relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function currency()
+    public function currency(): BelongsTo
     {
         return $this->belongsTo(Currency::class);
     }
 
     /**
      * Return the customer group relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function customerGroup()
+    public function customerGroup(): BelongsTo
     {
         return $this->belongsTo(CustomerGroup::class);
     }
 
     /**
      * Return the price exclusive of tax.
-     *
-     * @return \Lunar\DataTypes\Price
      */
-    public function priceExTax()
+    public function priceExTax(): \Lunar\DataTypes\Price
     {
         if (! prices_inc_tax()) {
             return $this->price;
@@ -97,10 +91,8 @@ class Price extends BaseModel
 
     /**
      * Return the price inclusive of tax.
-     *
-     * @return \Lunar\DataTypes\Price
      */
-    public function priceIncTax()
+    public function priceIncTax(): int|\Lunar\DataTypes\Price
     {
         if (prices_inc_tax()) {
             return $this->price;
@@ -114,10 +106,8 @@ class Price extends BaseModel
 
     /**
      * Return the total tax rate amount within the predefined tax zone for the related priceable
-     *
-     * @return int|float
      */
-    protected function getPriceableTaxRate()
+    protected function getPriceableTaxRate(): int|float
     {
         return Blink::once('price_tax_rate_'.$this->priceable->getTaxClass()->id, function () {
             $taxZone = TaxZone::where('default', '=', 1)->first();

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -4,8 +4,12 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
@@ -79,50 +83,40 @@ class Product extends BaseModel implements SpatieHasMedia
 
     /**
      * Returns the attributes to be stored against this model.
-     *
-     * @return array
      */
-    public function mappedAttributes()
+    public function mappedAttributes(): Collection
     {
         return $this->productType->mappedAttributes;
     }
 
     /**
      * Return the product type relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function productType()
+    public function productType(): BelongsTo
     {
         return $this->belongsTo(ProductType::class);
     }
 
     /**
      * Return the product images relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    public function images()
+    public function images(): MorphMany
     {
         return $this->media()->where('collection_name', 'images');
     }
 
     /**
      * Return the product variants relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function variants()
+    public function variants(): HasMany
     {
         return $this->hasMany(ProductVariant::class);
     }
 
     /**
      * Return the product collections relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function collections()
+    public function collections(): BelongsToMany
     {
         return $this->belongsToMany(
             Collection::class,
@@ -132,44 +126,32 @@ class Product extends BaseModel implements SpatieHasMedia
 
     /**
      * Return the associations relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function associations()
+    public function associations(): HasMany
     {
         return $this->hasMany(ProductAssociation::class, 'product_parent_id');
     }
 
     /**
      * Return the associations relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function inverseAssociations()
+    public function inverseAssociations(): HasMany
     {
         return $this->hasMany(ProductAssociation::class, 'product_target_id');
     }
 
     /**
      * Associate a product to another with a type.
-     *
-     * @param  mixed  $product
-     * @param  string  $type
-     * @return void
      */
-    public function associate($product, $type)
+    public function associate(mixed $product, string $type): void
     {
         Associate::dispatch($this, $product, $type);
     }
 
     /**
      * Dissociate a product to another with a type.
-     *
-     * @param  mixed  $product
-     * @param  string  $type
-     * @return void
      */
-    public function dissociate($product, $type = null)
+    public function dissociate(mixed $product, string $type = null): void
     {
         Dissociate::dispatch($this, $product, $type);
     }
@@ -195,31 +177,24 @@ class Product extends BaseModel implements SpatieHasMedia
 
     /**
      * Return the brand relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function brand()
+    public function brand(): BelongsTo
     {
         return $this->belongsTo(Brand::class);
     }
 
     /**
      * Apply the status scope.
-     *
-     * @param  string  $status
-     * @return Builder
      */
-    public function scopeStatus(Builder $query, $status)
+    public function scopeStatus(Builder $query, string $status): Builder
     {
         return $query->whereStatus($status);
     }
 
     /**
      * Return the prices relationship.
-     *
-     * @return HasManyThrough
      */
-    public function prices()
+    public function prices(): HasManyThrough
     {
         return $this->hasManyThrough(
             Price::class,

--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -4,6 +4,7 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\ProductAssociationFactory;
@@ -22,12 +23,12 @@ class ProductAssociation extends BaseModel
     use HasMacros;
 
     /**
-     * Define the cross sell type.
+     * Define the cross-sell type.
      */
     const CROSS_SELL = 'cross-sell';
 
     /**
-     * Define the up sell type.
+     * Define the upsell type.
      */
     const UP_SELL = 'up-sell';
 
@@ -57,61 +58,48 @@ class ProductAssociation extends BaseModel
 
     /**
      * Return the parent relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function parent()
+    public function parent(): BelongsTo
     {
         return $this->belongsTo(Product::class, 'product_parent_id');
     }
 
     /**
      * Return the parent relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function target()
+    public function target(): BelongsTo
     {
         return $this->belongsTo(Product::class, 'product_target_id');
     }
 
     /**
-     * Apply the cross sell scope.
-     *
-     * @return void
+     * Apply the cross-sell scope.
      */
-    public function scopeCrossSell(Builder $query)
+    public function scopeCrossSell(Builder $query): void
     {
         $query->type(self::CROSS_SELL);
     }
 
     /**
-     * Apply the up sell scope.
-     *
-     * @return void
+     * Apply the upsell scope.
      */
-    public function scopeUpSell(Builder $query)
+    public function scopeUpSell(Builder $query): void
     {
         $query->type(self::UP_SELL);
     }
 
     /**
      * Apply the up alternate scope.
-     *
-     * @return void
      */
-    public function scopeAlternate(Builder $query)
+    public function scopeAlternate(Builder $query): void
     {
         $query->type(self::ALTERNATE);
     }
 
     /**
      * Apply the type scope.
-     *
-     * @param  string  $type
-     * @return void
      */
-    public function scopeType(Builder $query, $type)
+    public function scopeType(Builder $query, string $type): Builder
     {
         return $query->whereType($type);
     }

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -5,6 +5,7 @@ namespace Lunar\Models;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
@@ -48,12 +49,12 @@ class ProductOption extends BaseModel implements SpatieHasMedia
         return ProductOptionFactory::new();
     }
 
-    public function getNameAttribute($value)
+    public function getNameAttribute(string $value): mixed
     {
         return json_decode($value);
     }
 
-    protected function setNameAttribute($value)
+    protected function setNameAttribute(mixed $value): void
     {
         $this->attributes['name'] = json_encode($value);
     }
@@ -77,9 +78,9 @@ class ProductOption extends BaseModel implements SpatieHasMedia
     /**
      * Get the values.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<ProductOptionValue>
+     * @return HasMany<ProductOptionValue>
      */
-    public function values()
+    public function values(): HasMany
     {
         return $this->hasMany(ProductOptionValue::class)->orderBy('position');
     }

--- a/packages/core/src/Models/ProductOptionValue.php
+++ b/packages/core/src/Models/ProductOptionValue.php
@@ -4,6 +4,8 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\HasMedia;
@@ -51,22 +53,22 @@ class ProductOptionValue extends BaseModel implements SpatieHasMedia
      */
     protected $guarded = [];
 
-    protected function setNameAttribute($value)
-    {
-        $this->attributes['name'] = json_encode($value);
-    }
-
-    public function getNameAttribute($value)
+    public function getNameAttribute(string $value): mixed
     {
         return json_decode($value);
     }
 
-    public function option()
+    protected function setNameAttribute(mixed $value): void
+    {
+        $this->attributes['name'] = json_encode($value);
+    }
+
+    public function option(): BelongsTo
     {
         return $this->belongsTo(ProductOption::class, 'product_option_id');
     }
 
-    public function variants()
+    public function variants(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 

--- a/packages/core/src/Models/ProductType.php
+++ b/packages/core/src/Models/ProductType.php
@@ -3,6 +3,8 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasAttributes;
 use Lunar\Base\Traits\HasMacros;
@@ -38,10 +40,8 @@ class ProductType extends BaseModel
 
     /**
      * Get the mapped attributes relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function mappedAttributes()
+    public function mappedAttributes(): MorphToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -54,30 +54,24 @@ class ProductType extends BaseModel
 
     /**
      * Return the product attributes relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function productAttributes()
+    public function productAttributes(): MorphToMany
     {
         return $this->mappedAttributes()->whereAttributeType(Product::class);
     }
 
     /**
      * Return the variant attributes relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
      */
-    public function variantAttributes()
+    public function variantAttributes(): MorphToMany
     {
         return $this->mappedAttributes()->whereAttributeType(ProductVariant::class);
     }
 
     /**
      * Get the products relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function products()
+    public function products(): HasMany
     {
         return $this->hasMany(Product::class);
     }

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -3,6 +3,8 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
@@ -79,30 +81,24 @@ class ProductVariant extends BaseModel implements Purchasable
 
     /**
      * The related product.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function product()
+    public function product(): BelongsTo
     {
         return $this->belongsTo(Product::class)->withTrashed();
     }
 
     /**
      * Return the tax class relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxClass()
+    public function taxClass(): BelongsTo
     {
         return $this->belongsTo(TaxClass::class);
     }
 
     /**
      * Return the related product option values.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function values()
+    public function values(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -137,7 +133,7 @@ class ProductVariant extends BaseModel implements Purchasable
         });
     }
 
-    public function getTaxReference()
+    public function getTaxReference(): ?string
     {
         return $this->tax_ref;
     }
@@ -145,7 +141,7 @@ class ProductVariant extends BaseModel implements Purchasable
     /**
      * {@inheritDoc}
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->shippable ? 'physical' : 'digital';
     }
@@ -153,7 +149,7 @@ class ProductVariant extends BaseModel implements Purchasable
     /**
      * {@inheritDoc}
      */
-    public function isShippable()
+    public function isShippable(): bool
     {
         return $this->shippable;
     }
@@ -161,7 +157,7 @@ class ProductVariant extends BaseModel implements Purchasable
     /**
      * {@inheritDoc}
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->product->translateAttribute('name');
     }
@@ -169,7 +165,7 @@ class ProductVariant extends BaseModel implements Purchasable
     /**
      * {@inheritDoc}
      */
-    public function getOption()
+    public function getOption(): string
     {
         return $this->values->map(fn ($value) => $value->translate('name'))->join(', ');
     }
@@ -177,7 +173,7 @@ class ProductVariant extends BaseModel implements Purchasable
     /**
      * {@inheritDoc}
      */
-    public function getOptions()
+    public function getOptions(): Collection
     {
         return $this->values->map(fn ($value) => $value->translate('name'));
     }
@@ -185,12 +181,12 @@ class ProductVariant extends BaseModel implements Purchasable
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->sku;
     }
 
-    public function images()
+    public function images(): BelongsToMany
     {
         $prefix = config('lunar.database.table_prefix');
 
@@ -200,7 +196,7 @@ class ProductVariant extends BaseModel implements Purchasable
             ->withTimestamps();
     }
 
-    public function getThumbnail()
+    public function getThumbnail(): ?Media
     {
         return $this->images->first(function ($media) {
             return (bool) $media->pivot?->primary;

--- a/packages/core/src/Models/State.php
+++ b/packages/core/src/Models/State.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\StateFactory;
@@ -38,10 +39,8 @@ class State extends BaseModel
 
     /**
      * Return the country relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function country()
+    public function country(): BelongsTo
     {
         return $this->belongsTo(Country::class);
     }

--- a/packages/core/src/Models/Tag.php
+++ b/packages/core/src/Models/Tag.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TagFactory;
@@ -34,9 +35,8 @@ class Tag extends BaseModel
      */
     protected $guarded = [];
 
-    public function taggable()
+    public function taggable(): MorphTo
     {
         return $this->morphTo();
     }
-    
 }

--- a/packages/core/src/Models/TaxClass.php
+++ b/packages/core/src/Models/TaxClass.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasDefaultRecord;
 use Lunar\Base\Traits\HasMacros;
@@ -58,20 +59,16 @@ class TaxClass extends BaseModel
 
     /**
      * Return the tax rate amounts relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function taxRateAmounts()
+    public function taxRateAmounts(): HasMany
     {
         return $this->hasMany(TaxRateAmount::class);
     }
 
     /**
      * Return the ProductVariants relationship.
-     *
-     * @return HasMany
      */
-    public function productVariants()
+    public function productVariants(): HasMany
     {
         return $this->hasMany(ProductVariant::class);
     }

--- a/packages/core/src/Models/TaxRate.php
+++ b/packages/core/src/Models/TaxRate.php
@@ -3,6 +3,8 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TaxRateFactory;
@@ -38,20 +40,16 @@ class TaxRate extends BaseModel
 
     /**
      * Return the tax zone relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxZone()
+    public function taxZone(): BelongsTo
     {
         return $this->belongsTo(TaxZone::class);
     }
 
     /**
      * Return the tax rate amounts relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function taxRateAmounts()
+    public function taxRateAmounts(): HasMany
     {
         return $this->hasMany(TaxRateAmount::class);
     }

--- a/packages/core/src/Models/TaxRateAmount.php
+++ b/packages/core/src/Models/TaxRateAmount.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TaxRateAmountFactory;
@@ -45,20 +46,16 @@ class TaxRateAmount extends BaseModel
 
     /**
      * Return the tax rate relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxRate()
+    public function taxRate(): BelongsTo
     {
         return $this->belongsTo(TaxRate::class);
     }
 
     /**
      * Return the tax class relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxClass()
+    public function taxClass(): BelongsTo
     {
         return $this->belongsTo(TaxClass::class);
     }

--- a/packages/core/src/Models/TaxZone.php
+++ b/packages/core/src/Models/TaxZone.php
@@ -3,6 +3,8 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasDefaultRecord;
 use Lunar\Base\Traits\HasMacros;
@@ -52,60 +54,48 @@ class TaxZone extends BaseModel
 
     /**
      * Return the countries relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function countries()
+    public function countries(): HasMany
     {
         return $this->hasMany(TaxZoneCountry::class);
     }
 
     /**
      * Return the states relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function states()
+    public function states(): HasMany
     {
         return $this->hasMany(TaxZoneState::class);
     }
 
     /**
      * Return the postcodes relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function postcodes()
+    public function postcodes(): HasMany
     {
         return $this->hasMany(TaxZonePostcode::class);
     }
 
     /**
      * Return the customer groups relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function customerGroups()
+    public function customerGroups(): HasMany
     {
         return $this->hasMany(TaxZoneCustomerGroup::class);
     }
 
     /**
      * Return the tax rates relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function taxRates()
+    public function taxRates(): HasMany
     {
         return $this->hasMany(TaxRate::class);
     }
 
     /**
      * Return the tax amounts relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function taxAmounts()
+    public function taxAmounts(): HasManyThrough
     {
         return $this->hasManyThrough(TaxRateAmount::class, TaxRate::class);
     }

--- a/packages/core/src/Models/TaxZoneCountry.php
+++ b/packages/core/src/Models/TaxZoneCountry.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TaxZoneCountryFactory;
@@ -37,20 +38,16 @@ class TaxZoneCountry extends BaseModel
 
     /**
      * Return the tax zone relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxZone()
+    public function taxZone(): BelongsTo
     {
         return $this->belongsTo(TaxZone::class);
     }
 
     /**
      * Return the country relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function country()
+    public function country(): BelongsTo
     {
         return $this->belongsTo(Country::class);
     }

--- a/packages/core/src/Models/TaxZoneCustomerGroup.php
+++ b/packages/core/src/Models/TaxZoneCustomerGroup.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TaxZoneCustomerGroupFactory;
@@ -37,20 +38,16 @@ class TaxZoneCustomerGroup extends BaseModel
 
     /**
      * Return the customer group relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function customerGroup()
+    public function customerGroup(): BelongsTo
     {
         return $this->belongsTo(CustomerGroup::class);
     }
 
     /**
      * Return the tax zone relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxZone()
+    public function taxZone(): BelongsTo
     {
         return $this->belongsTo(TaxZone::class);
     }

--- a/packages/core/src/Models/TaxZonePostcode.php
+++ b/packages/core/src/Models/TaxZonePostcode.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TaxZonePostcodeFactory;
@@ -38,20 +39,16 @@ class TaxZonePostcode extends BaseModel
 
     /**
      * Return the tax zone relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxZone()
+    public function taxZone(): BelongsTo
     {
         return $this->belongsTo(TaxZone::class);
     }
 
     /**
      * Return the country relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function country()
+    public function country(): BelongsTo
     {
         return $this->belongsTo(Country::class);
     }

--- a/packages/core/src/Models/TaxZoneState.php
+++ b/packages/core/src/Models/TaxZoneState.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\TaxZoneStateFactory;
@@ -37,20 +38,16 @@ class TaxZoneState extends BaseModel
 
     /**
      * Return the tax zone relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function taxZone()
+    public function taxZone(): BelongsTo
     {
         return $this->belongsTo(TaxZone::class);
     }
 
     /**
      * Return the state relation.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function state()
+    public function state(): BelongsTo
     {
         return $this->belongsTo(State::class);
     }

--- a/packages/core/src/Models/Transaction.php
+++ b/packages/core/src/Models/Transaction.php
@@ -4,6 +4,8 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\Price;
 use Lunar\Base\Traits\HasMacros;
@@ -59,20 +61,16 @@ class Transaction extends BaseModel
 
     /**
      * Return the order relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function order()
+    public function order(): BelongsTo
     {
         return $this->belongsTo(Order::class);
     }
 
     /**
      * Return the currency relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOneThrough
      */
-    public function currency()
+    public function currency(): HasOneThrough
     {
         return $this->hasOneThrough(
             Currency::class,

--- a/packages/core/src/Models/Url.php
+++ b/packages/core/src/Models/Url.php
@@ -3,6 +3,9 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Query\Builder;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\UrlFactory;
@@ -49,31 +52,24 @@ class Url extends BaseModel
 
     /**
      * Return the element relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function element()
+    public function element(): MorphTo
     {
         return $this->morphTo();
     }
 
     /**
      * Return the language relationship.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function language()
+    public function language(): BelongsTo
     {
         return $this->belongsTo(Language::class);
     }
 
     /**
      * Return the query scope for default.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \Illuminate\Database\Query\Builder
      */
-    public function scopeDefault($query)
+    public function scopeDefault(Builder $query): Builder
     {
         return $query->whereDefault(true);
     }

--- a/utils/scout-database-engine/src/DatabaseEngine.php
+++ b/utils/scout-database-engine/src/DatabaseEngine.php
@@ -121,7 +121,7 @@ class DatabaseEngine extends Engine
         return SearchIndex::where('index', '=', $index)
             ->when(
                 $builder->query,
-                fn ($query) => $query ->whereFullText('content', $builder->query.'*', ['mode' => 'boolean'])
+                fn ($query) => $query ->whereFullText('content', "'\"".$builder->query.'*'."\"'", ['mode' => 'boolean'])
             );
     }
 

--- a/utils/scout-database-engine/src/DatabaseEngine.php
+++ b/utils/scout-database-engine/src/DatabaseEngine.php
@@ -121,7 +121,7 @@ class DatabaseEngine extends Engine
         return SearchIndex::where('index', '=', $index)
             ->when(
                 $builder->query,
-                fn ($query) => $query ->whereFullText('content', "'\"".$builder->query.'*'."\"'", ['mode' => 'boolean'])
+                fn ($query) => $query->whereFullText('content', '"'.$builder->query.'*"')
             );
     }
 


### PR DESCRIPTION
This PR fix issue #1355 

DatabaseEngine no longer espace query on SQL 

The engine execute query without quote and generate syntax error on database server

Before 

```
SELECT
  *
FROM
  `search_index`
WHERE
  `index` = "demostore_products"
  AND MATCH (`content`) against (email@* IN boolean mode)
``` 

After 

```
SELECT
  *
FROM
  `search_index`
WHERE
  `index` = "demostore_products"
  AND MATCH (`content`) against ('"email@*"' IN boolean mode)
``` 
