### PR TITLE
Hotfix - Update ShippingModifier to return closure

### DIFF
--- a/docs/core/extending/shipping.md
+++ b/docs/core/extending/shipping.md
@@ -21,7 +21,7 @@ use Lunar\Models\TaxClass;
 
 class CustomShippingModifier extends ShippingModifier
 {
-    public function handle(Cart $cart)
+    public function handle(Cart $cart, \Closure $next)
     {
         // Get the tax class
         $taxClass = TaxClass::first();
@@ -65,6 +65,8 @@ class CustomShippingModifier extends ShippingModifier
                 taxClass: $taxClass
             )
         ]));
+        
+        return $next($cart);
     }
 }
 

--- a/packages/table-rate-shipping/src/ShippingModifier.php
+++ b/packages/table-rate-shipping/src/ShippingModifier.php
@@ -9,7 +9,7 @@ use Lunar\Shipping\Facades\Shipping;
 
 class ShippingModifier
 {
-    public function handle(Cart $cart)
+    public function handle(Cart $cart, \Closure $next)
     {
         $shippingRates = Shipping::shippingRates($cart)->get();
 
@@ -22,5 +22,7 @@ class ShippingModifier
         foreach ($options as $option) {
             ShippingManifest::addOption($option->option);
         }
+
+        return $next($cart);
     }
 }


### PR DESCRIPTION
We use Pipelines for shipping modifiers, but the one provided by the add on was not using the `$next($cart)` closure, so any additional modifiers where not being triggered.