### PR TITLE
Feature - Brand relation managers

### DIFF
--- a/packages/admin/resources/lang/en/brand.php
+++ b/packages/admin/resources/lang/en/brand.php
@@ -34,6 +34,11 @@ return [
             'actions' => [
                 'attach' => [
                     'label' => 'Associate a product',
+                    'form' => [
+                        'record_id' => [
+                            'label' => 'Product',
+                        ],
+                    ],
                     'notification' => [
                         'success' => 'Product attached to brand',
                     ],
@@ -47,6 +52,15 @@ return [
         ],
         'collections' => [
             'label' => 'Collections',
+            'table' => [
+                'header_actions' => [
+                    'attach' => [
+                        'record_select' => [
+                            'placeholder' => 'Select a collection',
+                        ],
+                    ],
+                ],
+            ],
             'actions' => [
                 'attach' => [
                     'label' => 'Associate a collection',

--- a/packages/admin/resources/lang/en/brand.php
+++ b/packages/admin/resources/lang/en/brand.php
@@ -33,6 +33,7 @@ return [
             'label' => 'Products',
             'actions' => [
                 'attach' => [
+                    'label' => 'Associate a product',
                     'notification' => [
                         'success' => 'Product attached to brand',
                     ],
@@ -46,6 +47,11 @@ return [
         ],
         'collections' => [
             'label' => 'Collections',
+            'actions' => [
+                'attach' => [
+                    'label' => 'Associate a collection',
+                ],
+            ],
         ],
     ],
 

--- a/packages/admin/resources/lang/en/brand.php
+++ b/packages/admin/resources/lang/en/brand.php
@@ -28,4 +28,25 @@ return [
             ],
         ],
     ],
+    'pages' => [
+        'products' => [
+            'label' => 'Products',
+            'actions' => [
+                'attach' => [
+                    'notification' => [
+                        'success' => 'Product attached to brand',
+                    ],
+                ],
+                'detach' => [
+                    'notification' => [
+                        'success' => 'Product detached.',
+                    ],
+                ],
+            ],
+        ],
+        'collections' => [
+            'label' => 'Collections',
+        ],
+    ],
+
 ];

--- a/packages/admin/src/Filament/Resources/BrandResource.php
+++ b/packages/admin/src/Filament/Resources/BrandResource.php
@@ -56,6 +56,8 @@ class BrandResource extends BaseResource
             Pages\EditBrand::class,
             Pages\ManageBrandMedia::class,
             Pages\ManageBrandUrls::class,
+            Pages\ManageBrandProducts::class,
+            Pages\ManageBrandCollections::class,
         ]);
     }
 
@@ -130,10 +132,10 @@ class BrandResource extends BaseResource
         ];
     }
 
-    public static function getRelations(): array
+    public static function getDefaultRelations(): array
     {
         return [
-            //
+
         ];
     }
 
@@ -145,6 +147,8 @@ class BrandResource extends BaseResource
             'edit' => Pages\EditBrand::route('/{record}/edit'),
             'media' => Pages\ManageBrandMedia::route('/{record}/media'),
             'urls' => Pages\ManageBrandUrls::route('/{record}/urls'),
+            'products' => Pages\ManageBrandProducts::route('/{record}/products'),
+            'collections' => Pages\ManageBrandCollections::route('/{record}/collections'),
         ];
     }
 

--- a/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandCollections.php
+++ b/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandCollections.php
@@ -48,7 +48,9 @@ class ManageBrandCollections extends BaseManageRelatedRecords
             Tables\Actions\AttachAction::make()
                 ->recordSelect(
                     function (Forms\Components\Select $select) {
-                        return $select->placeholder('Select a collection') // TODO: needs translation
+                        return $select->placeholder(
+                            __('lunarpanel::brand.pages.collections.table.header_actions.attach.record_select.placeholder')
+                        )
                             ->getSearchResultsUsing(static function (Forms\Components\Select $component, string $search): array {
                                 return Collection::search($search)
                                     ->get()

--- a/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandCollections.php
+++ b/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandCollections.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\BrandResource\Pages;
+
+use Filament\Forms;
+use Filament\Support\Facades\FilamentIcon;
+use Filament\Tables;
+use Filament\Tables\Actions\DetachAction;
+use Filament\Tables\Table;
+use Lunar\Admin\Filament\Resources\BrandResource;
+use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
+use Lunar\Admin\Support\Tables\Columns\TranslatedTextColumn;
+use Lunar\Models\Collection;
+
+class ManageBrandCollections extends BaseManageRelatedRecords
+{
+    protected static string $resource = BrandResource::class;
+
+    protected static string $relationship = 'collections';
+
+    public function getTitle(): string
+    {
+
+        return __('lunarpanel::brand.pages.collections.label');
+    }
+
+    public static function getNavigationIcon(): ?string
+    {
+        return FilamentIcon::resolve('lunar::collections');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('lunarpanel::brand.pages.collections.label');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table->columns([
+            TranslatedTextColumn::make('attribute_data.name')
+                ->attributeData()
+                ->limitedTooltip()
+                ->limit(50)
+                ->label(__('lunarpanel::product.table.name.label')),
+        ])->actions([
+            DetachAction::make(),
+        ])->headerActions([
+            Tables\Actions\AttachAction::make()
+                ->recordSelect(
+                    function (Forms\Components\Select $select) {
+                        return $select->placeholder('Select a collection') // TODO: needs translation
+                            ->getSearchResultsUsing(static function (Forms\Components\Select $component, string $search): array {
+                                return Collection::search($search)
+                                    ->get()
+                                    ->mapWithKeys(fn (Collection $record): array => [$record->getKey() => $record->breadcrumb->push($record->translateAttribute('name'))->join(' > ')])
+                                    ->all();
+                            });
+                    }
+                ),
+        ]);
+    }
+}

--- a/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandProducts.php
+++ b/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandProducts.php
@@ -65,7 +65,9 @@ class ManageBrandProducts extends BaseManageRelatedRecords
                 )
                 ->form([
                     Forms\Components\Select::make('recordId')
-                        ->label('Product')
+                        ->label(
+                            __('lunarpanel::brand.pages.products.actions.attach.form.record_id.label')
+                        )
                         ->required()
                         ->searchable()
                         ->getSearchResultsUsing(static function (Forms\Components\Select $component, string $search): array {

--- a/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandProducts.php
+++ b/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandProducts.php
@@ -39,7 +39,12 @@ class ManageBrandProducts extends BaseManageRelatedRecords
     public function table(Table $table): Table
     {
         return $table->columns([
-            ProductResource::getNameTableColumn()->searchable(),
+            ProductResource::getNameTableColumn()->searchable()
+                ->url(function (Model $record) {
+                    return ProductResource::getUrl('edit', [
+                        'record' => $record->getKey(),
+                    ]);
+                }),
             ProductResource::getSkuTableColumn(),
         ])->actions([
             DetachAction::make()
@@ -55,11 +60,14 @@ class ManageBrandProducts extends BaseManageRelatedRecords
                 }),
         ])->headerActions([
             AttachAction::make()
+                ->label(
+                    __('lunarpanel::brand.pages.products.actions.attach.label')
+                )
                 ->form([
                     Forms\Components\Select::make('recordId')
                         ->label('Product')
                         ->required()
-                        ->searchable(true)
+                        ->searchable()
                         ->getSearchResultsUsing(static function (Forms\Components\Select $component, string $search): array {
                             return Product::search($search)
                                 ->get()

--- a/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandProducts.php
+++ b/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandProducts.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\BrandResource\Pages;
+
+use Filament\Forms;
+use Filament\Notifications\Notification;
+use Filament\Support\Facades\FilamentIcon;
+use Filament\Tables\Actions\AttachAction;
+use Filament\Tables\Actions\DetachAction;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Lunar\Admin\Filament\Resources\BrandResource;
+use Lunar\Admin\Filament\Resources\ProductResource;
+use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
+use Lunar\Models\Product;
+
+class ManageBrandProducts extends BaseManageRelatedRecords
+{
+    protected static string $resource = BrandResource::class;
+
+    protected static string $relationship = 'products';
+
+    public function getTitle(): string
+    {
+
+        return __('lunarpanel::brand.pages.products.label');
+    }
+
+    public static function getNavigationIcon(): ?string
+    {
+        return FilamentIcon::resolve('lunar::products');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('lunarpanel::brand.pages.products.label');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table->columns([
+            ProductResource::getNameTableColumn()->searchable(),
+            ProductResource::getSkuTableColumn(),
+        ])->actions([
+            DetachAction::make()
+                ->action(function (Model $record) {
+                    $record->update([
+                        'brand_id' => null,
+                    ]);
+
+                    Notification::make()
+                        ->success()
+                        ->body(__('lunarpanel::brand.pages.products.actions.detach.notification.success'))
+                        ->send();
+                }),
+        ])->headerActions([
+            AttachAction::make()
+                ->form([
+                    Forms\Components\Select::make('recordId')
+                        ->label('Product')
+                        ->required()
+                        ->searchable(true)
+                        ->getSearchResultsUsing(static function (Forms\Components\Select $component, string $search): array {
+                            return Product::search($search)
+                                ->get()
+                                ->mapWithKeys(fn (Product $record): array => [$record->getKey() => $record->translateAttribute('name')])
+                                ->all();
+                        }),
+                ])
+                ->action(function (array $arguments, array $data) {
+                    Product::where('id', '=', $data['recordId'])
+                        ->update([
+                            'brand_id' => $this->getRecord()->id,
+                        ]);
+
+                    Notification::make()
+                        ->success()
+                        ->body(__('lunarpanel::brand.pages.products.actions.attach.notification.success'))
+                        ->send();
+                }),
+        ]);
+    }
+}

--- a/packages/admin/src/Filament/Resources/ProductResource.php
+++ b/packages/admin/src/Filament/Resources/ProductResource.php
@@ -248,34 +248,12 @@ class ProductResource extends BaseResource
                 ->limit(1)
                 ->square()
                 ->label(''),
-            TranslatedTextColumn::make('attribute_data.name')
-                ->attributeData()
-                ->limitedTooltip()
-                ->limit(50)
-                ->label(__('lunarpanel::product.table.name.label')),
+            static::getNameTableColumn(),
             Tables\Columns\TextColumn::make('brand.name')
                 ->label(__('lunarpanel::product.table.brand.label'))
                 ->toggleable()
                 ->searchable(),
-            Tables\Columns\TextColumn::make('variants.sku')
-                ->label(__('lunarpanel::product.table.sku.label'))
-                ->tooltip(function (Tables\Columns\TextColumn $column, Model $record): ?string {
-
-                    if ($record->variants->count() <= $column->getListLimit()) {
-                        return null;
-                    }
-
-                    if ($record->variants->count() > 30) {
-                        $record->variants = $record->variants->slice(0, 30);
-                    }
-
-                    return $record->variants
-                        ->map(fn ($variant) => $variant->sku)
-                        ->implode(', ');
-                })
-                ->listWithLineBreaks()
-                ->limitList(1)
-                ->toggleable(),
+            static::getSkuTableColumn(),
             Tables\Columns\TextColumn::make('variants_sum_stock')
                 ->label(__('lunarpanel::product.table.stock.label'))
                 ->sum('variants', 'stock'),
@@ -294,6 +272,38 @@ class ProductResource extends BaseResource
                 })
                 ->toggleable(),
         ];
+    }
+
+    public static function getNameTableColumn(): Tables\Columns\Column
+    {
+        return TranslatedTextColumn::make('attribute_data.name')
+            ->attributeData()
+            ->limitedTooltip()
+            ->limit(50)
+            ->label(__('lunarpanel::product.table.name.label'));
+    }
+
+    public static function getSkuTableColumn(): Tables\Columns\Column
+    {
+        return Tables\Columns\TextColumn::make('variants.sku')
+            ->label(__('lunarpanel::product.table.sku.label'))
+            ->tooltip(function (Tables\Columns\TextColumn $column, Model $record): ?string {
+
+                if ($record->variants->count() <= $column->getListLimit()) {
+                    return null;
+                }
+
+                if ($record->variants->count() > 30) {
+                    $record->variants = $record->variants->slice(0, 30);
+                }
+
+                return $record->variants
+                    ->map(fn ($variant) => $variant->sku)
+                    ->implode(', ');
+            })
+            ->listWithLineBreaks()
+            ->limitList(1)
+            ->toggleable();
     }
 
     public static function getDefaultRelations(): array

--- a/packages/core/database/migrations/2024_03_26_100000_create_brand_collection_table.php
+++ b/packages/core/database/migrations/2024_03_26_100000_create_brand_collection_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+class CreateBrandCollectionTable extends Migration
+{
+    public function up()
+    {
+        Schema::create($this->prefix.'brand_collection', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('brand_id')->constrained($this->prefix.'brands');
+            $table->foreignId('collection_id')->constrained($this->prefix.'collections');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('brand_collection');
+    }
+}

--- a/packages/core/database/migrations/2024_03_26_100000_create_brand_collection_table.php
+++ b/packages/core/database/migrations/2024_03_26_100000_create_brand_collection_table.php
@@ -18,6 +18,6 @@ class CreateBrandCollectionTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('brand_collection');
+        Schema::dropIfExists($this->prefix.'brand_collection');
     }
 }

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -3,6 +3,7 @@
 namespace Lunar\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
@@ -67,5 +68,12 @@ class Brand extends BaseModel implements SpatieHasMedia
         $prefix = config('lunar.database.table_prefix');
 
         return $this->belongsToMany(Discount::class, "{$prefix}brand_discount");
+    }
+
+    public function collections(): BelongsToMany
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return $this->belongsToMany(Collection::class, "{$prefix}brand_collection");
     }
 }

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -135,4 +135,14 @@ class Collection extends BaseModel implements SpatieHasMedia
             "{$prefix}collection_discount"
         )->withPivot(['type'])->withTimestamps();
     }
+
+    public function brands(): BelongsToMany
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return $this->belongsToMany(
+            Brand::class,
+            "{$prefix}brand_collection"
+        )->withTimestamps();
+    }
 }

--- a/tests/admin/Feature/Filament/Resources/BrandResource/Pages/ManageBrandCollectionsTest.php
+++ b/tests/admin/Feature/Filament/Resources/BrandResource/Pages/ManageBrandCollectionsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.collection');
+
+it('can render the brand collections page', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Brand::factory()->create();
+
+    $this->asStaff(admin: true)
+        ->get(\Lunar\Admin\Filament\Resources\BrandResource::getUrl('collections', [
+            'record' => $record,
+        ]))
+        ->assertSuccessful();
+});

--- a/tests/admin/Feature/Filament/Resources/BrandResource/Pages/ManageBrandProductsTest.php
+++ b/tests/admin/Feature/Filament/Resources/BrandResource/Pages/ManageBrandProductsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.collection');
+
+it('can render the brand products page', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Brand::factory()->create();
+
+    $this->asStaff(admin: true)
+        ->get(\Lunar\Admin\Filament\Resources\BrandResource::getUrl('products', [
+            'record' => $record,
+        ]))
+        ->assertSuccessful();
+});


### PR DESCRIPTION
This PR looks to add an additional relationship to brands for collections. This is so you can associate multiple collections to brands, the idea is that this will "bring more life" to brands and allow developers to create specific brand pages which can show different collections or products (as a start).

Also this PR brings in relationship managers to the panel so users can administer these relations from within the brand page.