### PR TITLE
Hotfix - Remove weird dash on migrations

### DIFF
--- a/packages/core/database/migrations/2024_01_29_100000_update_nullable_currency_on_prices_table.php
+++ b/packages/core/database/migrations/2024_01_29_100000_update_nullable_currency_on_prices_table.php
@@ -1,4 +1,4 @@
--<?php
+<?php
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/packages/core/database/migrations/2024_01_31_100000_update_tier_to_min_quantity_on_prices_table.php
+++ b/packages/core/database/migrations/2024_01_31_100000_update_tier_to_min_quantity_on_prices_table.php
@@ -1,4 +1,4 @@
--<?php
+<?php
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/packages/opayo/database/migrations/2024_02_22_100000_create_opayo_tokens_table.php
+++ b/packages/opayo/database/migrations/2024_02_22_100000_create_opayo_tokens_table.php
@@ -1,4 +1,4 @@
--<?php
+<?php
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;


### PR DESCRIPTION
Not sure where this came from, but there is a `-` at the start of some migration files.