### PR TITLE
Trigger searchable when records are updated.

### DIFF
--- a/packages/admin/src/Events/ChildCollectionCreated.php
+++ b/packages/admin/src/Events/ChildCollectionCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ChildCollectionCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/CollectionProductAttached.php
+++ b/packages/admin/src/Events/CollectionProductAttached.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CollectionProductAttached
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/CollectionProductDetached.php
+++ b/packages/admin/src/Events/CollectionProductDetached.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CollectionProductDetached
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/CustomerAddressEdited.php
+++ b/packages/admin/src/Events/CustomerAddressEdited.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CustomerAddressEdited
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/CustomerUserEdited.php
+++ b/packages/admin/src/Events/CustomerUserEdited.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CustomerUserEdited
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ModelChannelsUpdated.php
+++ b/packages/admin/src/Events/ModelChannelsUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ModelChannelsUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ModelMediaUpdated.php
+++ b/packages/admin/src/Events/ModelMediaUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ModelMediaUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ModelPricesUpdated.php
+++ b/packages/admin/src/Events/ModelPricesUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ModelPricesUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ModelUrlsUpdated.php
+++ b/packages/admin/src/Events/ModelUrlsUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ModelUrlsUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ProductAssociationsUpdated.php
+++ b/packages/admin/src/Events/ProductAssociationsUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductAssociationsUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ProductCollectionsUpdated.php
+++ b/packages/admin/src/Events/ProductCollectionsUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductCollectionsUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ProductCustomerGroupsUpdated.php
+++ b/packages/admin/src/Events/ProductCustomerGroupsUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductCustomerGroupsUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ProductPricingUpdated.php
+++ b/packages/admin/src/Events/ProductPricingUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductPricingUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Events/ProductVariantOptionsUpdated.php
+++ b/packages/admin/src/Events/ProductVariantOptionsUpdated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lunar\Admin\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProductVariantOptionsUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Model $model
+    ) {
+    }
+}

--- a/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionChildren.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionChildren.php
@@ -73,7 +73,11 @@ class ManageCollectionChildren extends BaseManageRelatedRecords
                 return CollectionResource::getUrl('edit', ['record' => $record]);
             }),
         ])->headerActions([
-            CreateChildCollection::make('createChildCollection'),
+            CreateChildCollection::make('createChildCollection')->after(
+                fn () => sync_with_search(
+                    $this->getOwnerRecord()
+                )
+            ),
         ]);
     }
 }

--- a/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionChildren.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionChildren.php
@@ -8,6 +8,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Lunar\Admin\Events\ChildCollectionCreated;
 use Lunar\Admin\Filament\Resources\CollectionResource;
 use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
 use Lunar\Admin\Support\Tables\Actions\Collections\CreateChildCollection;
@@ -74,9 +75,7 @@ class ManageCollectionChildren extends BaseManageRelatedRecords
             }),
         ])->headerActions([
             CreateChildCollection::make('createChildCollection')->after(
-                fn () => sync_with_search(
-                    $this->getOwnerRecord()
-                )
+                fn () => ChildCollectionCreated::dispatch($this->getRecord())
             ),
         ]);
     }

--- a/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionProducts.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionProducts.php
@@ -67,7 +67,11 @@ class ManageCollectionProducts extends BaseManageRelatedRecords
                 ->formatStateUsing(fn (Model $record): string => $record->translateAttribute('name'))
                 ->label(__('lunarpanel::product.table.name.label')),
         ])->actions([
-            Tables\Actions\DetachAction::make(),
+            Tables\Actions\DetachAction::make()->after(
+                fn () => sync_with_search(
+                    $this->getOwnerRecord()
+                )
+            ),
             Tables\Actions\EditAction::make()->url(
                 fn (Model $record) => ProductResource::getUrl('edit', [
                     'record' => $record,
@@ -96,6 +100,8 @@ class ManageCollectionProducts extends BaseManageRelatedRecords
                     $relationship->attach($product, [
                         'position' => $relationship->count() + 1,
                     ]);
+
+                    $product->searchable();
                 }),
         ])->reorderable('position');
     }

--- a/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionProducts.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionProducts.php
@@ -9,6 +9,8 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Lunar\Admin\Events\CollectionProductAttached;
+use Lunar\Admin\Events\CollectionProductDetached;
 use Lunar\Admin\Filament\Resources\CollectionResource;
 use Lunar\Admin\Filament\Resources\ProductResource;
 use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
@@ -68,9 +70,7 @@ class ManageCollectionProducts extends BaseManageRelatedRecords
                 ->label(__('lunarpanel::product.table.name.label')),
         ])->actions([
             Tables\Actions\DetachAction::make()->after(
-                fn () => sync_with_search(
-                    $this->getOwnerRecord()
-                )
+                fn () => CollectionProductDetached::dispatch($this->getOwnerRecord())
             ),
             Tables\Actions\EditAction::make()->url(
                 fn (Model $record) => ProductResource::getUrl('edit', [
@@ -100,6 +100,8 @@ class ManageCollectionProducts extends BaseManageRelatedRecords
                     $relationship->attach($product, [
                         'position' => $relationship->count() + 1,
                     ]);
+
+                    CollectionProductAttached::dispatch($this->getOwnerRecord());
 
                     $product->searchable();
                 }),

--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/AddressRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/AddressRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Lunar\Admin\Events\CustomerAddressEdited;
 use Lunar\Models\Address;
 use Lunar\Models\State;
 
@@ -68,9 +69,7 @@ class AddressRelationManager extends RelationManager
             ])->actions([
                 Tables\Actions\EditAction::make('editAddress')
                     ->after(
-                        fn () => sync_with_search(
-                            $this->getOwnerRecord()
-                        )
+                        fn (Model $record) => CustomerAddressEdited::dispatch($record)
                     )
                     ->fillForm(fn (Address $record): array => [
                         'title' => $record->title,

--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/AddressRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/AddressRelationManager.php
@@ -67,6 +67,11 @@ class AddressRelationManager extends RelationManager
                 ),
             ])->actions([
                 Tables\Actions\EditAction::make('editAddress')
+                    ->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    )
                     ->fillForm(fn (Address $record): array => [
                         'title' => $record->title,
                         'first_name' => $record->first_name,

--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/UserRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/UserRelationManager.php
@@ -7,7 +7,9 @@ use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
+use Lunar\Admin\Events\CustomerUserEdited;
 
 class UserRelationManager extends RelationManager
 {
@@ -28,9 +30,7 @@ class UserRelationManager extends RelationManager
         ])->actions([
             Tables\Actions\EditAction::make('edit')
                 ->after(
-                    fn () => sync_with_search(
-                        $this->getOwnerRecord()
-                    )
+                    fn (Model $record) => CustomerUserEdited::dispatch($record)
                 )
                 ->form([
                     Group::make([

--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/UserRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/UserRelationManager.php
@@ -27,6 +27,11 @@ class UserRelationManager extends RelationManager
                 ->label(__('lunarpanel::user.table.email.label')),
         ])->actions([
             Tables\Actions\EditAction::make('edit')
+                ->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                )
                 ->form([
                     Group::make([
                         TextInput::make('email')

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Lunar\Admin\Events\ProductAssociationsUpdated;
 use Lunar\Admin\Filament\Resources\ProductResource;
 use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
 use Lunar\Models\Product;
@@ -86,14 +87,14 @@ class ManageProductAssociations extends BaseManageRelatedRecords
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ProductAssociationsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
             ])
             ->actions([
                 Tables\Actions\DeleteAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ProductAssociationsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
@@ -101,7 +102,7 @@ class ManageProductAssociations extends BaseManageRelatedRecords
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make()->after(
-                        fn () => sync_with_search(
+                        fn () => ProductAssociationsUpdated::dispatch(
                             $this->getOwnerRecord()
                         )
                     ),

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php
@@ -85,14 +85,26 @@ class ManageProductAssociations extends BaseManageRelatedRecords
                 //
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ])
             ->actions([
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\DeleteAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    ),
                 ]),
             ]);
     }

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
@@ -58,14 +58,26 @@ class ManageProductCollections extends BaseManageRelatedRecords
                                         ->all();
                                 });
                         }
+                    )->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
                     ),
             ])
             ->actions([
-                Tables\Actions\DetachAction::make(),
+                Tables\Actions\DetachAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DetachBulkAction::make(),
+                    Tables\Actions\DetachBulkAction::make()->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    ),
                 ]),
             ]);
     }

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
@@ -6,6 +6,7 @@ use Filament\Forms;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Lunar\Admin\Events\ProductCollectionsUpdated;
 use Lunar\Admin\Filament\Resources\ProductResource;
 use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
 use Lunar\Admin\Support\Tables\Columns\TranslatedTextColumn;
@@ -59,14 +60,14 @@ class ManageProductCollections extends BaseManageRelatedRecords
                                 });
                         }
                     )->after(
-                        fn () => sync_with_search(
+                        fn () => ProductCollectionsUpdated::dispatch(
                             $this->getOwnerRecord()
                         )
                     ),
             ])
             ->actions([
                 Tables\Actions\DetachAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ProductCollectionsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
@@ -74,7 +75,7 @@ class ManageProductCollections extends BaseManageRelatedRecords
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DetachBulkAction::make()->after(
-                        fn () => sync_with_search(
+                        fn () => ProductCollectionsUpdated::dispatch(
                             $this->getOwnerRecord()
                         )
                     ),

--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
@@ -148,8 +148,12 @@ class CustomerGroupPricingRelationManager extends RelationManager
                     return $data;
                 })->label(
                     __('lunarpanel::relationmanagers.customer_group_pricing.table.actions.create.label')
-                )
-                    ->modalHeading(__('lunarpanel::relationmanagers.customer_group_pricing.table.actions.create.modal.heading')),
+                )->modalHeading(__('lunarpanel::relationmanagers.customer_group_pricing.table.actions.create.modal.heading'))
+                    ->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    ),
             ])
             ->actions([
                 Tables\Actions\EditAction::make()->mutateFormDataUsing(function (array $data): array {
@@ -159,7 +163,11 @@ class CustomerGroupPricingRelationManager extends RelationManager
                     $data['price'] = (int) ($data['price'] * $currencyModel->factor);
 
                     return $data;
-                }),
+                })->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
                 Tables\Actions\DeleteAction::make(),
             ]);
     }

--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
@@ -10,6 +10,7 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rules\Unique;
+use Lunar\Admin\Events\ProductPricingUpdated;
 use Lunar\Facades\DB;
 use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
@@ -150,9 +151,7 @@ class CustomerGroupPricingRelationManager extends RelationManager
                     __('lunarpanel::relationmanagers.customer_group_pricing.table.actions.create.label')
                 )->modalHeading(__('lunarpanel::relationmanagers.customer_group_pricing.table.actions.create.modal.heading'))
                     ->after(
-                        fn () => sync_with_search(
-                            $this->getOwnerRecord()
-                        )
+                        fn () => ProductPricingUpdated::dispatch($this->getOwnerRecord())
                     ),
             ])
             ->actions([
@@ -164,9 +163,7 @@ class CustomerGroupPricingRelationManager extends RelationManager
 
                     return $data;
                 })->after(
-                    fn () => sync_with_search(
-                        $this->getOwnerRecord()
-                    )
+                    fn () => ProductPricingUpdated::dispatch($this->getOwnerRecord())
                 ),
                 Tables\Actions\DeleteAction::make(),
             ]);

--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Lunar\Admin\Events\ProductCustomerGroupsUpdated;
 
 class CustomerGroupRelationManager extends RelationManager
 {
@@ -95,9 +96,7 @@ class CustomerGroupRelationManager extends RelationManager
                     ->label(
                         __('lunarpanel::relationmanagers.customer_groups.actions.attach.label')
                     )->after(
-                        fn () => sync_with_search(
-                            $this->getOwnerRecord()
-                        )
+                        fn () => ProductCustomerGroupsUpdated::dispatch($this->getOwnerRecord())
                     ),
             ])->columns([
                 ...[
@@ -116,7 +115,7 @@ class CustomerGroupRelationManager extends RelationManager
                 ],
             ])->actions([
                 Tables\Actions\EditAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ProductCustomerGroupsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),

--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -94,6 +94,10 @@ class CustomerGroupRelationManager extends RelationManager
                 })->preloadRecordSelect()
                     ->label(
                         __('lunarpanel::relationmanagers.customer_groups.actions.attach.label')
+                    )->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
                     ),
             ])->columns([
                 ...[
@@ -111,7 +115,11 @@ class CustomerGroupRelationManager extends RelationManager
                     )->dateTime(),
                 ],
             ])->actions([
-                Tables\Actions\EditAction::make(),
+                Tables\Actions\EditAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ]);
     }
 }

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -80,7 +80,11 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                         fn ($value) => $this->mapOptionValue($value, true)
                     )->toArray()
                 );
-            });
+            })->after(
+                fn () => sync_with_search(
+                    $this->record
+                )
+            );
     }
 
     public function configureBaseOptions(): void
@@ -432,7 +436,11 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                 Notification::make()->title(
                     __('lunarpanel::productoption.widgets.product-options.notifications.save-variants.success.title')
                 )->success()->send();
-            });
+            })->after(
+                fn () => sync_with_search(
+                    $this->record
+                )
+            );
     }
 
     public function getVariantLink($variantId)

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -14,6 +14,7 @@ use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Lunar\Admin\Actions\Products\MapVariantsToProductOptions;
+use Lunar\Admin\Events\ProductVariantOptionsUpdated;
 use Lunar\Admin\Filament\Resources\ProductVariantResource;
 use Lunar\Facades\DB;
 use Lunar\Models\Language;
@@ -81,9 +82,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                     )->toArray()
                 );
             })->after(
-                fn () => sync_with_search(
-                    $this->record
-                )
+                fn () => ProductVariantOptionsUpdated::dispatch($this->record)
             );
     }
 
@@ -437,9 +436,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                     __('lunarpanel::productoption.widgets.product-options.notifications.save-variants.success.title')
                 )->success()->send();
             })->after(
-                fn () => sync_with_search(
-                    $this->record
-                )
+                fn () => ProductVariantOptionsUpdated::dispatch($this->record)
             );
     }
 

--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -16,6 +16,18 @@ use Livewire\Livewire;
 use Lunar\Admin\Auth\Manifest;
 use Lunar\Admin\Console\Commands\MakeLunarAdminCommand;
 use Lunar\Admin\Database\State\EnsureBaseRolesAndPermissions;
+use Lunar\Admin\Events\ChildCollectionCreated;
+use Lunar\Admin\Events\CollectionProductDetached;
+use Lunar\Admin\Events\CustomerAddressEdited;
+use Lunar\Admin\Events\CustomerUserEdited;
+use Lunar\Admin\Events\ModelChannelsUpdated;
+use Lunar\Admin\Events\ModelPricesUpdated;
+use Lunar\Admin\Events\ModelUrlsUpdated;
+use Lunar\Admin\Events\ProductAssociationsUpdated;
+use Lunar\Admin\Events\ProductCollectionsUpdated;
+use Lunar\Admin\Events\ProductCustomerGroupsUpdated;
+use Lunar\Admin\Events\ProductPricingUpdated;
+use Lunar\Admin\Events\ProductVariantOptionsUpdated;
 use Lunar\Admin\Listeners\FilamentUpgradedListener;
 use Lunar\Admin\Models\Staff;
 use Lunar\Admin\Support\ActivityLog\Manifest as ActivityLogManifest;
@@ -77,6 +89,21 @@ class LunarPanelProvider extends ServiceProvider
                 MakeLunarAdminCommand::class,
             ]);
         }
+
+        Event::listen([
+            ChildCollectionCreated::class,
+            CollectionProductDetached::class,
+            CustomerAddressEdited::class,
+            CustomerUserEdited::class,
+            ProductAssociationsUpdated::class,
+            ProductCollectionsUpdated::class,
+            ProductPricingUpdated::class,
+            ProductCustomerGroupsUpdated::class,
+            ProductVariantOptionsUpdated::class,
+            ModelChannelsUpdated::class,
+            ModelPricesUpdated::class,
+            ModelUrlsUpdated::class,
+        ], fn ($event) => sync_with_search($event->model));
 
         $this->publishes([
             __DIR__.'/../public' => public_path('vendor/lunarpanel'),

--- a/packages/admin/src/Support/Pages/BaseEditRecord.php
+++ b/packages/admin/src/Support/Pages/BaseEditRecord.php
@@ -32,4 +32,11 @@ abstract class BaseEditRecord extends EditRecord
 
         return $this->callLunarHook('afterUpdate', $record, $data);
     }
+
+    public function afterSave()
+    {
+        sync_with_search(
+            $this->getRecord()
+        );
+    }
 }

--- a/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
@@ -62,7 +62,11 @@ class ChannelRelationManager extends RelationManager
                     ...static::getFormInputs(),
                 ])->recordTitle(function ($record) {
                     return $record->name;
-                })->preloadRecordSelect()
+                })->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                )->preloadRecordSelect()
                     ->label(
                         __('lunarpanel::relationmanagers.channels.actions.attach.label')
                     ),
@@ -88,7 +92,11 @@ class ChannelRelationManager extends RelationManager
                     __('lunarpanel::relationmanagers.channels.table.ends_at.label')
                 )->dateTime(),
             ])->actions([
-                Tables\Actions\EditAction::make(),
+                Tables\Actions\EditAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ]);
     }
 }

--- a/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/ChannelRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Lunar\Admin\Events\ModelChannelsUpdated;
 
 class ChannelRelationManager extends RelationManager
 {
@@ -93,7 +94,7 @@ class ChannelRelationManager extends RelationManager
                 )->dateTime(),
             ])->actions([
                 Tables\Actions\EditAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ModelChannelsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),

--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -91,10 +91,18 @@ class MediaRelationManager extends RelationManager
                                 'primary' => $data['custom_properties']['primary'],
                             ])
                             ->toMediaCollection($this->mediaCollection);
-                    }),
+                    })->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    ),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
+                Tables\Actions\EditAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
                 Tables\Actions\DeleteAction::make(),
                 Action::make('view_open')
                     ->label('View')
@@ -104,7 +112,11 @@ class MediaRelationManager extends RelationManager
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    ),
                 ]),
             ])
             ->reorderable('order_column');

--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -11,6 +11,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Lunar\Admin\Events\ModelMediaUpdated;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class MediaRelationManager extends RelationManager
@@ -92,14 +93,14 @@ class MediaRelationManager extends RelationManager
                             ])
                             ->toMediaCollection($this->mediaCollection);
                     })->after(
-                        fn () => sync_with_search(
+                        fn () => ModelMediaUpdated::dispatch(
                             $this->getOwnerRecord()
                         )
                     ),
             ])
             ->actions([
                 Tables\Actions\EditAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ModelMediaUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
@@ -113,7 +114,7 @@ class MediaRelationManager extends RelationManager
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make()->after(
-                        fn () => sync_with_search(
+                        fn () => ModelMediaUpdated::dispatch(
                             $this->getOwnerRecord()
                         )
                     ),

--- a/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
@@ -11,6 +11,7 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rules\Unique;
+use Lunar\Admin\Events\ModelPricesUpdated;
 use Lunar\Facades\DB;
 use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
@@ -180,7 +181,7 @@ class PriceRelationManager extends RelationManager
                 })->label(
                     __('lunarpanel::relationmanagers.pricing.table.actions.create.label')
                 )->after(
-                    fn () => sync_with_search(
+                    fn () => ModelPricesUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
@@ -193,12 +194,12 @@ class PriceRelationManager extends RelationManager
 
                     return $data;
                 })->after(
-                    fn () => sync_with_search(
+                    fn () => ModelPricesUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
                 Tables\Actions\DeleteAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ModelPricesUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),

--- a/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
@@ -179,6 +179,10 @@ class PriceRelationManager extends RelationManager
                     return $data;
                 })->label(
                     __('lunarpanel::relationmanagers.pricing.table.actions.create.label')
+                )->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
                 ),
             ])
             ->actions([
@@ -188,8 +192,16 @@ class PriceRelationManager extends RelationManager
                     $data['price'] = (int) ($data['price'] * $currencyModel->factor);
 
                     return $data;
-                }),
-                Tables\Actions\DeleteAction::make(),
+                })->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
+                Tables\Actions\DeleteAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ]);
     }
 }

--- a/packages/admin/src/Support/Resources/Pages/ManageUrlsRelatedRecords.php
+++ b/packages/admin/src/Support/Resources/Pages/ManageUrlsRelatedRecords.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Unique;
+use Lunar\Admin\Events\ModelUrlsUpdated;
 use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
 
 class ManageUrlsRelatedRecords extends BaseManageRelatedRecords
@@ -96,19 +97,19 @@ class ManageUrlsRelatedRecords extends BaseManageRelatedRecords
                 Tables\Actions\CreateAction::make()->label(
                     __('lunarpanel::relationmanagers.urls.actions.create.label')
                 )->after(
-                    fn () => sync_with_search(
+                    fn () => ModelUrlsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
             ])
             ->actions([
                 Tables\Actions\EditAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ModelUrlsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
                 Tables\Actions\DeleteAction::make()->after(
-                    fn () => sync_with_search(
+                    fn () => ModelUrlsUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
@@ -116,7 +117,7 @@ class ManageUrlsRelatedRecords extends BaseManageRelatedRecords
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make()->after(
-                        fn () => sync_with_search(
+                        fn () => ModelUrlsUpdated::dispatch(
                             $this->getOwnerRecord()
                         )
                     ),

--- a/packages/admin/src/Support/Resources/Pages/ManageUrlsRelatedRecords.php
+++ b/packages/admin/src/Support/Resources/Pages/ManageUrlsRelatedRecords.php
@@ -95,15 +95,31 @@ class ManageUrlsRelatedRecords extends BaseManageRelatedRecords
             ->headerActions([
                 Tables\Actions\CreateAction::make()->label(
                     __('lunarpanel::relationmanagers.urls.actions.create.label')
+                )->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
                 ),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\EditAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
+                Tables\Actions\DeleteAction::make()->after(
+                    fn () => sync_with_search(
+                        $this->getOwnerRecord()
+                    )
+                ),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()->after(
+                        fn () => sync_with_search(
+                            $this->getOwnerRecord()
+                        )
+                    ),
                 ]),
             ]);
     }

--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -28,6 +28,16 @@ if (! function_exists('sync_with_search')) {
         if ($model instanceof \Lunar\Models\ProductVariant) {
             $model->product()->first()->searchable();
         }
+
+        if ($model instanceof \Lunar\Models\Address) {
+            $model->customer()->first()->searchable();
+        }
+
+        if ($model instanceof \Illuminate\Contracts\Auth\Authenticatable) {
+            foreach ($model->customers()->get() as $customer) {
+                $customer->searchable();
+            }
+        }
     }
 }
 

--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -33,7 +33,7 @@ if (! function_exists('sync_with_search')) {
             $model->customer()->first()->searchable();
         }
 
-        if ($model instanceof \Illuminate\Contracts\Auth\Authenticatable) {
+        if (is_lunar_user($model)) {
             foreach ($model->customers()->get() as $customer) {
                 $customer->searchable();
             }

--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -1,11 +1,33 @@
 <?php
 
+use Lunar\Base\Traits\Searchable;
 use Lunar\DataTypes\Price;
 
 if (! function_exists('price')) {
     function price($value, $currency, $unitQty = 1)
     {
         return new Price($value, $currency, $unitQty);
+    }
+}
+
+if (! function_exists('sync_with_search')) {
+    function sync_with_search(Illuminate\Database\Eloquent\Model $model = null): void
+    {
+        if (! $model) {
+            return;
+        }
+
+        $isSearchable = in_array(Searchable::class, class_uses($model));
+
+        if ($isSearchable) {
+            $model->searchable();
+
+            return;
+        }
+
+        if ($model instanceof \Lunar\Models\ProductVariant) {
+            $model->product()->first()->searchable();
+        }
     }
 }
 


### PR DESCRIPTION
There are numerous places in the panel, like relationship managers, which don't trigger it's owner record's Observers and as a consequence  it's not always clear if a searchable record has been updated on the index.

Whilst the use of observers will still work this PR looks to also hook into various `after` triggers in the panel to manually call `searchable` on the affected model.