### PR TITLE
Feature - Add new badge total product published 

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ListProducts.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ListProducts.php
@@ -8,6 +8,7 @@ use Filament\Resources\Components\Tab;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Number;
 use Lunar\Admin\Filament\Resources\ProductResource;
 use Lunar\Admin\Support\Pages\BaseListRecords;
 use Lunar\Facades\DB;
@@ -91,10 +92,10 @@ class ListProducts extends BaseListRecords
             'all' => Tab::make('All'),
             'published' => Tab::make('Published')
                 ->modifyQueryUsing(fn (Builder $query) => $query->where('status', 'published'))
-                ->badge(Product::query()->where('status', 'published')->count()),
+                ->badge(Number::format(Product::query()->where('status', 'published')->count())),
             'draft' => Tab::make('Draft')
                 ->modifyQueryUsing(fn (Builder $query) => $query->where('status', 'draft'))
-                ->badge(Product::query()->where('status', 'draft')->count())->badgeColor('warning'),
+                ->badge(Number::format(Product::query()->where('status', 'draft')->count()))->badgeColor('warning'),
         ];
     }
 

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ListProducts.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ListProducts.php
@@ -90,10 +90,11 @@ class ListProducts extends BaseListRecords
         return [
             'all' => Tab::make('All'),
             'published' => Tab::make('Published')
-                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', 'published')),
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('status', 'published'))
+                ->badge(Product::query()->where('status', 'published')->count()),
             'draft' => Tab::make('Draft')
                 ->modifyQueryUsing(fn (Builder $query) => $query->where('status', 'draft'))
-                ->badge(Product::query()->where('status', 'draft')->count()),
+                ->badge(Product::query()->where('status', 'draft')->count())->badgeColor('warning'),
         ];
     }
 


### PR DESCRIPTION
Reference #1401 pr

The number of products in the catalog is not indicated anywhere. For example with my catalog team the leader like follow number of new products, draft products etc. 

I purpose variation on new commit,  I think that’s a much better approach.

![Capture d’écran 2023-12-21 à 13 46 50](https://github.com/lunarphp/lunar/assets/6489718/6b4a7e11-c8ee-41e2-9944-cbb38722cb26)
