### PR TITLE
Monorepo splitting updates

### DIFF
--- a/.github/workflows/split_packages.yml
+++ b/.github/workflows/split_packages.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - "0.*"
+      - "1.*"
     tags:
       - "*"
 jobs:
@@ -16,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           coverage: none
 
       - name: Split ${{ matrix.package }}

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -34,7 +34,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PACKAGE_DIRECTORIES, [
         // default value
         __DIR__.'/packages',
-        __DIR__.'/utils',
     ]);
 
     // for "merge" command


### PR DESCRIPTION
Allows the new `1x` branch to automatically split into separate packages.