### PR TITLE
Fix - Attribute group order by position

### DIFF
--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -42,12 +42,14 @@ class Attributes extends Forms\Components\Group
                     $groups = AttributeGroup::where(
                         'attributable_type',
                         $modelClass
-                    )->get()->map(function ($group) use ($attributes) {
-                        return [
-                            'model' => $group,
-                            'fields' => $attributes->groupBy('attribute_group_id')->get($group->id, []),
-                        ];
-                    });
+                    )->orderBy('position', 'asc')
+                        ->get()
+                        ->map(function ($group) use ($attributes) {
+                            return [
+                                'model' => $group,
+                                'fields' => $attributes->groupBy('attribute_group_id')->get($group->id, []),
+                            ];
+                        });
 
                     $groupComponents = [];
 


### PR DESCRIPTION
This PR fix that AttributeGroup display by position when edit resource.