### PR TITLE
Docs: fix example usage of addLines

### DIFF
--- a/docs/core/reference/carts.md
+++ b/docs/core/reference/carts.md
@@ -279,7 +279,7 @@ CartSession::add($purchasable, $quantity);
 ```php
 CartSession::addLines([
     [
-        'id' => 1,
+        'purchasable' => \Lunar\Models\ProductVariant::find(123),
         'quantity' => 25,
         'meta' => ['foo' => 'bar'],
     ],


### PR DESCRIPTION
Fixes a typo in the example of CartSession::addLines usage.

The implementation of [addLines](https://github.com/lunarphp/lunar/blob/7f41cf66ebc96ee7465a84c8a4c4dd24228bf47d/packages/core/src/Models/Cart.php#L337C10-L337C10) currently expects a purchasable instance as below:
```php
public function add(Purchasable $purchasable, int $quantity = 1, array $meta = [], bool $refresh = true): Cart
{
    foreach (config('lunar.cart.validators.add_to_cart', []) as $action) {
        // Throws a validation exception?
        app($action)->using(
            cart: $this,
            purchasable: $purchasable,
            quantity: $quantity,
            meta: $meta
        )->validate();
    }

    return app(
        config('lunar.cart.actions.add_to_cart', AddOrUpdatePurchasable::class)
    )->execute($this, $purchasable, $quantity, $meta)
        ->then(fn () => $refresh ? $this->refresh()->calculate() : $this);
}

public function addLines(iterable $lines): Cart
{
    DB::transaction(function () use ($lines) {
        collect($lines)->each(function ($line) {
            $this->add(
                purchasable: $line['purchasable'],
                quantity: $line['quantity'],
                meta: (array) ($line['meta'] ?? null),
                refresh: false
            );
        });
    });

    return $this->refresh()->calculate();
}
```

