### PR TITLE
Lock DOMPDF to `^2.0.7`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "awcodes/shout": "^2.0.2",
         "barryvdh/laravel-dompdf": "^2.0",
-        "dompdf/dompdf": "2.0.7",
+        "dompdf/dompdf": "^2.0.7",
         "cartalyst/converter": "^8.0|^9.0",
         "doctrine/dbal": "^3.6",
         "ext-bcmath": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "awcodes/shout": "^2.0.2",
         "barryvdh/laravel-dompdf": "^2.0",
-        "dompdf/dompdf": "2.0.6",
+        "dompdf/dompdf": "2.0.7",
         "cartalyst/converter": "^8.0|^9.0",
         "doctrine/dbal": "^3.6",
         "ext-bcmath": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "awcodes/shout": "^2.0.2",
         "barryvdh/laravel-dompdf": "^2.0",
+        "dompdf/dompdf": "2.0.4",
         "cartalyst/converter": "^8.0|^9.0",
         "doctrine/dbal": "^3.6",
         "ext-bcmath": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "awcodes/shout": "^2.0.2",
         "barryvdh/laravel-dompdf": "^2.0",
-        "dompdf/dompdf": "2.0.4",
+        "dompdf/dompdf": "2.0.6",
         "cartalyst/converter": "^8.0|^9.0",
         "doctrine/dbal": "^3.6",
         "ext-bcmath": "*",


### PR DESCRIPTION
There is a current issue on DOMPDF 2.0.5 https://github.com/dompdf/dompdf/issues/3434

This PR Locks the version to one patch version behind the latest until it's fixed.