### PR TITLE
Fix date formatting in order-related charts

### DIFF
--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/AverageOrderValueChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/AverageOrderValueChart.php
@@ -162,7 +162,7 @@ class AverageOrderValueChart extends ApexChartWidget
                 DB::RAW('year'),
                 DB::RAW('monthstamp'),
                 DB::RAW(db_date('placed_at', '%Y-%m')),
-            )->orderBy(DB::RAW("DATE_FORMAT(placed_at, '%Y-%m')"), 'desc')->get();
+            )->orderBy(DB::RAW(db_date('placed_at', '%Y-%m')), 'desc')->get();
 
         foreach ($period as $date) {
             // Find our records for this period.

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php
@@ -51,7 +51,7 @@ class NewVsReturningCustomersChart extends ApexChartWidget
                 ) as new_customer_count'),
                 DB::RAW('SUM(
                     CASE
-                        WHEN !new_customer THEN 1 
+                        WHEN NOT new_customer THEN 1 
                         ELSE 0
                     END
                 ) as returning_customer_count'),
@@ -64,7 +64,7 @@ class NewVsReturningCustomersChart extends ApexChartWidget
                 DB::RAW('year'),
                 DB::RAW('monthstamp'),
                 DB::RAW(db_date('placed_at', '%Y-%m')),
-            )->orderBy(DB::RAW("DATE_FORMAT(placed_at, '%Y-%m')"), 'desc')->get();
+            )->orderBy(DB::RAW(db_date('placed_at', '%Y-%m')), 'desc')->get();
 
         $labels = [];
         $newCustomers = [];
@@ -137,7 +137,7 @@ class NewVsReturningCustomersChart extends ApexChartWidget
                 DB::RAW('year'),
                 DB::RAW('monthstamp'),
                 DB::RAW(db_date('placed_at', '%Y-%m')),
-            )->orderBy(DB::RAW("DATE_FORMAT(placed_at, '%Y-%m')"), 'desc')->get();
+            )->orderBy(DB::RAW(db_date('placed_at', '%Y-%m')), 'desc')->get();
 
         foreach ($period as $date) {
             // Find our records for this period.

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderTotalsChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderTotalsChart.php
@@ -109,7 +109,7 @@ class OrderTotalsChart extends ApexChartWidget
                 DB::RAW('year'),
                 DB::RAW('monthstamp'),
                 DB::RAW(db_date('placed_at', '%Y-%m')),
-            )->orderBy(DB::RAW("DATE_FORMAT(placed_at, '%Y-%m')"), 'desc')->get();
+            )->orderBy(DB::RAW(db_date('placed_at', '%Y-%m')), 'desc')->get();
 
         foreach ($period as $date) {
             // Find our records for this period.


### PR DESCRIPTION
This PR fixes some issues in the charts widgets, where the widgets was using `DATE_FORMAT` directly, instead of using the `db_date` helper function. This made the charts tightly coupled to MySQL.

This PR should fix this issue, ensuring the charts will work across the supported database drivers.