### PR TITLE
Feat - Expand payment event logging

### DIFF
--- a/docs/core/extending/payments.md
+++ b/docs/core/extending/payments.md
@@ -46,6 +46,7 @@ namespace App\PaymentTypes;
 use Lunar\Base\DataTransferObjects\PaymentCapture;
 use Lunar\Base\DataTransferObjects\PaymentRefund;
 use Lunar\Base\DataTransferObjects\PaymentAuthorize;
+use Lunar\Events\PaymentAttemptEvent;
 use Lunar\Models\Transaction;
 
 class CustomPayment extends AbstractPayment
@@ -62,8 +63,17 @@ class CustomPayment extends AbstractPayment
         }
 
         // ...
+        
+        $response = new PaymentAuthorize(
+            success: true,
+            message: 'The payment was successful',
+            orderId: $this->order->id,
+            paymentType: 'custom-type'
+        );
+        
+        PaymentAttemptEvent::dispatch($response)
 
-        return new PaymentAuthorize(true);
+        return $response;
     }
 
     /**

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -59,6 +59,15 @@ public Collection $tiered,
 public Collection $priceBreaks,
 ```
 
+##### Lunar\Base\DataTransferObjects\PaymentAuthorize
+
+Two new properties have been added to the constructor for this DTO.
+
+```php
+public ?int $orderId = null,
+public ?string $paymentType = null
+```
+
 ## 0.8
 
 No significant changes.

--- a/packages/core/src/Base/DataTransferObjects/PaymentAuthorize.php
+++ b/packages/core/src/Base/DataTransferObjects/PaymentAuthorize.php
@@ -7,7 +7,8 @@ class PaymentAuthorize
     public function __construct(
         public bool $success = false,
         public ?string $message = null,
-        public ?int $orderId = null
+        public ?int $orderId = null,
+        public ?string $paymentType = null
     ) {
         //
     }

--- a/packages/core/src/PaymentTypes/OfflinePayment.php
+++ b/packages/core/src/PaymentTypes/OfflinePayment.php
@@ -5,6 +5,7 @@ namespace Lunar\PaymentTypes;
 use Lunar\Base\DataTransferObjects\PaymentAuthorize;
 use Lunar\Base\DataTransferObjects\PaymentCapture;
 use Lunar\Base\DataTransferObjects\PaymentRefund;
+use Lunar\Events\PaymentAttemptEvent;
 use Lunar\Models\Transaction;
 
 class OfflinePayment extends AbstractPayment
@@ -32,7 +33,15 @@ class OfflinePayment extends AbstractPayment
             'placed_at' => now(),
         ]);
 
-        return new PaymentAuthorize(true);
+        $response = new PaymentAuthorize(
+            success: true,
+            orderId: $this->order->id,
+            paymentType: 'offline',
+        );
+
+        PaymentAttemptEvent::dispatch($response);
+
+        return $response;
     }
 
     /**

--- a/packages/opayo/src/Responses/PaymentAuthorize.php
+++ b/packages/opayo/src/Responses/PaymentAuthorize.php
@@ -15,7 +15,9 @@ class PaymentAuthorize extends GcPaymentAuthorize
         public ?string $cReq = null,
         public ?string $paReq = null,
         public ?string $transactionId = null,
-        public ?string $message = null
+        public ?string $message = null,
+        public ?int $orderId = null,
+        public ?string $paymentType = null,
     ) {
         //
     }

--- a/packages/stripe/src/StripePaymentType.php
+++ b/packages/stripe/src/StripePaymentType.php
@@ -64,6 +64,7 @@ class StripePaymentType extends AbstractPayment
                     paymentType: 'stripe'
                 );
                 PaymentAttemptEvent::dispatch($failure);
+
                 return $failure;
             }
         }


### PR DESCRIPTION
The `PaymentAttemptEvent` was being dispatched in only a handful of places, where it should be dispatched anytime we respond with a `PaymentAuthorize` response.

Also added the `orderId` to the response and the `paymentType` that returned it, this should give listeners more information about what's happening when these attempts are made.