### PR TITLE
Feature - Restore legacy informations in display list

### DIFF
--- a/packages/admin/resources/lang/en/brand.php
+++ b/packages/admin/resources/lang/en/brand.php
@@ -11,8 +11,8 @@ return [
             'label' => 'Name',
         ],
         'products_count' => [
-            'label'=> 'Product count',
-        ]
+            'label' => 'No. Products',
+        ],
     ],
 
     'form' => [

--- a/packages/admin/resources/lang/en/brand.php
+++ b/packages/admin/resources/lang/en/brand.php
@@ -10,6 +10,9 @@ return [
         'name' => [
             'label' => 'Name',
         ],
+        'products_count' => [
+            'label'=> 'Product count',
+        ]
     ],
 
     'form' => [

--- a/packages/admin/resources/lang/en/producttype.php
+++ b/packages/admin/resources/lang/en/producttype.php
@@ -11,14 +11,14 @@ return [
             'label' => 'Name',
         ],
         'products_count' => [
-            'label'=> 'Product count',
+            'label' => 'Product count',
         ],
         'product_attributes_count' => [
-            'label'=> 'Attributes Product count',
+            'label' => 'Product Attributes',
         ],
         'variant_attributes_count' => [
-            'label'=> 'Attributes Variant count',
-        ]
+            'label' => 'Variant Attributes',
+        ],
     ],
 
     'tabs' => [

--- a/packages/admin/resources/lang/en/producttype.php
+++ b/packages/admin/resources/lang/en/producttype.php
@@ -10,6 +10,15 @@ return [
         'name' => [
             'label' => 'Name',
         ],
+        'products_count' => [
+            'label'=> 'Product count',
+        ],
+        'product_attributes_count' => [
+            'label'=> 'Attributes Product count',
+        ],
+        'variant_attributes_count' => [
+            'label'=> 'Attributes Variant count',
+        ]
     ],
 
     'form' => [

--- a/packages/admin/src/Filament/Resources/BrandResource.php
+++ b/packages/admin/src/Filament/Resources/BrandResource.php
@@ -96,6 +96,12 @@ class BrandResource extends BaseResource
                 ->label(''),
             Tables\Columns\TextColumn::make('name')
                 ->label(__('lunarpanel::brand.table.name.label')),
+            Tables\Columns\TextColumn::make('products_count')
+                ->counts('products')
+                ->formatStateUsing(
+                    fn ($state) => number_format($state, 0)
+                )
+                ->label(__('lunarpanel::brand.table.products_count.label')),
         ];
     }
 

--- a/packages/admin/src/Filament/Resources/ProductTypeResource.php
+++ b/packages/admin/src/Filament/Resources/ProductTypeResource.php
@@ -129,7 +129,10 @@ class ProductTypeResource extends BaseResource
                 ->formatStateUsing(
                     fn ($state) => number_format($state, 0)
                 )
-                ->label(__('lunarpanel::producttype.table.variant_attributes_count.label')),
+                ->label(__('lunarpanel::producttype.table.variant_attributes_count.label'))
+                ->visible(
+                    config('lunar.panel.enable_variants', true)
+                ),
         ];
     }
 

--- a/packages/admin/src/Filament/Resources/ProductTypeResource.php
+++ b/packages/admin/src/Filament/Resources/ProductTypeResource.php
@@ -110,6 +110,24 @@ class ProductTypeResource extends BaseResource
         return [
             Tables\Columns\TextColumn::make('name')
                 ->label(__('lunarpanel::producttype.table.name.label')),
+            Tables\Columns\TextColumn::make('products_count')
+                ->counts('products')
+                ->formatStateUsing(
+                    fn ($state) => number_format($state, 0)
+                )
+                ->label(__('lunarpanel::producttype.table.products_count.label')),
+            Tables\Columns\TextColumn::make('product_attributes_count')
+                ->counts('productAttributes')
+                ->formatStateUsing(
+                    fn ($state) => number_format($state, 0)
+                )
+                ->label(__('lunarpanel::producttype.table.product_attributes_count.label')),
+            Tables\Columns\TextColumn::make('variant_attributes_count')
+                ->counts('variantAttributes')
+                ->formatStateUsing(
+                    fn ($state) => number_format($state, 0)
+                )
+                ->label(__('lunarpanel::producttype.table.variant_attributes_count.label')),
         ];
     }
 


### PR DESCRIPTION
Restore legacy display informations in the product type list and brands

<img width="1120" alt="Capture d’écran 2024-01-07 à 16 25 18" src="https://github.com/lunarphp/lunar/assets/6489718/149bca32-b575-4510-8d1e-15c18d7e8077">
<img width="1144" alt="Capture d’écran 2024-01-07 à 16 25 10" src="https://github.com/lunarphp/lunar/assets/6489718/3fa9f203-cd7b-4719-a6cd-eb2374e46ea3">
