### PR TITLE
remove lazy load for page with only relation manager or widget

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -10,6 +10,8 @@ use Filament\Tables\Table;
 
 class CustomerGroupRelationManager extends RelationManager
 {
+    protected static bool $isLazy = false;
+
     protected static string $relationship = 'customerGroups';
 
     public function isReadOnly(): bool

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -32,15 +32,13 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
 
     public array $variants = [];
 
-    protected static bool $isLazy = false;
-
     /**
      * The product options which are being actively configured.
      */
     public array $configuredOptions = [];
 
     public bool $configuringOptions = false;
-    
+
     protected static bool $isLazy = false;
 
     public function mount()

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -38,6 +38,8 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
     public array $configuredOptions = [];
 
     public bool $configuringOptions = false;
+    
+    protected static bool $isLazy = false;
 
     public function mount()
     {

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -32,6 +32,8 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
 
     public array $variants = [];
 
+    protected static bool $isLazy = false;
+
     /**
      * The product options which are being actively configured.
      */

--- a/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
@@ -11,6 +11,8 @@ use Filament\Tables\Table;
 
 class ChannelRelationManager extends RelationManager
 {
+    protected static bool $isLazy = false;
+
     protected static string $relationship = 'channels';
 
     public function isReadOnly(): bool

--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -15,6 +15,8 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class MediaRelationManager extends RelationManager
 {
+    protected static bool $isLazy = false;
+
     protected static string $relationship = 'media';
 
     public string $mediaCollection = 'default';


### PR DESCRIPTION
some pages are using widget & relation manager as the only section/component in the page, and with the lazy load enabled by default in Filament, this causes those pages to be empty on initial load and have slight flicker 