### PR TITLE
Allow discount cache to be reset

### DIFF
--- a/docs/core/reference/discounts.md
+++ b/docs/core/reference/discounts.md
@@ -66,6 +66,14 @@ Discount::usable()->get();
 Discount::products($productIds, $type = 'condition');
 ```
 
+### Resetting the discount cache
+
+For performance reasons the applicable discounts are cached per request. If you need to reset this cache (for example after adding a discount code) you should call `resetDiscounts()`:
+
+```php
+Discount::resetDiscounts();
+```
+
 ## Discount Purchasable
 
 You can relate a purchasable to a discount via this model. Each has a type for whether it's a `condition` or `reward`.

--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -209,6 +209,13 @@ class DiscountManager implements DiscountManagerInterface
         return $cart;
     }
 
+    public function resetDiscounts(): self
+    {
+        $this->discounts = null;
+
+        return $this;
+    }
+
     public function validateCoupon(string $coupon): bool
     {
         return app(


### PR DESCRIPTION
This PR adds the ability to reset the DiscountManager query cache - this is necessary if you add a discount coupon and want to update the cart totals in the same request.