### PR TITLE
Use Lunar Migration class for media table

### DIFF
--- a/packages/core/database/migrations/2021_08_10_101547_create_media_table.php
+++ b/packages/core/database/migrations/2021_08_10_101547_create_media_table.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
+use Lunar\Base\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 


### PR DESCRIPTION
Currently this migration extends the default migration class of Laravel. The normal migration class does not set the connection from the Lunar connection of course.

This will cause errors in the upcoming migration `2022_08_09_100000_create_media_variant_table`, because this table references to the normal `media` table.
This only happens if using another connection for Lunar tables.