### PR TITLE
Fix - null safe operator for Dashboard Order Total

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Products/Tables/ProductVariantsTable.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/Tables/ProductVariantsTable.php
@@ -63,7 +63,7 @@ class ProductVariantsTable extends Table
             TextColumn::make('price', function ($record) {
                 $price = $record->basePrices->first(fn ($price) => $price->currency->default);
 
-                return $price->price->formatted;
+                return $price->price->formatted ?? 0;
             }),
             TextColumn::make('stock'),
             TextColumn::make('backorder'),

--- a/packages/admin/src/Http/Livewire/Dashboard.php
+++ b/packages/admin/src/Http/Livewire/Dashboard.php
@@ -64,14 +64,14 @@ class Dashboard extends Component
             return 0;
         }
 
-        $returning = $orders->first(fn ($order) => ! $order->new_customer);
+        $returning = $orders->first(fn ($order) => !$order->new_customer);
         $new = $orders->first(fn ($order) => $order->new_customer);
 
-        if (! $returning || ! $returning->count) {
+        if (!$returning || !$returning->count) {
             return 0;
         }
 
-        if (! $new || ! $new->count) {
+        if (!$new || !$new->count) {
             return 100;
         }
 
@@ -115,7 +115,7 @@ class Dashboard extends Component
             DB::RAW('SUM(sub_total) as total')
         )->first();
 
-        return new Price($query->total->value, $this->defaultCurrency, 1);
+        return new Price($query->total->value ?? 0, $this->defaultCurrency, 1);
     }
 
     /**
@@ -220,7 +220,7 @@ class Dashboard extends Component
         foreach ($customerGroups as $group) {
             // Find our counts...
             $data = $orders->filter(function ($row) use ($group) {
-                if ($group->default && ! $row->customer_group_id) {
+                if ($group->default && !$row->customer_group_id) {
                     return true;
                 }
 

--- a/packages/admin/src/Http/Livewire/Dashboard.php
+++ b/packages/admin/src/Http/Livewire/Dashboard.php
@@ -64,14 +64,14 @@ class Dashboard extends Component
             return 0;
         }
 
-        $returning = $orders->first(fn ($order) => !$order->new_customer);
+        $returning = $orders->first(fn ($order) => ! $order->new_customer);
         $new = $orders->first(fn ($order) => $order->new_customer);
 
-        if (!$returning || !$returning->count) {
+        if (! $returning || ! $returning->count) {
             return 0;
         }
 
-        if (!$new || !$new->count) {
+        if (! $new || ! $new->count) {
             return 100;
         }
 
@@ -220,7 +220,7 @@ class Dashboard extends Component
         foreach ($customerGroups as $group) {
             // Find our counts...
             $data = $orders->filter(function ($row) use ($group) {
-                if ($group->default && !$row->customer_group_id) {
+                if ($group->default && ! $row->customer_group_id) {
                     return true;
                 }
 


### PR DESCRIPTION
This PR can prevent potential errors after trying to create a new `Order` and maybe could be deleted.

Encountered this error:

<img width="1373" alt="Screenshot 2024-01-13 at 3 32 16 PM" src="https://github.com/lunarphp/lunar/assets/3388422/75624b58-b5d0-4ea3-87a8-8cb73da1041d">
