### PR TITLE
Fix - Product variant attributes display 

### DIFF
--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -41,7 +41,7 @@ class Attributes extends Forms\Components\Group
                     if ($modelClass == ProductVariant::class) {
                         $productTypeId = $record->product?->product_type_id ?: ProductType::first()->id;
 
-                        // If we have a product variant type, the attributes should be based off that.
+                        // If we have a product type, the attributes should be based off that.
                         if ($productTypeId) {
                             $attributeQuery = ProductType::find($productTypeId)->variantAttributes();
                         }

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -11,6 +11,7 @@ use Lunar\Models\Attribute;
 use Lunar\Models\AttributeGroup;
 use Lunar\Models\Product;
 use Lunar\Models\ProductType;
+use Lunar\Models\ProductVariant;
 
 class Attributes extends Forms\Components\Group
 {
@@ -30,11 +31,20 @@ class Attributes extends Forms\Components\Group
                     // to try and find the product type ID
                     if ($modelClass == Product::class) {
                         $productTypeId = $record?->product_type_id ?: ProductType::first()->id;
+
+                        // If we have a product type, the attributes should be based off that.
+                        if ($productTypeId) {
+                            $attributeQuery = ProductType::find($productTypeId)->productAttributes();
+                        }
                     }
 
-                    // If we have a product type, the attributes should be based off that.
-                    if ($productTypeId) {
-                        $attributeQuery = ProductType::find($productTypeId)->productAttributes();
+                    if ($modelClass == ProductVariant::class) {
+                        $productTypeId = $record->product?->product_type_id ?: ProductType::first()->id;
+
+                        // If we have a product variant type, the attributes should be based off that.
+                        if ($productTypeId) {
+                            $attributeQuery = ProductType::find($productTypeId)->variantAttributes();
+                        }
                     }
 
                     $attributes = $attributeQuery->orderBy('position')->get();


### PR DESCRIPTION
Currently, all attributes of ProductVariant display when editing. Now, the behavior has like of Product.
 