### PR TITLE
Fixes enabled channel relation manager

### DIFF
--- a/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
@@ -32,7 +32,7 @@ class ChannelRelationManager extends RelationManager
         return [
             Filament\Forms\Components\Toggle::make('enabled')->label(
                 __('lunarpanel::relationmanagers.channels.form.enabled.label')
-            )->hint(fn (Forms\Get $get): string => match ($get('enabled')) {
+            )->hint(fn (bool $state): string => match ($state) {
                 false => __('lunarpanel::relationmanagers.channels.form.enabled.helper_text_false'),
                 true => '',
             })->hintColor('danger')->live()->columnSpan(2),
@@ -75,12 +75,12 @@ class ChannelRelationManager extends RelationManager
                 Tables\Columns\IconColumn::make('enabled')->label(
                     __('lunarpanel::relationmanagers.channels.table.enabled.label')
                 )
-                    ->color(fn (string $state): string => match ($state) {
-                        '1' => 'success',
-                        '0' => 'warning',
-                    })->icon(fn (string $state): string => match ($state) {
-                        '0' => 'heroicon-o-x-circle',
-                        '1' => 'heroicon-o-check-circle',
+                    ->color(fn (bool $state): string => match ($state) {
+                        true => 'success',
+                        false => 'warning',
+                    })->icon(fn (bool $state): string => match ($state) {
+                        false => 'heroicon-o-x-circle',
+                        true => 'heroicon-o-check-circle',
                     }),
                 Tables\Columns\TextColumn::make('starts_at')->label(
                     __('lunarpanel::relationmanagers.channels.table.starts_at.label')

--- a/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
@@ -3,7 +3,6 @@
 namespace Lunar\Admin\Support\RelationManagers;
 
 use Filament;
-use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;

--- a/packages/core/src/Models/Channel.php
+++ b/packages/core/src/Models/Channel.php
@@ -31,6 +31,10 @@ class Channel extends BaseModel
     use LogsActivity;
     use SoftDeletes;
 
+    public $casts = [
+        'enabled' => 'boolean',
+    ];
+
     /**
      * Return a new factory instance for the model.
      */


### PR DESCRIPTION
![Screenshot from 2024-03-12 08-12-29](https://github.com/lunarphp/lunar/assets/8534680/98fc7546-255a-4a10-af26-8514aac391b0)
![Screenshot from 2024-03-12 08-12-41](https://github.com/lunarphp/lunar/assets/8534680/6f64d79a-9514-42c0-94b8-2fc6bcfe09bc)
When clicking on edit above error appears, as `string $state` has converted to '' string. I think it should be bool as it is also same in database and model state also.
