### PR TITLE
[0.8] Fix some pruning issues

### DIFF
--- a/packages/core/config/cart.php
+++ b/packages/core/config/cart.php
@@ -150,26 +150,27 @@ return [
         'lines.purchasable.product',
         'lines.cart.currency',
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Prune carts
     |--------------------------------------------------------------------------
     |
-    | Should the cart models be pruned to prevent data build up and 
+    | Should the cart models be pruned to prevent data build up and
     | some settings controlling how pruning should be determined
     |
     */
     'prune_tables' => [
-        
+
         'enabled' => false,
-        
+
         'pipelines' => [
             Lunar\Pipelines\CartPrune\PruneAfter::class,
             Lunar\Pipelines\CartPrune\WithoutOrders::class,
+            Lunar\Pipelines\CartPrune\WhereNotMerged::class,
         ],
-        
+
         'prune_interval' => 90, // days
-        
+
     ],
 ];

--- a/packages/core/src/Console/Commands/PruneCarts.php
+++ b/packages/core/src/Console/Commands/PruneCarts.php
@@ -39,11 +39,7 @@ class PruneCarts extends Command
                 config('lunar.cart.prune_tables.pipelines', [])
             )->then(function ($query) {
                 $query->chunk(200, function ($carts) {
-                    $carts->each(function ($cart) {
-                        Cart::where('merged_id', $cart->id)->get()->each(fn ($cart) => $this->pruneCart($cart));
-
-                        $this->pruneCart($cart);
-                    });
+                    $carts->each(fn ($cart) => $this->pruneCart($cart));
                 });
             });
 
@@ -52,6 +48,8 @@ class PruneCarts extends Command
 
     public function pruneCart(Cart $cart)
     {
+        Cart::where('merged_id', $cart->id)->get()->each(fn ($merged) => $this->pruneCart($merged));
+
         $cart->lines()->delete();
         $cart->addresses()->delete();
         $cart->delete();

--- a/packages/core/src/Pipelines/CartPrune/WhereNotMerged.php
+++ b/packages/core/src/Pipelines/CartPrune/WhereNotMerged.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lunar\Pipelines\CartPrune;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+
+final class WhereNotMerged
+{
+    public function handle(Builder $query, Closure $next)
+    {
+        $query->unmerged();
+
+        return $next($query);
+    }
+}


### PR DESCRIPTION
I noticed on our live sites that the approach to pruning merged carts was causing issues as it touched the updated_at date for any merged carts, which then triggered our cart abandonment emails.

This PR updates the prune command to ignore merged carts in the initial query, and then remove any merged carts associated with the current model as part of the deleting process. I think this is a better approach.