### PR TITLE
Refactor search scope in Staff model

### DIFF
--- a/packages/admin/src/Models/Staff.php
+++ b/packages/admin/src/Models/Staff.php
@@ -104,9 +104,7 @@ class Staff extends Authenticatable implements FilamentUser, HasName
             $parts = explode(' ', $term);
 
             foreach ($parts as $part) {
-                $query->where('email', 'LIKE', "%$part%")
-                    ->orWhere('firstname', 'LIKE', "%$part%")
-                    ->orWhere('lastname', 'LIKE', "%$part%");
+                $query->whereAny(['email', 'firstname', 'lastname'], 'LIKE', "%$part%");
             }
         }
     }


### PR DESCRIPTION
from Laravel 10.47, it supports `whereAll`, `orWhereAll`, and `orWhereAny`. This is such a nice little cleanup. ⛏️ 