### PR TITLE
Allow not Lunar model to use StandardMediaConversions

### DIFF
--- a/packages/core/src/Base/StandardMediaConversions.php
+++ b/packages/core/src/Base/StandardMediaConversions.php
@@ -2,11 +2,12 @@
 
 namespace Lunar\Base;
 
+use Illuminate\Database\Eloquent\Model;
 use Spatie\Image\Manipulations;
 
 class StandardMediaConversions
 {
-    public function apply(BaseModel $model)
+    public function apply(Model $model)
     {
         $conversions = [
             'zoom' => [


### PR DESCRIPTION
the `StandardMediaConversions` expects model to be an extension of `BaseModel` class which not always the case for all models added to the app. for example not wanting it to be prefixed with Lunar's table prefix

this changes make this model possible
```php
<?php

namespace App\Models;

use Illuminate\Database\Eloquent\Model;
use Lunar\Base\Traits\HasMedia as LunarHasMedia;
use Spatie\MediaLibrary\HasMedia;

class Banner extends Model implements HasMedia
{
    use LunarHasMedia;
    
```