### PR TITLE
Only load lunar filament styles inside filament

### DIFF
--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin;
 
+use Filament\Facades\Filament;
 use Filament\Support\Assets\Css;
 use Filament\Support\Events\FilamentUpgraded;
 use Filament\Support\Facades\FilamentAsset;
@@ -107,9 +108,11 @@ class LunarPanelProvider extends ServiceProvider
 
     protected function registerPanelAssets(): void
     {
-        FilamentAsset::register([
-            Css::make('lunar-panel', __DIR__.'/../resources/dist/lunar-panel.css'),
-        ], 'lunarphp/panel');
+        if (Filament::isServing()) {
+            FilamentAsset::register([
+                Css::make('lunar-panel', __DIR__.'/../resources/dist/lunar-panel.css'),
+            ], 'lunarphp/panel');
+        }
     }
 
     /**

--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -108,11 +108,11 @@ class LunarPanelProvider extends ServiceProvider
 
     protected function registerPanelAssets(): void
     {
-        if (Filament::isServing()) {
+        Filament::serving(function() {
             FilamentAsset::register([
                 Css::make('lunar-panel', __DIR__.'/../resources/dist/lunar-panel.css'),
             ], 'lunarphp/panel');
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
This PR prevents the package's `lunar-panel.css` file from being included outside of Filament.

Currently, the `LunarPanelProvider` has a `registerPanelAssets` method that registers this file as a Filament Asset. By doing so, it's included anywhere the `@filamentStyles` blade directive is used.

For any sites that implement Filament on their storefront (for example, by using Filament's Form Builder or Notifications features), this `@filamentStyles` blade directive is likely added to their various blade layout files (as instructed by the Filament documentation). However, this will result in the style rules defined in the `lunar-panel.css` file being included on the storefront pages. And in that case, those style rules may inadvertently overwrite existing style rules set on the user's storefront.

To prevent this, this PR wraps the registration of the `lunar-panel.css` file inside of the `Lunar::isServing()` conditional. By doing so, the style is only included on Filament pages and not on the storefront.