### PR TITLE
Fix: use session's customer groups correctly

### DIFF
--- a/packages/core/src/Managers/StorefrontSessionManager.php
+++ b/packages/core/src/Managers/StorefrontSessionManager.php
@@ -80,7 +80,7 @@ class StorefrontSessionManager implements StorefrontSessionInterface
         );
 
         if ($this->customerGroups?->count()) {
-            if (! $groupHandles) {
+            if ($groupHandles->isEmpty()) {
                 return $this->setCustomerGroups(
                     $this->customerGroups
                 );
@@ -89,7 +89,7 @@ class StorefrontSessionManager implements StorefrontSessionInterface
             return $this->customerGroups;
         }
 
-        if (count($groupHandles) > 0) {
+        if (! $groupHandles->isEmpty()) {
             return $this->customerGroups = CustomerGroup::whereIn('handle', $groupHandles)->get();
         }
 

--- a/packages/core/src/Managers/StorefrontSessionManager.php
+++ b/packages/core/src/Managers/StorefrontSessionManager.php
@@ -89,16 +89,14 @@ class StorefrontSessionManager implements StorefrontSessionInterface
             return $this->customerGroups;
         }
 
-        if (! $this->customerGroups?->count()) {
-            return $this->setCustomerGroups(
-                collect([
-                    CustomerGroup::getDefault(),
-                ])
-            );
+        if (count($groupHandles) > 0) {
+            return $this->customerGroups = CustomerGroup::whereIn('handle', $groupHandles)->get();
         }
 
         return $this->setCustomerGroups(
-            CustomerGroup::whereIn('handle', $groupHandles)->get()
+            collect([
+                CustomerGroup::getDefault(),
+            ])
         );
     }
 


### PR DESCRIPTION
### Previously saved customerGroups are not used
This occurs because the condition present in the second if is always true when the previous one is false and the latest return instruction is never reached. 
This always involves using the default customerGroup, ignoring customer groups from the session.
```php
public function initCustomerGroups()
{
    $groupHandles = collect(
        $this->sessionManager->get(
            $this->getSessionKey().'_customer_groups'
        )
    );

    if ($this->customerGroups?->count()) {
        if (! $groupHandles) {
            return $this->setCustomerGroups(
                $this->customerGroups
            );
        }

        return $this->customerGroups;
    }

    if (! $this->customerGroups?->count()) {
        return $this->setCustomerGroups(
            collect([
                CustomerGroup::getDefault(),
            ])
        );
    }

    return $this->setCustomerGroups(
        CustomerGroup::whereIn('handle', $groupHandles)->get()
    );
}
```

this PR uses the $groupHandles (session's customer group) to initialise the current customer groups, if something is present, otherwise it uses the default one.

```php
public function initCustomerGroups()
{
    $groupHandles = collect(
        $this->sessionManager->get(
            $this->getSessionKey().'_customer_groups'
        )
    );

    if ($this->customerGroups?->count()) {
        if (! $groupHandles) {
            return $this->setCustomerGroups(
                $this->customerGroups
            );
        }

        return $this->customerGroups;
    }

    if (count($groupHandles) > 0) {
        return $this->customerGroups = CustomerGroup::whereIn('handle', $groupHandles)->get();
    }

    return $this->setCustomerGroups(
        collect([
            CustomerGroup::getDefault(),
        ])
    );
}
```

PS: the `if (count($groupHandles) > 0)` doesn't use the setCustomerGroups method because the session already contain those values, overwriting them is useless.