### PR TITLE
Fix observer namespace for shipping observer

### DIFF
--- a/packages/table-rate-shipping/src/ShippingServiceProvider.php
+++ b/packages/table-rate-shipping/src/ShippingServiceProvider.php
@@ -6,11 +6,11 @@ use Illuminate\Support\ServiceProvider;
 use Lunar\Base\ShippingModifiers;
 use Lunar\Models\Order;
 use Lunar\Models\Product;
-use Lunar\Observers\OrderObserver;
 use Lunar\Shipping\Interfaces\ShippingMethodManagerInterface;
 use Lunar\Shipping\Managers\ShippingManager;
 use Lunar\Shipping\Models\ShippingExclusion;
 use Lunar\Shipping\Models\ShippingZone;
+use Lunar\Shipping\Observers\OrderObserver;
 
 class ShippingServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
Currently the observer registered in the shipping service provider has the wrong namespace.