### PR TITLE
Add null for transaction order check

### DIFF
--- a/packages/admin/resources/views/livewire/components/orders/capture.blade.php
+++ b/packages/admin/resources/views/livewire/components/orders/capture.blade.php
@@ -23,7 +23,7 @@
       />
     </x-hub::input.group>
 
-    @if($this->transactionModel->amount->decimal > $amount)
+    @if(! is_null($this->transactionModel) && $this->transactionModel->amount->decimal > $amount)
       <x-hub::alert level="danger">
         You're about to capture an amount less than the total transaction value.
       </x-hub::alert>


### PR DESCRIPTION
I am getting an error when the transaction model is null when viewing an order with only an intent transaction. Adding this null check fixes the error.