### PR TITLE
While Using simple pagination, it solves string * int issue

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ListOrders.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ListOrders.php
@@ -41,7 +41,7 @@ class ListOrders extends BaseListRecords
 
     protected function paginateTableQuery(Builder $query): Paginator
     {
-        return $query->paginate($this->getTableRecordsPerPage());
+        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
     }
 
     public function getMaxContentWidth(): MaxWidth

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ListProducts.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ListProducts.php
@@ -93,7 +93,7 @@ class ListProducts extends BaseListRecords
 
     protected function paginateTableQuery(Builder $query): Paginator
     {
-        return $query->simplePaginate($this->getTableRecordsPerPage());
+        return $query->simplePaginate(($this->getTableRecordsPerPage() === 'all') ? $query->count() : $this->getTableRecordsPerPage());
     }
 
     public function getMaxContentWidth(): MaxWidth


### PR DESCRIPTION
Currently, in ListOrders and ListProducts, when we select 'all' option in pagination, it tends to error stating, string * int 
![image](https://github.com/lunarphp/lunar/assets/8534680/59495355-0384-465e-bd66-6335d056e6c0)

This solves the above issue. Also, snippet is found in the documentaion of source of filamentphp version 3.
