### PR TITLE
Update Paypal Production URL

### DIFF
--- a/packages/paypal/src/Paypal.php
+++ b/packages/paypal/src/Paypal.php
@@ -20,7 +20,7 @@ class Paypal implements PaypalInterface
     {
         return config('services.paypal.env', 'sandbox') == 'sandbox' ?
             'https://api-m.sandbox.paypal.com' :
-            'https://api-m.live.paypal.com';
+            'https://api-m.paypal.com';
     }
 
     public function getAccessToken()


### PR DESCRIPTION
The production URL was wrong, this is the correct URL and the DNS will resolve.
