### PR TITLE
Change to show billing address rather than shipping address fields

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -93,7 +93,7 @@ class OrderResource extends BaseResource
             Tables\Columns\TextColumn::make('customer_reference')
                 ->label(__('lunarpanel::order.table.customer_reference.label'))
                 ->toggleable(),
-            Tables\Columns\TextColumn::make('shippingAddress.fullName')
+            Tables\Columns\TextColumn::make('billingAddress.fullName')
                 ->label(__('lunarpanel::order.table.customer.label'))
                 ->toggleable(),
             Tables\Columns\TextColumn::make('new_customer')
@@ -108,16 +108,16 @@ class OrderResource extends BaseResource
                 ->badge()
                 ->toggleable()
                 ->separator(','),
-            Tables\Columns\TextColumn::make('shippingAddress.postcode')
+            Tables\Columns\TextColumn::make('billingAddress.postcode')
                 ->label(__('lunarpanel::order.table.postcode.label'))
                 ->toggleable(),
-            Tables\Columns\TextColumn::make('shippingAddress.contact_email')
+            Tables\Columns\TextColumn::make('billingAddress.contact_email')
                 ->label(__('lunarpanel::order.table.email.label'))
                 ->toggleable()
                 ->copyable()
                 ->copyMessage(__('lunarpanel::order.table.email.copy_message'))
                 ->copyMessageDuration(1500),
-            Tables\Columns\TextColumn::make('shippingAddress.contact_phone')
+            Tables\Columns\TextColumn::make('billingAddress.contact_phone')
                 ->label(__('lunarpanel::order.table.phone.label'))
                 ->toggleable(),
             Tables\Columns\TextColumn::make('total')
@@ -215,9 +215,9 @@ class OrderResource extends BaseResource
             'reference',
             'customer_reference',
             'notes',
-            'shippingAddress.first_name',
-            'shippingAddress.last_name',
-            'shippingAddress.contact_email',
+            'billingAddress.first_name',
+            'billingAddress.last_name',
+            'billingAddress.contact_email',
             'tags.value',
         ];
     }
@@ -225,7 +225,7 @@ class OrderResource extends BaseResource
     public static function getGlobalSearchEloquentQuery(): Builder
     {
         return parent::getGlobalSearchEloquentQuery()->with([
-            'shippingAddress',
+            'billingAddress',
             'tags',
         ]);
     }


### PR DESCRIPTION
Orders will always have a billing address, but not always shipping details - e.g. if an order is for collection or digital goods.

This PR looks to change the default columns on the order listing page to use billing details instead.