### PR TITLE
Fix: Error selecting applicable discounts

### DIFF
--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -149,7 +149,13 @@ class DiscountManager implements DiscountManagerInterface
                 }
             )->when(
                 $cart?->coupon_code,
-                fn ($query, $value) => $query->where('coupon', '=', $value)->orWhere(fn ($query) => $query->whereNull('coupon')->orWhere('coupon', '')),
+                function ($query, $value) {
+                    return $query->where(function ($query) use ($value) {
+                        $query->where('coupon', $value)
+                            ->orWhereNull('coupon')
+                            ->orWhere('coupon', '');
+                    });
+                },
                 fn ($query, $value) => $query->whereNull('coupon')->orWhere('coupon', '')
             )->orderBy('priority', 'desc')
             ->orderBy('id')


### PR DESCRIPTION
The discount selection currently takes all the discounts with and without coupon code because of [ this conditional query ](https://github.com/lunarphp/lunar/blob/7f41cf66ebc96ee7465a84c8a4c4dd24228bf47d/packages/core/src/Managers/DiscountManager.php#L152)
```php
->when($cart?->coupon_code,
                fn ($query, $value) => $query->where('coupon', '=', $value)->orWhere(fn ($query) => $query->whereNull('coupon')->orWhere('coupon', '')),
                fn ($query, $value) => $query->whereNull('coupon')->orWhere('coupon', '')
            )
```
when the `$cart?->coupon_code` is true, it executes the first closure in which it selects the discounts having the correct coupon but also the discounts with null coupon code or empty strings. Only the second clousure (executed when `$cart?->coupon_code` is false) should selects the discount with null coupons or empty.

This issue currently make the query selects all the discounts that has no coupon_code (even the expired ones, because of the OR clause)
Below a simplified result of the ->toSql() of the query.
```sql
select *
from `lunar_discounts`
where `starts_at` is not null and `starts_at` <= now() and (`ends_at` is null or `ends_at` > now())
          and (uses < max_uses or `max_uses` is null)
          and `coupon` = 'EXAMPLE_CODE' or (`coupon` is null or `coupon` = '')
order by `priority` desc, `id` asc
```

The PR essentially changes the positive closure. By making use of a where condition with a closure, the query builder creates a logical group around the WHERE conditions and the resulting SQL query will have the affected conditions placed in parentheses, as the simplified example below:
```sql
select *
from `lunar_discounts`
where `starts_at` is not null and `starts_at` <= now() and (`ends_at` is null or `ends_at` > now())
          and (uses < max_uses or `max_uses` is null)
          and (`coupon` = 'EXAMPLE_CODE' or `coupon` is null or `coupon` = '')
order by `priority` desc, `id` asc
``` 

PS: the provided example are simplified because for readability purpose i removed the subqueries relative to channels, customer groups and discount's purchasables.



