### PR TITLE
Handle cart line update validation

### DIFF
--- a/packages/core/src/Validation/CartLine/CartLineQuantity.php
+++ b/packages/core/src/Validation/CartLine/CartLineQuantity.php
@@ -13,6 +13,14 @@ class CartLineQuantity extends BaseValidator
     {
         $quantity = $this->parameters['quantity'] ?? 0;
         $purchasable = $this->parameters['purchasable'] ?? null;
+        $cartLineId = $this->parameters['cartLineId'] ?? null;
+        $cart = $this->parameters['cart'] ?? null;
+
+        if ($cartLineId && ! $purchasable && $cart) {
+            $purchasable = $cart->lines->first(
+                fn ($cartLine) => $cartLine->id == $cartLineId
+            )?->purchasable;
+        }
 
         if ($quantity < 1) {
             $this->fail(

--- a/tests/core/Unit/Validation/CartLine/CartLineQuantityTest.php
+++ b/tests/core/Unit/Validation/CartLine/CartLineQuantityTest.php
@@ -164,3 +164,32 @@ test('can validate quantity increment quantity', function (array $quantities, in
         'increment' => 14,
     ],
 ]);
+
+test('can validate from cart line id', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = \Lunar\Models\ProductVariant::factory()->create([
+        'quantity_increment' => 25,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => \Lunar\Models\ProductVariant::class,
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 50,
+    ]);
+
+    $validator = (new CartLineQuantity)->using(
+        cart: $cart,
+        purchasable: null,
+        cartLineId: $cart->lines()->first()->id,
+        quantity: 26,
+        meta: []
+    );
+
+    expect(fn () => $validator->validate())
+        ->toThrow(CartException::class);
+});


### PR DESCRIPTION
Currently when validating the quantity when updating cart lines, we don't pass the purchasable so most of the validation actually gets skipped. This PR tries to handle if the purchasable is missing and act accordingly.
