### PR TITLE
Fix return type

### DIFF
--- a/packages/core/src/Pipelines/CartLine/GetUnitPrice.php
+++ b/packages/core/src/Pipelines/CartLine/GetUnitPrice.php
@@ -13,7 +13,7 @@ class GetUnitPrice
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return mixed
      */
     public function handle(CartLine $cartLine, Closure $next)
     {


### PR DESCRIPTION
`handle()` should invoke the next callable which could be could be any type of response or `CartLine` object.