### PR TITLE
Added order table filters and column toggleability

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -2,8 +2,8 @@
 
 namespace Lunar\Admin\Filament\Resources;
 
-use Filament\Support\Facades\FilamentIcon;
 use Filament\Forms;
+use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;

--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -3,6 +3,7 @@
 namespace Lunar\Admin\Filament\Resources;
 
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Forms;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
@@ -68,6 +69,7 @@ class OrderResource extends BaseResource
                         ->deselectRecordsAfterCompletion(),
                 ]),
             ])
+            ->filters(static::getTableFilters())
             ->defaultSort('id', 'DESC')
             ->paginated([10, 25, 50, 100])
             ->selectCurrentPageOnly()
@@ -79,6 +81,7 @@ class OrderResource extends BaseResource
         return [
             Tables\Columns\TextColumn::make('status')
                 ->label(__('lunarpanel::order.table.status.label'))
+                ->toggleable()
                 ->formatStateUsing(fn (string $state) => OrderStatus::getLabel($state))
                 ->color(fn (string $state) => OrderStatus::getColor($state))
                 ->badge(),
@@ -87,27 +90,62 @@ class OrderResource extends BaseResource
                 ->toggleable()
                 ->searchable(),
             Tables\Columns\TextColumn::make('customer_reference')
-                ->label(__('lunarpanel::order.table.customer_reference.label')),
+                ->label(__('lunarpanel::order.table.customer_reference.label'))
+                ->toggleable(),
             Tables\Columns\TextColumn::make('shippingAddress.fullName')
-                ->label(__('lunarpanel::order.table.customer.label')),
+                ->label(__('lunarpanel::order.table.customer.label'))
+                ->toggleable(),
             Tables\Columns\TextColumn::make('new_customer')
                 ->label(__('lunarpanel::order.table.new_customer.label'))
+                ->toggleable()
                 ->formatStateUsing(fn (bool $state) => CustomerStatus::getLabel($state))
                 ->color(fn (bool $state) => CustomerStatus::getColor($state))
                 ->icon(fn (bool $state) => CustomerStatus::getIcon($state))
                 ->badge(),
             Tables\Columns\TextColumn::make('shippingAddress.postcode')
-                ->label(__('lunarpanel::order.table.postcode.label')),
+                ->label(__('lunarpanel::order.table.postcode.label'))
+                ->toggleable(),
             Tables\Columns\TextColumn::make('shippingAddress.contact_email')
-                ->label(__('lunarpanel::order.table.email.label')),
+                ->label(__('lunarpanel::order.table.email.label'))
+                ->toggleable(),
             Tables\Columns\TextColumn::make('shippingAddress.contact_phone')
-                ->label(__('lunarpanel::order.table.phone.label')),
+                ->label(__('lunarpanel::order.table.phone.label'))
+                ->toggleable(),
             Tables\Columns\TextColumn::make('total')
                 ->label(__('lunarpanel::order.table.total.label'))
+                ->toggleable()
                 ->formatStateUsing(fn ($state): string => $state->formatted),
             Tables\Columns\TextColumn::make('placed_at')
                 ->label(__('lunarpanel::order.table.date.label'))
+                ->toggleable()
                 ->dateTime(),
+        ];
+    }
+
+    public static function getTableFilters(): array
+    {
+        return [
+            Tables\Filters\SelectFilter::make('status')
+                ->label(__('lunarpanel::order.table.status.label'))
+                ->options(collect(config('lunar.orders.statuses', []))
+                    ->mapWithKeys(fn ($data, $status) => [$status => $data['label']])),
+            Tables\Filters\Filter::make('placed_at')
+                ->form([
+                    Forms\Components\DatePicker::make('placed_after'),
+                    Forms\Components\DatePicker::make('placed_before')
+                        ->default(now()),
+                ])
+                ->query(function (Builder $query, array $data): Builder {
+                    return $query
+                        ->when(
+                            $data['placed_after'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('placed_at', '>=', $date),
+                        )
+                        ->when(
+                            $data['placed_before'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('placed_at', '<=', $date),
+                        );
+                }),
         ];
     }
 


### PR DESCRIPTION
This provides basic table filters for the orders page and also allows users to toggle the columns they see, as the table can sometimes be quite wide.

<img width="427" alt="image" src="https://github.com/lunarphp/lunar/assets/647407/5b254052-cda5-43df-9225-9199ddbda56a">

<img width="366" alt="image" src="https://github.com/lunarphp/lunar/assets/647407/13d4befb-4c5a-43de-9851-1ef174770584">
