### PR TITLE
Implement PayPal refund

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -12,6 +12,7 @@ use Filament\Infolists;
 use Filament\Infolists\Components\Actions\Action;
 use Filament\Infolists\Components\TextEntry\TextEntrySize;
 use Filament\Infolists\Infolist;
+use Filament\Notifications\Notification;
 use Filament\Support\Colors\Color;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\FontWeight;
@@ -769,7 +770,9 @@ class ManageOrder extends BaseViewRecord
                 $response = $transaction->refund(bcmul($data['amount'], $record->currency->factor), $data['notes']);
 
                 if (! $response->success) {
-                    $action->failureNotification(fn () => $response->message);
+                    $action->failureNotification(
+                        fn () => Notification::make('refund_failure')->color('danger')->title($response->message)
+                    );
 
                     $action->failure();
 

--- a/packages/paypal/src/Paypal.php
+++ b/packages/paypal/src/Paypal.php
@@ -51,6 +51,20 @@ class Paypal implements PaypalInterface
             ->json();
     }
 
+    public function refund($transactionId, string $amount, string $currencyCode)
+    {
+        return $this->baseHttpClient()->withToken($this->getAccessToken())
+            ->withBody(json_encode([
+                'amount' => [
+                    'value' => $amount,
+                    'currency_code' => $currencyCode,
+                ],
+            ]), 'application/json')
+            ->post("/v2/payments/captures/{$transactionId}/refund")
+            ->throw()
+            ->json();
+    }
+
     public function buildInitialOrder(Cart $cart): array
     {
         $billingAddress = $cart->billingAddress;


### PR DESCRIPTION
Refunds were not implemented in the PayPal payment driver. This PR looks to address that.

There was also an issue in the refund action, where the failure notification was implemented incorrectly.