### PR TITLE
Change approach to ensure attribute_data validates

### DIFF
--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -44,13 +44,6 @@ class AttributeData
         return $fieldType::getFilamentComponent($attribute)->label(
             $attribute->translate('name')
         )
-            ->formatStateUsing(fn ($state) => ($state ?: (new $attribute->type))->getValue())
-            ->dehydrateStateUsing(function ($state) use ($attribute) {
-                $field = new $attribute->type;
-                $field->setValue($state);
-
-                return $field;
-            })
             ->required($attribute->required)
             ->default($attribute->default_value);
     }

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -81,6 +81,10 @@ class Attributes extends Forms\Components\Group
         ->configure()
         ->key('attributeData')
         ->mutateStateForValidationUsing(function ($state) {
+            if (! is_array($state)) {
+                return $state;
+            }
+
             foreach ($state as $key => $value) {
                 if (! $value instanceof \Lunar\Base\Fieldtype) {
                     continue;

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -77,6 +77,19 @@ class Attributes extends Forms\Components\Group
                     return $groupComponents;
                 },
             ]
-        )->configure()->key('attributeData');
+        )
+        ->configure()
+        ->key('attributeData')
+        ->mutateStateForValidationUsing(function ($state) {
+            foreach ($state as $key => $value) {
+                if (! $value instanceof \Lunar\Base\Fieldtype) {
+                    continue;
+                }
+
+                $state[$key] = $value->getValue();
+            }
+
+            return $state;
+        });
     }
 }


### PR DESCRIPTION
This PR takes a different approach to #1639 (and reverts it), instead using the mutateStateForValidationUsing hook Filament provides.

Closes https://github.com/lunarphp/lunar/issues/1655