### PR TITLE
sort new variants at top

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -252,7 +252,16 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
             ];
         })->toArray();
 
-        $this->variants = MapVariantsToProductOptions::map($optionValues, $variants, $fillMissing);
+        $variantPermutations = MapVariantsToProductOptions::map($optionValues, $variants, $fillMissing);
+
+        $this->variants = [
+            ...collect($variantPermutations)
+                ->filter(fn ($v) => ! $v['variant_id'])
+                ->toArray(),
+            ...collect($variantPermutations)
+                ->reject(fn ($v) => ! $v['variant_id'])
+                ->toArray(),
+        ];
     }
 
     public function getHasNewVariantsProperty()


### PR DESCRIPTION
currently when adding new product options to a product, new variants are added to the bottom of the list. Moving it up will improve UX

 ![image](https://github.com/lunarphp/lunar/assets/67364036/210643a7-8436-49fd-895d-68426f13e84e)