### PR TITLE
Hotfix - Tweak shipping option descriptions

### DIFF
--- a/packages/core/src/DataTypes/ShippingOption.php
+++ b/packages/core/src/DataTypes/ShippingOption.php
@@ -9,15 +9,15 @@ use Lunar\Models\TaxClass;
 class ShippingOption implements Purchasable
 {
     public function __construct(
-        public $name,
-        public $description,
-        public $identifier,
+        public string $name,
+        public ?string $description,
+        public string $identifier,
         public Price $price,
         public TaxClass $taxClass,
-        public $taxReference = null,
-        public $option = null,
+        public ?string $taxReference = null,
+        public ?string $option = null,
         public bool $collect = false,
-        public $meta = null
+        public ?array $meta = null
     ) {
         //  ..
     }

--- a/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
@@ -31,7 +31,7 @@ class CreateShippingLine
                 'purchasable_type' => ShippingOption::class,
                 'purchasable_id' => 1,
                 'type' => 'shipping',
-                'description' => $shippingOption->getDescription(),
+                'description' => $shippingOption->getName(),
                 'option' => $shippingOption->getOption(),
                 'identifier' => $shippingOption->getIdentifier(),
                 'unit_price' => $shippingOption->price->value,

--- a/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
@@ -43,7 +43,7 @@ class CreateShippingLine
                 'tax_total' => $shippingAddress->shippingTaxTotal->value,
                 'total' => $shippingAddress->shippingTotal->value,
                 'notes' => null,
-                'meta' => [],
+                'meta' => $shippingOption->meta,
             ])->save();
         }
 


### PR DESCRIPTION
When creating a shipping line on an order we use the shipping option description, this is wrong as the description on order lines should be the name.

Also any meta information when adding a shipping line was being lost, now the meta should be retained from the option when the line is created

Lastly, added parameter types on the shipping option data type for better IDE support.