### PR TITLE
Clear shipping breakdown first if overriding for estimate

### DIFF
--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -24,14 +24,18 @@ final class ApplyShipping
         $shippingOption = $cart->shippingOptionOverride ?: ShippingManifest::getShippingOption($cart);
 
         if ($shippingOption) {
-            $shippingBreakdown->items->put(
-                $shippingOption->getIdentifier(),
-                new ShippingBreakdownItem(
-                    name: $shippingOption->getName(),
-                    identifier: $shippingOption->getIdentifier(),
-                    price: $shippingOption->price,
-                )
-            );
+            if ($cart->shippingOptionOverride) {
+                $shippingBreakdown = new ShippingBreakdown(collect([$shippingOption]));
+            } else {
+                $shippingBreakdown->items->put(
+                    $shippingOption->getIdentifier(),
+                    new ShippingBreakdownItem(
+                        name: $shippingOption->getName(),
+                        identifier: $shippingOption->getIdentifier(),
+                        price: $shippingOption->price,
+                    )
+                );
+            }
 
             $shippingSubTotal = $shippingOption->price->value;
             $shippingTotal = $shippingSubTotal;

--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -25,17 +25,17 @@ final class ApplyShipping
 
         if ($shippingOption) {
             if ($cart->shippingOptionOverride) {
-                $shippingBreakdown = new ShippingBreakdown(collect([$shippingOption]));
-            } else {
-                $shippingBreakdown->items->put(
-                    $shippingOption->getIdentifier(),
-                    new ShippingBreakdownItem(
-                        name: $shippingOption->getName(),
-                        identifier: $shippingOption->getIdentifier(),
-                        price: $shippingOption->price,
-                    )
-                );
+                $shippingBreakdown->items = collect();
             }
+
+            $shippingBreakdown->items->put(
+                $shippingOption->getIdentifier(),
+                new ShippingBreakdownItem(
+                    name: $shippingOption->getName(),
+                    identifier: $shippingOption->getIdentifier(),
+                    price: $shippingOption->price,
+                )
+            );
 
             $shippingSubTotal = $shippingOption->price->value;
             $shippingTotal = $shippingSubTotal;


### PR DESCRIPTION
Currently when passing the shipping override, we're adding it to the shipping breakdown which means it will consider any existing items which I think goes against what the shipping override should do.

This PR will clean the shipping breakdown before if the shipping override is present