### PR TITLE
Match first character on postcode

### DIFF
--- a/packages/table-rate-shipping/src/Resolvers/PostcodeResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/PostcodeResolver.php
@@ -18,6 +18,7 @@ class PostcodeResolver
             rtrim($postcode, '0..9').'*',
             substr($postcode, 0, 2),
             substr($postcode, 0, 2).'*',
+            substr($postcode, 0, 1),
         ])->filter()->unique()->values();
     }
 }


### PR DESCRIPTION
Some postcodes might need to be able to match on the first character i.e. `L25`  would need a match on `L`. This PR looks to add this to the `getParts` function.