### PR TITLE
Allow registration of the same extension on multiple pages

### DIFF
--- a/docs/admin/extending/overview.md
+++ b/docs/admin/extending/overview.md
@@ -18,7 +18,7 @@ use Lunar\Panel\Filament\Resources\ProductResource\Pages\EditProduct;
 use App\Admin\Filament\Resources\Pages\MyEditExtension;
 
 LunarPanel::extensions([
-    MyEditExtension::class => EditProduct::class
+    EditProduct::class => MyEditExtension::class,
 ]);
 
 ```
@@ -33,7 +33,7 @@ use Lunar\Panel\Filament\Resources\ProductResource\Pages\ListProduct;
 use App\Admin\Filament\Resources\Pages\MyEditExtension;
 
 LunarPanel::extensions([
-    MyListExtension::class => ListProduct::class
+    ListProduct::class => MyListExtension::class,
 ]);
 
 ```
@@ -49,7 +49,7 @@ use Lunar\Panel\Filament\Resources\ProductResource;
 use App\Admin\Filament\Resources\MyProductResourceExtension;
 
 LunarPanel::extensions([
-    MyProductResourceExtension::class => ProductResource::class
+    ProductResource::class => MyProductResourceExtension::class,
 ]);
 
 ```

--- a/docs/admin/extending/pages.md
+++ b/docs/admin/extending/pages.md
@@ -90,7 +90,7 @@ class MyCreateExtension extends CreatePageExtension
 
 // Typically placed in your AppServiceProvider file...
 LunarPanel::extensions([
-    MyCreateExtension::class => \Lunar\Admin\Filament\Resources\CustomerGroupResource\Pages\CreateCustomerGroup::class,
+    \Lunar\Admin\Filament\Resources\CustomerGroupResource\Pages\CreateCustomerGroup::class => MyCreateExtension::class,
 ]);
 ```
 
@@ -189,7 +189,7 @@ class MyEditExtension extends EditPageExtension
 
 // Typically placed in your AppServiceProvider file...
 LunarPanel::extensions([
-    MyEditExtension::class => \Lunar\Admin\Filament\Resources\ProductResource\Pages\EditProduct::class,
+    \Lunar\Admin\Filament\Resources\ProductResource\Pages\EditProduct::class => MyEditExtension::class,
 ]);
 ```
 
@@ -251,7 +251,7 @@ class MyListExtension extends ListPageExtension
 
 // Typically placed in your AppServiceProvider file...
 LunarPanel::extensions([
-    MyListExtension::class => \Lunar\Admin\Filament\Resources\ProductResource\Pages\ListProducts::class,
+    \Lunar\Admin\Filament\Resources\ProductResource\Pages\ListProducts::class => MyListExtension::class,
 ]);
 ```
 
@@ -291,7 +291,7 @@ class MyViewExtension extends ViewPageExtension
 
 // Typically placed in your AppServiceProvider file...
 LunarPanel::extensions([
-    MyViewExtension::class => \Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder::class,
+    \Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder::class => MyViewExtension::class,
 ]);
 ```
 
@@ -330,7 +330,7 @@ class MyRelationExtension extends RelationPageExtension
 
 // Typically placed in your AppServiceProvider file...
 LunarPanel::extensions([
-    MyRelationExtension::class => \Lunar\Admin\Filament\Resources\ProductResource\Pages\ManageProductMedia::class,
+    \Lunar\Admin\Filament\Resources\ProductResource\Pages\ManageProductMedia::class => MyRelationExtension::class,
 ]);
 ```
 

--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -249,7 +249,7 @@ class LunarPanelManager
     public function extensions(array $extensions): self
     {
         foreach ($extensions as $class => $extension) {
-            $this->extensions[$extension][] = new $class;
+            $this->extensions[$class][] = new $extension;
         }
 
         return $this;

--- a/tests/admin/Feature/Support/Extending/CreatePageExtensionTest.php
+++ b/tests/admin/Feature/Support/Extending/CreatePageExtensionTest.php
@@ -21,7 +21,7 @@ it('can customise page headings', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => CreateCustomer::class,
+        CreateCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);
@@ -43,7 +43,7 @@ it('can change data before creation', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => CreateCustomer::class,
+        CreateCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);
@@ -75,7 +75,7 @@ it('can manipulate model after creation', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => CreateCustomer::class,
+        CreateCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);

--- a/tests/admin/Feature/Support/Extending/EditPageExtensionTest.php
+++ b/tests/admin/Feature/Support/Extending/EditPageExtensionTest.php
@@ -22,7 +22,7 @@ it('can change data before fill', function () {
     ]);
 
     LunarPanel::extensions([
-        $class::class => EditCustomer::class,
+        EditCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);
@@ -54,7 +54,7 @@ it('can change data before save', function () {
     ]);
 
     LunarPanel::extensions([
-        $class::class => EditCustomer::class,
+        EditCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);

--- a/tests/admin/Feature/Support/Extending/RelationPageExtensionTest.php
+++ b/tests/admin/Feature/Support/Extending/RelationPageExtensionTest.php
@@ -25,7 +25,7 @@ it('can customise page headings', function () {
     $product = \Lunar\Models\Product::factory()->create();
 
     LunarPanel::extensions([
-        $class::class => ManageProductMedia::class,
+        ManageProductMedia::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);

--- a/tests/admin/Unit/Support/Extending/CreatePageExtensionTest.php
+++ b/tests/admin/Unit/Support/Extending/CreatePageExtensionTest.php
@@ -18,7 +18,7 @@ it('can extend header actions', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => ChannelResource\Pages\CreateChannel::class,
+        ChannelResource\Pages\CreateChannel::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);
@@ -39,7 +39,7 @@ it('can extend form actions', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => ChannelResource\Pages\CreateChannel::class,
+        ChannelResource\Pages\CreateChannel::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);

--- a/tests/admin/Unit/Support/Extending/EditPageExtensionTest.php
+++ b/tests/admin/Unit/Support/Extending/EditPageExtensionTest.php
@@ -18,7 +18,7 @@ it('can extend header actions', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => EditCustomer::class,
+        EditCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);
@@ -44,7 +44,7 @@ it('can extend form actions', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => EditCustomer::class,
+        EditCustomer::class => $class::class,
     ]);
 
     $this->asStaff(admin: true);

--- a/tests/admin/Unit/Support/Extending/ResourceExtensionTest.php
+++ b/tests/admin/Unit/Support/Extending/ResourceExtensionTest.php
@@ -31,7 +31,7 @@ it('can extend relationship managers', function () {
     };
 
     LunarPanel::extensions([
-        $class::class => CustomerResource::class,
+        CustomerResource::class => $class::class,
     ]);
 
     $relations = CustomerResource::getRelations();
@@ -51,7 +51,7 @@ it('can extend table columns', function ($resource, $page) {
     };
 
     LunarPanel::extensions([
-        $class::class => $resource,
+        $resource => $class::class,
     ]);
 
     $this->asStaff();
@@ -79,7 +79,7 @@ it('can extend form schema', function ($resource, $page) {
     };
 
     LunarPanel::extensions([
-        $class::class => $resource,
+        $resource => $class::class,
     ]);
 
     $this->asStaff(admin: true);


### PR DESCRIPTION
The new `LunarPanel::extensions([])` registration method prevents the reuse of the same extension across multiple pages as it will create duplicate keys in the array.

As it's much more likely that an extension will be reused, rather than having multiple extensions for a single page/resource, this update switches the key/value on the array. This also aligns better with the way the array is used in the Panel Manager.

