### PR TITLE
fix migration for product option relation

### DIFF
--- a/packages/core/database/migrations/2024_01_16_100010_update_product_option_relations.php
+++ b/packages/core/database/migrations/2024_01_16_100010_update_product_option_relations.php
@@ -40,8 +40,12 @@ class UpdateProductOptionRelations extends Migration
             "{$productsTable}.id as product_id",
             "{$optionsTable}.id as product_option_id",
             "{$optionsTable}.position",
-        ])->groupBy(['product_id', 'product_option_id'])
-            ->orderBy('product_id')
+        ])->groupBy([
+            "{$productsTable}.id",
+            "{$optionsTable}.id",
+            "{$optionsTable}.position",
+        ])
+            ->orderBy("{$productsTable}.id")
             ->chunk(200, function ($rows) {
                 DB::table(
                     $this->prefix.'product_product_option'


### PR DESCRIPTION
Fix `SQLSTATE[42000]: Syntax error or access violation: 1055 'schema.lunar_products.id' isn't in GROUP BY `
`Syntax error or access violation: 1055 'schema.lunar_product_options.position' isn't in GROUP BY `

this happens when `config/databases.php` `mysql.strict => true` or `ONLY_FULL_GROUP_BY` mode enabled

I verify the before and after by checking the count(*) and some eyeballing. 