### PR TITLE
Set minimum refund amount based on currency factor

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -743,7 +743,9 @@ class ManageOrder extends BaseViewRecord
                     ->default(fn ($record) => number_format($this->availableToRefund / $record->currency->factor, $record->currency->decimal_places, '.', ''))
                     ->live()
                     ->autocomplete(false)
-                    ->minValue(1)
+                    ->minValue(
+                        1 / $this->getRecord()->currency->factor
+                    )
                     ->numeric(),
 
                 Forms\Components\Textarea::make('notes')


### PR DESCRIPTION
Currently the minimum refund amount is set to `1`. This means we're unable able to refund anything lower than $1 so `0.5` wouldn't work.

This PR takes 1 and divides it by the currency factor to get the minimum denominator the currency accepts and sets that to the minimum.