### PR TITLE
[1.x] - Increase polling interval for dashboard widgets

### DIFF
--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/AverageOrderValueChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/AverageOrderValueChart.php
@@ -16,6 +16,8 @@ class AverageOrderValueChart extends ApexChartWidget
      */
     protected static ?string $chartId = 'averageOrderValue';
 
+    protected static ?string $pollingInterval = '60s';
+
     protected function getHeading(): ?string
     {
         return __('lunarpanel::widgets.dashboard.orders.average_order_value.heading');

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/LatestOrdersTable.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/LatestOrdersTable.php
@@ -9,6 +9,11 @@ use Lunar\Models\Order;
 
 class LatestOrdersTable extends TableWidget
 {
+    protected function getTablePollingInterval(): ?string
+    {
+        return '60s';
+    }
+
     protected int|string|array $columnSpan = 'full';
 
     public static function getHeading(): ?string

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php
@@ -15,6 +15,8 @@ class NewVsReturningCustomersChart extends ApexChartWidget
      */
     protected static ?string $chartId = 'newVsReturningCustomers';
 
+    protected static ?string $pollingInterval = '60s';
+
     protected function getHeading(): ?string
     {
         return __('lunarpanel::widgets.dashboard.orders.new_returning_customers.heading');
@@ -45,13 +47,13 @@ class NewVsReturningCustomersChart extends ApexChartWidget
             ->select(
                 DB::RAW('SUM(
                     CASE
-                        WHEN new_customer THEN 1 
+                        WHEN new_customer THEN 1
                         ELSE 0
                     END
                 ) as new_customer_count'),
                 DB::RAW('SUM(
                     CASE
-                        WHEN NOT new_customer THEN 1 
+                        WHEN NOT new_customer THEN 1
                         ELSE 0
                     END
                 ) as returning_customer_count'),

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderStatsOverview.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderStatsOverview.php
@@ -10,6 +10,8 @@ use Lunar\Models\Order;
 
 class OrderStatsOverview extends BaseWidget
 {
+    protected static ?string $pollingInterval = '60s';
+    
     protected function getOrderQuery(\DateTime $from = null, \DateTime $to = null)
     {
         return Order::whereNotNull('placed_at')

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderStatsOverview.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderStatsOverview.php
@@ -11,7 +11,7 @@ use Lunar\Models\Order;
 class OrderStatsOverview extends BaseWidget
 {
     protected static ?string $pollingInterval = '60s';
-    
+
     protected function getOrderQuery(\DateTime $from = null, \DateTime $to = null)
     {
         return Order::whereNotNull('placed_at')

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderTotalsChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderTotalsChart.php
@@ -18,6 +18,8 @@ class OrderTotalsChart extends ApexChartWidget
      */
     protected static ?string $chartId = 'orderTotalsChart';
 
+    protected static ?string $pollingInterval = '60s';
+
     protected function getHeading(): ?string
     {
         return __('lunarpanel::widgets.dashboard.orders.order_totals_chart.heading');

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrdersSalesChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrdersSalesChart.php
@@ -17,6 +17,8 @@ class OrdersSalesChart extends ApexChartWidget
      */
     protected static ?string $chartId = 'ordersSalesChart';
 
+    protected static ?string $pollingInterval = '60s';
+
     protected function getHeading(): ?string
     {
         return __('lunarpanel::widgets.dashboard.orders.order_sales_chart.heading');

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/PopularProductsTable.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/PopularProductsTable.php
@@ -12,6 +12,11 @@ class PopularProductsTable extends TableWidget
 {
     protected int|string|array $columnSpan = 'full';
 
+    protected function getTablePollingInterval(): ?string
+    {
+        return '60s';
+    }
+
     public static function getHeading(): ?string
     {
         return __('lunarpanel::widgets.dashboard.latest_orders.heading');


### PR DESCRIPTION
On the dashboard, the widgets currently use the Filament default polling interval. Since some of the queries can be quite intense this could lead to timeouts, this PR increases this time to 60 seconds to help mitigate the issue without having to remove polling completely.