### PR TITLE
[1.x] Use find in pricing manager so observers and events fire

### DIFF
--- a/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
+++ b/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
@@ -62,7 +62,7 @@ trait ManagesProductPricing
 
         $prices->filter(
             fn ($price) => $price['id']
-        )->each(fn ($price) => Price::whereId($price['id'])->update([
+        )->each(fn ($price) => Price::find($price['id'])->update([
             'price' => (int) ($price['value'] * $price['factor']),
             'compare_price' => (int) ($price['compare_price'] * $price['factor']),
         ])


### PR DESCRIPTION
We run a lot of calculations on pricing save using the base price, so we need to know when its updated.

Currently this area doesnt fire events as it's using a database update, rather than a model update. This PR changes that.