### PR TITLE
Update link to admin docs on index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
     link: /core/overview
   - title: Admin Panel
     details: Filament-powered admin panel to administer your product catalog, customers, orders and much more.
-    link: #
+    link: /admin/overview
   - title: API - Coming Soon
     details: Connect to your store via a JSON:API, ideal for PWA storefronts and mobile apps.
 ---


### PR DESCRIPTION
Adds link to admin docs on front page.

![image](https://github.com/lunarphp/lunar/assets/1066486/90ef8c14-c721-4054-86a2-7a190b279971)