### PR TITLE
Dropdown attribute change label name

### DIFF
--- a/packages/admin/resources/lang/en/fieldtypes.php
+++ b/packages/admin/resources/lang/en/fieldtypes.php
@@ -6,6 +6,8 @@ return [
         'form' => [
             'lookups' => [
                 'label' => 'Lookups',
+                'key_label' => 'Label',
+                'value_label' => 'Value',
             ],
         ],
     ],

--- a/packages/admin/src/Support/FieldTypes/Dropdown.php
+++ b/packages/admin/src/Support/FieldTypes/Dropdown.php
@@ -26,18 +26,22 @@ class Dropdown extends BaseFieldType
         return [
             KeyValue::make('lookups')->label(
                 __('lunarpanel::fieldtypes.dropdown.form.lookups.label')
-            )->formatStateUsing(function ($state) {
-                return collect($state)->mapWithKeys(
-                    fn ($lookup) => [$lookup['label'] => $lookup['value'] ?? $lookup['label']]
-                )->toArray();
-            })->mutateDehydratedStateUsing(function ($state) {
-                return collect($state)->map(function ($value, $label) {
-                    return [
-                        'label' => $label ?? $value,
-                        'value' => $value,
-                    ];
-                })->values()->toArray();
-            }),
+            )
+                ->keyLabel(__('lunarpanel::fieldtypes.dropdown.form.lookups.key_label'))
+                ->valueLabel(__('lunarpanel::fieldtypes.dropdown.form.lookups.value_label'))
+                ->formatStateUsing(function ($state) {
+                    return collect($state)->mapWithKeys(
+                        fn ($lookup) => [$lookup['label'] => $lookup['value'] ?? $lookup['label']]
+                    )->toArray();
+                })
+                ->mutateDehydratedStateUsing(function ($state) {
+                    return collect($state)->map(function ($value, $label) {
+                        return [
+                            'label' => $label ?? $value,
+                            'value' => $value,
+                        ];
+                    })->values()->toArray();
+                }),
         ];
     }
 }


### PR DESCRIPTION
In the legacy hub, dropdown product attribute is labeled as label-value, instead of the key-value default label in filament field

Hub
![image](https://github.com/lunarphp/lunar/assets/67364036/b7a9773d-02b4-4c06-9dd6-007731a89782)

Before
![image](https://github.com/lunarphp/lunar/assets/67364036/a47e32a6-2096-4889-9e64-175f23049418)

After
![image](https://github.com/lunarphp/lunar/assets/67364036/5f0cae36-af7a-4e1f-a23a-886e7c8f00a4)

