### PR TITLE
fix(core): fix preg_replace deprecation notice

### DIFF
--- a/packages/core/src/Base/Casts/Price.php
+++ b/packages/core/src/Base/Casts/Price.php
@@ -22,10 +22,12 @@ class Price implements CastsAttributes
     {
         $currency = $model->currency ?: Currency::getDefault();
 
-        /**
-         * Make it an integer based on currency requirements.
-         */
-        $value = preg_replace('/[^0-9]/', '', $value);
+        if (! is_null($value)) {
+            /**
+             * Make it an integer based on currency requirements.
+             */
+            $value = preg_replace('/[^0-9]/', '', $value);
+        }
 
         Validator::make([
             $key => $value,


### PR DESCRIPTION
Fixes the deprecation warning: "Passing null to parameter #3 ($subject) of type array|string is deprecated"

As the notice says passing null as third parameter is deprecated. I simply bypassed the preg_replace. 

Another option would be checking for null value and if so return a zero PriceDataType avoiding the validation and value casting.

I've choosen the first option in order to minimize the amount of duplicated code. If you prefer the second option for the small optimization that gives, i'll update the PR. 
