### PR TITLE
fix: property definition for currency_code in Order model

### DIFF
--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -35,7 +35,7 @@ use Lunar\Database\Factories\OrderFactory;
  * @property int $tax_total
  * @property int $total
  * @property ?string $notes
- * @property string $currency
+ * @property string $currency_code
  * @property ?string $compare_currency_code
  * @property float $exchange_rate
  * @property ?\Illuminate\Support\Carbon $placed_at


### PR DESCRIPTION
The property tag for `currency_code` in the `order` table was defined as `@property string $currency`
This is corrected to `@property string $currency_code`.