### PR TITLE
Fix - Method remove into ShippingModifiers

### DIFF
--- a/packages/core/src/Base/ShippingModifiers.php
+++ b/packages/core/src/Base/ShippingModifiers.php
@@ -48,6 +48,6 @@ class ShippingModifiers
      */
     public function remove($modifier)
     {
-        $this->modifiers->forget($modifier);
+        $this->modifiers = $this->modifiers->reject(fn ($value) => $value == $modifier);
     }
 }

--- a/packages/core/tests/Unit/Base/ShippingModifiersTest.php
+++ b/packages/core/tests/Unit/Base/ShippingModifiersTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Lunar\Tests\Unit\Base;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Base\ShippingModifier;
+use Lunar\Base\ShippingModifiers;
+use Lunar\Models\Cart;
+use Lunar\Models\Currency;
+use Lunar\Tests\TestCase;
+
+class ShippingModifiersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Cart $cart;
+
+    private ShippingModifiers $shippingModifiers;
+
+    private ShippingModifier $class;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $currency = Currency::factory()->create([
+            'decimal_places' => 2,
+        ]);
+
+        $this->cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $this->class = new class extends ShippingModifier
+        {
+            public function handle(Cart $cart)
+            {
+                //
+            }
+        };
+
+        $this->shippingModifiers = new ShippingModifiers();
+    }
+
+    /** @test */
+    public function can_add_modifier()
+    {
+        $this->shippingModifiers->add($this->class::class);
+
+        $this->assertCount(1, $this->shippingModifiers->getModifiers());
+    }
+
+
+    public function can_remove_modifier()
+    {
+        $this->shippingModifiers->remove($this->class::class);
+
+        $this->assertCount(0, $this->shippingModifiers->getModifiers());
+    }
+
+}


### PR DESCRIPTION
The ShippingModifiers store modifiers in collection, the method remove tried to remove the key that didn't exist.