### PR TITLE
Feature - Hide variant attributes when disabled

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductTypeResource.php
+++ b/packages/admin/src/Filament/Resources/ProductTypeResource.php
@@ -66,8 +66,8 @@ class ProductTypeResource extends BaseResource
                                 ->relationship(name: 'mappedAttributes')
                                 ->label('')
                                 ->columnSpan(2),
-                        ])->hidden(
-                            fn () => config('lunar.panel.enabled_variants', true)
+                        ])->visible(
+                            config('lunar.panel.enable_variants', false)
                         ),
 
                 ])->columnSpan(2),

--- a/packages/admin/src/Filament/Resources/ProductTypeResource.php
+++ b/packages/admin/src/Filament/Resources/ProductTypeResource.php
@@ -66,7 +66,9 @@ class ProductTypeResource extends BaseResource
                                 ->relationship(name: 'mappedAttributes')
                                 ->label('')
                                 ->columnSpan(2),
-                        ]),
+                        ])->hidden(
+                            fn () => config('lunar.panel.enabled_variants', true)
+                        ),
 
                 ])->columnSpan(2),
             ]);


### PR DESCRIPTION
Some PR to remove variant attributes from product type editing when they have been disabled in the config.