### PR TITLE
Improvements to standard media conversions

### DIFF
--- a/packages/core/src/Base/StandardMediaDefinitions.php
+++ b/packages/core/src/Base/StandardMediaDefinitions.php
@@ -15,7 +15,7 @@ class StandardMediaDefinitions implements MediaDefinitionsInterface
         // Add a conversion for the admin panel to use
         $model->addMediaConversion('small')
             ->fit(Fit::Fill, 300, 300)
-            ->border(0, BorderType::Overlay)
+            ->border(0, BorderType::Overlay, color: '#FFF')
             ->background('#FFF')
             ->sharpen(10)
             ->keepOriginalImageFormat();
@@ -66,7 +66,10 @@ class StandardMediaDefinitions implements MediaDefinitionsInterface
                         Fit::Fill,
                         $conversion['width'],
                         $conversion['height']
-                    )->keepOriginalImageFormat();
+                    )
+                    ->border(0, BorderType::Overlay, color: '#FFF')
+                    ->background('#FFF')
+                    ->keepOriginalImageFormat();
             }
         });
     }


### PR DESCRIPTION
Currently, a border can be seen top-right sometimes. This resolves that and also applies the tweaks to the other default media conversion sizes also.