### PR TITLE
Fix - Query scout database engine #1355

### DIFF
--- a/utils/scout-database-engine/src/DatabaseEngine.php
+++ b/utils/scout-database-engine/src/DatabaseEngine.php
@@ -121,7 +121,7 @@ class DatabaseEngine extends Engine
         return SearchIndex::where('index', '=', $index)
             ->when(
                 $builder->query,
-                fn ($query) => $query->whereFullText('content', $builder->query.'*', ['mode' => 'boolean'])
+                fn ($query) => $query->whereFullText('content', '"'.$builder->query.'*"')
             );
     }
 


### PR DESCRIPTION
This PR fix issue [#1355](https://github.com/lunarphp/lunar/issues/1355)

DatabaseEngine no longer espace query on SQL

The engine execute query without quote and generate syntax error on database server