### PR TITLE
Order table tags

### DIFF
--- a/packages/admin/resources/lang/en/order.php
+++ b/packages/admin/resources/lang/en/order.php
@@ -51,6 +51,12 @@ return [
         'new_customer' => [
             'label' => 'Customer Type',
         ],
+        'placed_after' => [
+            'label' => 'Placed after',
+        ],
+        'placed_before' => [
+            'label' => 'Placed before',
+        ],
     ],
 
     'form' => [

--- a/packages/admin/resources/lang/en/order.php
+++ b/packages/admin/resources/lang/en/order.php
@@ -30,6 +30,9 @@ return [
         'customer' => [
             'label' => 'Customer',
         ],
+        'tags' => [
+            'label' => 'Tags',
+        ],
         'postcode' => [
             'label' => 'Postcode',
         ],

--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -135,9 +135,12 @@ class OrderResource extends BaseResource
                 ->options(collect(config('lunar.orders.statuses', []))
                     ->mapWithKeys(fn ($data, $status) => [$status => $data['label']])),
             Tables\Filters\Filter::make('placed_at')
+
                 ->form([
-                    Forms\Components\DatePicker::make('placed_after'),
+                    Forms\Components\DatePicker::make('placed_after')
+                        ->label(__('lunarpanel::order.table.placed_after.label')),
                     Forms\Components\DatePicker::make('placed_before')
+                        ->label(__('lunarpanel::order.table.placed_before.label'))
                         ->default(now()),
                 ])
                 ->query(function (Builder $query, array $data): Builder {

--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -102,6 +102,11 @@ class OrderResource extends BaseResource
                 ->color(fn (bool $state) => CustomerStatus::getColor($state))
                 ->icon(fn (bool $state) => CustomerStatus::getIcon($state))
                 ->badge(),
+            Tables\Columns\TextColumn::make('tags.value')
+                ->label(__('lunarpanel::order.table.tags.label'))
+                ->badge()
+                ->toggleable()
+                ->separator(','),
             Tables\Columns\TextColumn::make('shippingAddress.postcode')
                 ->label(__('lunarpanel::order.table.postcode.label'))
                 ->toggleable(),
@@ -146,6 +151,10 @@ class OrderResource extends BaseResource
                             fn (Builder $query, $date): Builder => $query->whereDate('placed_at', '<=', $date),
                         );
                 }),
+            Tables\Filters\SelectFilter::make('tags')
+                ->label(__('lunarpanel::order.table.tags.label'))
+                ->multiple()
+                ->relationship('tags', 'value'),
         ];
     }
 


### PR DESCRIPTION
Adds the tags column to the order table and also adds a tag filter.

<img width="286" alt="image" src="https://github.com/lunarphp/lunar/assets/647407/11409582-0e58-45c2-a50e-c69aa655c558">

<img width="355" alt="image" src="https://github.com/lunarphp/lunar/assets/647407/396e858a-4ab3-438e-ae36-28ae63bbde42">

Also, fixed a couple of missing translations at the same time.