### PR TITLE
Fix - Hydratation component issue

### DIFF
--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -44,6 +44,7 @@ class AttributeData
         return $fieldType::getFilamentComponent($attribute)->label(
             $attribute->translate('name')
         )
+            ->formatStateUsing(fn ($state) => ($state ?: new $attribute->type))
             ->required($attribute->required)
             ->default($attribute->default_value);
     }


### PR DESCRIPTION
This PR fix issue #1655.

After recents changes, the line has accidentally remove. Livewire Synthesizers need a type to hydrate and dehydrate state of component.