### PR TITLE
Update indexers to add compatibility for Typesense

### DIFF
--- a/packages/core/src/Search/BrandIndexer.php
+++ b/packages/core/src/Search/BrandIndexer.php
@@ -34,7 +34,7 @@ class BrandIndexer extends ScoutIndexer
         return array_merge([
             'id' => (string) $model->id,
             'name' => $model->name,
-            'created_at' => (integer) $model->created_at->timestamp,
+            'created_at' => (int) $model->created_at->timestamp,
         ], $this->mapSearchableAttributes($model));
     }
 }

--- a/packages/core/src/Search/BrandIndexer.php
+++ b/packages/core/src/Search/BrandIndexer.php
@@ -32,8 +32,9 @@ class BrandIndexer extends ScoutIndexer
     public function toSearchableArray(Model $model): array
     {
         return array_merge([
-            'id' => $model->id,
+            'id' => (string) $model->id,
             'name' => $model->name,
+            'created_at' => (integer) $model->created_at->timestamp,
         ], $this->mapSearchableAttributes($model));
     }
 }

--- a/packages/core/src/Search/CollectionIndexer.php
+++ b/packages/core/src/Search/CollectionIndexer.php
@@ -3,6 +3,7 @@
 namespace Lunar\Search;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class CollectionIndexer extends ScoutIndexer
 {
@@ -26,5 +27,13 @@ class CollectionIndexer extends ScoutIndexer
     public function makeAllSearchableUsing(Builder $query): Builder
     {
         return $query;
+    }
+
+    public function toSearchableArray(Model $model): array
+    {
+        return array_merge([
+            'id' => (string) $model->id,
+            'created_at' => (integer) $model->created_at->timestamp,
+        ], $this->mapSearchableAttributes($model));
     }
 }

--- a/packages/core/src/Search/CollectionIndexer.php
+++ b/packages/core/src/Search/CollectionIndexer.php
@@ -33,7 +33,7 @@ class CollectionIndexer extends ScoutIndexer
     {
         return array_merge([
             'id' => (string) $model->id,
-            'created_at' => (integer) $model->created_at->timestamp,
+            'created_at' => (int) $model->created_at->timestamp,
         ], $this->mapSearchableAttributes($model));
     }
 }

--- a/packages/core/src/Search/CustomerIndexer.php
+++ b/packages/core/src/Search/CustomerIndexer.php
@@ -43,7 +43,7 @@ class CustomerIndexer extends ScoutIndexer
             'company_name' => $model->company_name,
             'vat_no' => $model->vat_no,
             'account_ref' => $model->account_ref,
-            'created_at' => (integer) $model->created_at->timestamp,
+            'created_at' => (int) $model->created_at->timestamp,
         ], $this->mapSearchableAttributes($model));
 
         foreach ($metaFields as $key => $value) {

--- a/packages/core/src/Search/CustomerIndexer.php
+++ b/packages/core/src/Search/CustomerIndexer.php
@@ -38,11 +38,12 @@ class CustomerIndexer extends ScoutIndexer
         $metaFields = (array) $model->meta;
 
         $data = array_merge([
-            'id' => $model->id,
+            'id' => (string) $model->id,
             'name' => $model->fullName,
             'company_name' => $model->company_name,
             'vat_no' => $model->vat_no,
             'account_ref' => $model->account_ref,
+            'created_at' => (integer) $model->created_at->timestamp,
         ], $this->mapSearchableAttributes($model));
 
         foreach ($metaFields as $key => $value) {

--- a/packages/core/src/Search/OrderIndexer.php
+++ b/packages/core/src/Search/OrderIndexer.php
@@ -52,7 +52,7 @@ class OrderIndexer extends ScoutIndexer
             'customer_reference' => $model->customer_reference,
             'status' => $model->status,
             'placed_at' => optional($model->placed_at)->timestamp,
-            'created_at' => (integer) $model->created_at->timestamp,
+            'created_at' => (int) $model->created_at->timestamp,
             'sub_total' => $model->sub_total->value,
             'total' => $model->total->value,
             'currency_code' => $model->currency_code,

--- a/packages/core/src/Search/OrderIndexer.php
+++ b/packages/core/src/Search/OrderIndexer.php
@@ -46,13 +46,13 @@ class OrderIndexer extends ScoutIndexer
     public function toSearchableArray(Model $model): array
     {
         $data = [
-            'id' => $model->id,
+            'id' => (string) $model->id,
             'channel' => $model->channel->name,
             'reference' => $model->reference,
             'customer_reference' => $model->customer_reference,
             'status' => $model->status,
             'placed_at' => optional($model->placed_at)->timestamp,
-            'created_at' => $model->created_at->timestamp,
+            'created_at' => (integer) $model->created_at->timestamp,
             'sub_total' => $model->sub_total->value,
             'total' => $model->total->value,
             'currency_code' => $model->currency_code,

--- a/packages/core/src/Search/ScoutIndexer.php
+++ b/packages/core/src/Search/ScoutIndexer.php
@@ -61,7 +61,7 @@ class ScoutIndexer implements ScoutIndexerInterface
         }
 
         return array_merge([
-            'id' => $model->id,
+            'id' => (string) $model->id,
         ], $data);
     }
 

--- a/tests/core/Unit/Search/ScoutIndexerTest.php
+++ b/tests/core/Unit/Search/ScoutIndexerTest.php
@@ -39,7 +39,7 @@ test('can return searchable array', function () {
     $data = app(ScoutIndexer::class)->toSearchableArray($product);
 
     expect($data)->toBe([
-        'id' => $product->id,
+        'id' => (string) $product->id,
     ]);
 });
 


### PR DESCRIPTION
Typesense requires all IDs to be of type "string" and the created_at value should be an integer timestamp.

This PR updates the default indexers so they will work without modification when using Typesense.