### PR TITLE
Fix discount product and variants purchasables query

### DIFF
--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -139,12 +139,12 @@ class DiscountManager implements DiscountManagerInterface
                     return $query->where(function ($query) use ($value) {
                         return $query->where(fn ($query) => $query->products(
                                     $value->lines->pluck('purchasable.product_id')->filter()->values(),
-                                    'limitation'
+                                    ['condition', 'limitation']
                                 )
                             )
                             ->orWhere(fn ($query) => $query->productVariants(
                                     $value->lines->pluck('purchasable.id')->filter()->values(),
-                                    'limitation'
+                                    ['condition', 'limitation']
                                 )
                             );
                     });

--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -138,16 +138,19 @@ class DiscountManager implements DiscountManagerInterface
                 function ($query, $value) {
                     return $query->where(function ($query) use ($value) {
                         return $query->where(fn ($query) => $query->products(
-                            $value->lines->pluck('purchasable.product_id')->filter()->values()
-                        )
-                        )
-                            ->orWhere(fn ($query) => $query->productVariants(
-                                $value->lines->pluck('purchasable.id')->filter()->values()
+                                    $value->lines->pluck('purchasable.product_id')->filter()->values(),
+                                    'limitation'
+                                )
                             )
+                            ->orWhere(fn ($query) => $query->productVariants(
+                                    $value->lines->pluck('purchasable.id')->filter()->values(),
+                                    'limitation'
+                                )
                             );
                     });
                 }
-            )->when(
+            )
+            ->when(
                 $cart?->coupon_code,
                 function ($query, $value) {
                     return $query->where(function ($query) use ($value) {

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -174,7 +174,7 @@ class Discount extends BaseModel
         }
 
         return $query->where(
-            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables')
+            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables', fn ($query) => $query->when($type, fn ($query) => $query->whereType($type)))
                 ->orWhereHas('purchasables',
                     fn ($relation) => $relation->whereIn('purchasable_id', $productIds)
                         ->wherePurchasableType(Product::class)
@@ -196,7 +196,7 @@ class Discount extends BaseModel
         }
 
         return $query->where(
-            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables')
+            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables', fn ($query) => $query->when($type, fn ($query) => $query->whereType($type)))
                 ->orWhereHas('purchasables',
                     fn ($relation) => $relation->whereIn('purchasable_id', $variantIds)
                         ->wherePurchasableType(ProductVariant::class)

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Arr;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasChannels;
 use Lunar\Base\Traits\HasCustomerGroups;
@@ -167,20 +168,22 @@ class Discount extends BaseModel
     /**
      * Return the products scope.
      */
-    public function scopeProducts(Builder $query, iterable $productIds = [], string $type = null): Builder
+    public function scopeProducts(Builder $query, iterable $productIds = [], array|string $types = []): Builder
     {
         if (is_array($productIds)) {
             $productIds = collect($productIds);
         }
 
+        $types = Arr::wrap($types);
+
         return $query->where(
-            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables', fn ($query) => $query->when($type, fn ($query) => $query->whereType($type)))
+            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables', fn ($query) => $query->when($types, fn ($query) => $query->whereIn('type', $types)))
                 ->orWhereHas('purchasables',
                     fn ($relation) => $relation->whereIn('purchasable_id', $productIds)
                         ->wherePurchasableType(Product::class)
                         ->when(
-                            $type,
-                            fn ($query) => $query->whereType($type)
+                            $types,
+                            fn ($query) => $query->whereIn('type', $types)
                         )
                 )
         );
@@ -189,20 +192,22 @@ class Discount extends BaseModel
     /**
      * Return the product variants scope.
      */
-    public function scopeProductVariants(Builder $query, iterable $variantIds = [], string $type = null): Builder
+    public function scopeProductVariants(Builder $query, iterable $variantIds = [], array|string $types = []): Builder
     {
         if (is_array($variantIds)) {
             $variantIds = collect($variantIds);
         }
 
+        $types = Arr::wrap($types);
+
         return $query->where(
-            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables', fn ($query) => $query->when($type, fn ($query) => $query->whereType($type)))
+            fn ($subQuery) => $subQuery->whereDoesntHave('purchasables', fn ($query) => $query->when($types, fn ($query) => $query->whereIn('type', $types)))
                 ->orWhereHas('purchasables',
                     fn ($relation) => $relation->whereIn('purchasable_id', $variantIds)
                         ->wherePurchasableType(ProductVariant::class)
                         ->when(
-                            $type,
-                            fn ($query) => $query->whereType($type)
+                            $types,
+                            fn ($query) => $query->whereIn('type', $types)
                         )
                 )
         );


### PR DESCRIPTION
Update the discount query check to only consider limitations, which allows exclusions to continue working. 
Maybe this needs extended to conditions too, in which case the scope would need changed to accept an array of types.

Closes https://github.com/lunarphp/lunar/issues/1485