### PR TITLE
Hotfix - Fix brand mapped attributes

### DIFF
--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -4,7 +4,6 @@ namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasAttributes;
@@ -53,20 +52,6 @@ class Brand extends BaseModel implements SpatieHasMedia
     protected static function newFactory(): BrandFactory
     {
         return BrandFactory::new();
-    }
-
-    /**
-     * Get the mapped attributes relation.
-     */
-    public function mappedAttributes(): MorphToMany
-    {
-        $prefix = config('lunar.database.table_prefix');
-
-        return $this->morphToMany(
-            Attribute::class,
-            'attributable',
-            "{$prefix}attributables"
-        )->withTimestamps();
     }
 
     /**

--- a/tests/core/Unit/Models/BrandTest.php
+++ b/tests/core/Unit/Models/BrandTest.php
@@ -65,3 +65,13 @@ test('generates unique urls', function () {
 
     expect($brand4->urls->first()->slug)->toEqual('brand-test');
 });
+
+test('can return mapped attributes', function () {
+    \Lunar\Models\Attribute::factory()->create([
+        'attribute_type' => Brand::class,
+    ]);
+    $brand = Brand::factory()->create([
+        'name' => 'Test Brand',
+    ]);
+    expect($brand->mappedAttributes)->toHaveCount(1);
+});


### PR DESCRIPTION
The `mappedAttributes` on the `Brand` model was incorrect and returned an empty collection.