### PR TITLE
fix: tax classes title translation

### DIFF
--- a/packages/admin/resources/views/partials/navigation/taxes.blade.php
+++ b/packages/admin/resources/views/partials/navigation/taxes.blade.php
@@ -16,6 +16,6 @@
       'hover:text-gray-700 text-gray-500' =>  request()->route()->getName() != 'hub.taxes.tax-classes.index'
     ])
   >
-    {{ __('adminhub::settings.tax-classes.index.title') }}
+    {{ __('adminhub::settings.taxes.tax-classes.index.title') }}
   </a>
 </nav>


### PR DESCRIPTION
Tax classes title translation was broken:
![Screenshot 2024-02-13 at 10 21 58](https://github.com/lunarphp/lunar/assets/35270727/db6b1203-7122-4ee0-9781-31905da63976)
