### PR TITLE
Define inverse discount relationships

### DIFF
--- a/packages/core/src/Models/Channel.php
+++ b/packages/core/src/Models/Channel.php
@@ -68,6 +68,20 @@ class Channel extends BaseModel
     }
 
     /**
+     * Return the discounts relationship
+     */
+    public function discounts(): MorphToMany
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return $this->morphedByMany(
+            Discount::class,
+            'channelable',
+            "{$prefix}channelables"
+        );
+    }
+
+    /**
      * Return the products relationship
      */
     public function products(): MorphToMany

--- a/packages/core/src/Models/CustomerGroup.php
+++ b/packages/core/src/Models/CustomerGroup.php
@@ -50,6 +50,19 @@ class CustomerGroup extends BaseModel
     }
 
     /**
+     * Return the discounts relationship.
+     */
+    public function discounts(): BelongsToMany
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return $this->belongsToMany(
+            Discount::class,
+            "{$prefix}customer_group_discount"
+        )->withTimestamps();
+    }
+
+    /**
      * Return the product relationship.
      */
     public function products(): BelongsToMany

--- a/tests/core/Unit/Models/ChannelTest.php
+++ b/tests/core/Unit/Models/ChannelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 uses(\Lunar\Tests\Core\TestCase::class);
+
 use Lunar\Models\Channel;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
@@ -33,4 +34,20 @@ test('changes are recorded in activity log', function () {
     $log = $channel->activities()->whereEvent('updated')->first();
 
     expect($log)->not->toBeNull();
+});
+
+test('can return associated discounts', function () {
+
+    $channel = Channel::factory()->create();
+
+    // Stop observers creating the channel association.
+    \Illuminate\Support\Facades\Event::fake();
+
+    $discount = \Lunar\Models\Discount::factory()->create();
+
+    expect($channel->discounts)->toHaveCount(0);
+
+    $discount->channels()->attach($channel->id);
+
+    expect($channel->refresh()->discounts)->toHaveCount(1);
 });

--- a/tests/core/Unit/Models/CustomerGroupTest.php
+++ b/tests/core/Unit/Models/CustomerGroupTest.php
@@ -1,0 +1,17 @@
+<?php
+
+uses(\Lunar\Tests\Core\TestCase::class);
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+test('can return discounts', function () {
+    $customerGroup = \Lunar\Models\CustomerGroup::factory()->create();
+
+    $discount = \Lunar\Models\Discount::factory()->create();
+
+    expect($customerGroup->discounts)->toHaveCount(0);
+
+    $customerGroup->discounts()->attach($discount->id);
+
+    expect($customerGroup->refresh()->discounts)->toHaveCount(1);
+});


### PR DESCRIPTION
Define the inverse customerGroups and channels relationships on discounts so the Filament relation managers work.

Closes https://github.com/lunarphp/lunar/issues/1657