### PR TITLE
fix panel id

### DIFF
--- a/packages/admin/composer.json
+++ b/packages/admin/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "lunarphp/core": "self.version",
-        "filament/filament": "^3.1.23",
+        "filament/filament": "^3.2.25",
         "filament/spatie-laravel-media-library-plugin": "^3.0-stable",
         "spatie/laravel-permission": "^5.10",
         "barryvdh/laravel-dompdf": "^2.0",

--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -86,8 +86,6 @@ class LunarPanelManager
             $panel = $fn($panel);
         }
 
-        $panel->id($this->panelId);
-
         Filament::registerPanel($panel);
 
         FilamentIcon::register([


### PR DESCRIPTION
Prior to [Filament 3.2.25](https://github.com/filamentphp/filament/releases/tag/v3.2.25) a panel can be set with a different ID when dev register in service provider, and to avoid internally referencing the wrong ID/panel, lunar overrides it again during registration.

With the latest change, the panel ID is now not allowed to be overridden, when attempted Filament will throw an exception, hence we can now(have to) remove the overrides 