### PR TITLE
Fix - change color alert state

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource.php
+++ b/packages/admin/src/Filament/Resources/ProductResource.php
@@ -80,19 +80,19 @@ class ProductResource extends BaseResource
                 Shout::make('product-status')
                     ->content(
                         __('lunarpanel::product.status.unpublished.content')
-                    )->type('danger')->hidden(
+                    )->type('info')->hidden(
                         fn (Model $record) => $record?->status == 'published'
                     ),
                 Shout::make('product-customer-groups')
                     ->content(
                         __('lunarpanel::product.status.availability.customer_groups')
-                    )->type('danger')->hidden(function (Model $record) {
+                    )->type('warning')->hidden(function (Model $record) {
                         return $record->customerGroups()->where('enabled', true)->count();
                     }),
                 Shout::make('product-channels')
                     ->content(
                         __('lunarpanel::product.status.availability.channels')
-                    )->type('danger')->hidden(function (Model $record) {
+                    )->type('warning')->hidden(function (Model $record) {
                         return $record->channels()->where('enabled', true)->count();
                     }),
                 Forms\Components\Section::make()


### PR DESCRIPTION
I changed alert color in order to clarify visibility of user. 

Before 

<img width="1159" alt="Capture d’écran 2024-01-07 à 15 32 43" src="https://github.com/lunarphp/lunar/assets/6489718/8967402c-1355-4311-ae96-02fd1e83edcd">

After 

<img width="1143" alt="Capture d’écran 2024-01-07 à 15 33 04" src="https://github.com/lunarphp/lunar/assets/6489718/e2b11747-9a65-4f53-ab71-d1f712b76529">
