### PR TITLE
Fix attribute_data validation hydration and dehydration

### DIFF
--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -43,6 +43,7 @@ class AttributeData
 
         return $fieldType::getFilamentComponent($attribute)->label(
                 $attribute->translate('name')
+            )
             ->formatStateUsing(fn ($state) => ($state ?: (new $attribute->type))->getValue())
             ->dehydrateStateUsing(function ($state) use ($attribute) {
                 $field = new $attribute->type;

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -42,10 +42,14 @@ class AttributeData
         ] ?? TextField::class;
 
         return $fieldType::getFilamentComponent($attribute)->label(
-            $attribute->translate('name')
-        )->formatStateUsing(function ($state) use ($attribute) {
-            return $state ?: (new $attribute->type);
-        })->required($attribute->required)
+                $attribute->translate('name')
+            ->formatStateUsing(fn ($state) => ($state ?: (new $attribute->type))->getValue())
+            ->dehydrateStateUsing(function ($state) use ($attribute) {
+                $field = new $attribute->type;
+                $field->setValue($state);
+                return $field;
+            })
+            ->required($attribute->required)
             ->default($attribute->default_value);
     }
 


### PR DESCRIPTION
As discussed on Discord, when saving attribute_date with validation rules it threw errors.
This hydration/dehydration pattern solves the errors.