### PR TITLE
Remove hub logic from installer

### DIFF
--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\File;
 use Lunar\Admin\Models\Staff;
 use Lunar\Facades\DB;
 use Lunar\FieldTypes\TranslatedText;
-use Lunar\Hub\AdminHubServiceProvider;
 use Lunar\Models\Attribute;
 use Lunar\Models\AttributeGroup;
 use Lunar\Models\Channel;
@@ -248,11 +247,6 @@ class InstallLunar extends Command
             }
         });
 
-        if ($this->isHubInstalled()) {
-            $this->components->info('Installing Admin Hub.');
-            $this->call('lunar:hub:install');
-        }
-
         $this->components->info('Publishing Filament assets');
         $this->call('filament:assets');
 
@@ -307,13 +301,5 @@ class InstallLunar extends Command
         }
 
         $this->call('vendor:publish', $params);
-    }
-
-    /**
-     * Determines if the admin hub is installed.
-     */
-    private function isHubInstalled(): bool
-    {
-        return class_exists(AdminHubServiceProvider::class);
     }
 }


### PR DESCRIPTION
The installer is checking for the admin hub service provider, which doesn't exist anymore the logic within the if statement also would try to run a command that doesn't exist anymore.