### PR TITLE
[1.x] Remove `nunomaduro/larastan`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "larastan/larastan": "^2.9",
         "laravel/pint": "1.13.1",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/larastan": "^2.0",
         "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
This PR removes `nunomaduro/larastan` from dependencies. The package `larastan/larastan` is now being used instead.