### PR TITLE
 fix creating product options in hub

### DIFF
--- a/packages/admin/tests/Unit/Http/Livewire/Components/Settings/Product/ProductOptionCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Settings/Product/ProductOptionCreateTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Lunar\Hub\Tests\Unit\Http\Livewire\Components\Settings\Product;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Lunar\Hub\Http\Livewire\Components\Settings\Product\Options\OptionsIndex;
+use Lunar\Hub\Models\Staff;
+use Lunar\Hub\Tests\TestCase;
+use Lunar\Models\Language;
+use Lunar\Models\ProductOption;
+
+class ProductOptionCreateTest extends TestCase
+{
+  use RefreshDatabase;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    Language::factory()->create([
+      'default' => true,
+      'code' => 'en',
+    ]);
+  }
+
+  /**
+   * @test
+   * */
+  public function can_populate_product_option_data()
+  {
+    $staff = Staff::factory()->create([
+      'admin' => true,
+    ]);
+
+    LiveWire::actingAs($staff, 'staff')
+      ->test(OptionsIndex::class)
+      ->set('newProductOption.name.' . Language::getDefault()->code, 'Size')
+      ->call('createOption');
+
+    $this->assertDatabaseHas((new ProductOption())->getTable(), [
+      'name' => json_encode([Language::getDefault()->code => 'Size']),
+    ]);
+  }
+}

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -49,7 +49,7 @@ class ProductOption extends BaseModel implements SpatieHasMedia
         return ProductOptionFactory::new();
     }
 
-    public function getNameAttribute(string $value): mixed
+    public function getNameAttribute(string $value = null): mixed
     {
         return json_decode($value);
     }


### PR DESCRIPTION
Addressing #1356

After commit https://github.com/lunarphp/lunar/commit/c456c783cde72cb58ea6e588e864883da7b0db4e creating product option in hub throws error 

`Lunar\Models\ProductOptionValue::getNameAttribute(): Argument #1 ($value) must be of type string, null given, called in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php on line 658`

Added test for creating a product option and in ProductOption.php, the function `getNameAttribute` now accepts null value as an argument to avoid the error. 

