### PR TITLE
Fix - Multiple call permission manifest

### DIFF
--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -96,7 +96,7 @@ class LunarPanelProvider extends ServiceProvider
     {
         Gate::after(function ($user, $ability) {
             // Are we trying to authorize something within the admin panel?
-            $permission = $this->app->get(Manifest::class)->getPermissions()->first(fn ($permission) => $permission->handle === $ability);
+            $permission = $this->app->get('lunar-access-control')->getPermissions()->first(fn ($permission) => $permission->handle === $ability);
             if ($permission) {
                 return $user->admin || $user->hasPermissionTo($ability);
             }


### PR DESCRIPTION
Fix multiple call in permission Manifest, now Gate call the singleton 'lunar-access-control'

The fix increase performance and loading pages remove zombie queries.