### PR TITLE
Fix order line observer

### DIFF
--- a/packages/core/src/Observers/OrderLineObserver.php
+++ b/packages/core/src/Observers/OrderLineObserver.php
@@ -15,7 +15,7 @@ class OrderLineObserver
      */
     public function creating(OrderLine $orderLine)
     {
-        if ($orderLine->type != 'shipping' && ! $orderLine->purchasable instanceof Purchasable) {
+        if (! in_array(Purchasable::class, class_implements($orderLine->purchasable_type, true))) {
             throw new NonPurchasableItemException($orderLine->purchasable_type);
         }
     }
@@ -27,7 +27,7 @@ class OrderLineObserver
      */
     public function updating(OrderLine $orderLine)
     {
-        if ($orderLine->type != 'shipping' && ! $orderLine->purchasable instanceof Purchasable) {
+        if (! in_array(Purchasable::class, class_implements($orderLine->purchasable_type, true))) {
             throw new NonPurchasableItemException($orderLine->purchasable_type);
         }
     }

--- a/packages/core/tests/Stubs/DataTypes/TestPurchasable.php
+++ b/packages/core/tests/Stubs/DataTypes/TestPurchasable.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Lunar\Tests\Stubs\DataTypes;
+
+use Illuminate\Support\Collection;
+use Lunar\Base\Purchasable;
+use Lunar\DataTypes\Price;
+use Lunar\Models\TaxClass;
+
+class TestPurchasable implements Purchasable
+{
+    public function __construct(
+        public $name,
+        public $description,
+        public $identifier,
+        public Price $price,
+        public TaxClass $taxClass,
+        public $taxReference = null,
+        public $option = null,
+        public bool $collect = false,
+        public $meta = null
+    ) {
+        //  ..
+    }
+
+    /**
+     * Get the price for the purchasable item.
+     *
+     * @return \Lunar\DataTypes\Price
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * Get prices for the purchasable item.
+     */
+    public function getPrices(): Collection
+    {
+        return collect([
+            $this->price,
+        ]);
+    }
+
+    /**
+     * Return the purchasable unit quantity.
+     */
+    public function getUnitQuantity(): int
+    {
+        return 1;
+    }
+
+    /**
+     * Return the purchasable tax class.
+     */
+    public function getTaxClass(): TaxClass
+    {
+        return $this->taxClass;
+    }
+
+    /**
+     * Return the purchasable tax reference.
+     *
+     * @return string|null
+     */
+    public function getTaxReference()
+    {
+        return $this->taxReference;
+    }
+
+    /**
+     * Return what type of purchasable this is, i.e. physical,digital,shipping.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'test-purchsable';
+    }
+
+    /**
+     * Return the name for the purchasable.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Return the description for the purchasable.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Return the option for this purchasable.
+     *
+     * @return string|null
+     */
+    public function getOption()
+    {
+        return $this->option;
+    }
+
+    /**
+     * Return a unique string which identifies the purchasable item.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Returns whether the purchasable item is shippable.
+     *
+     * @return bool
+     */
+    public function isShippable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getThumbnail()
+    {
+        return null;
+    }
+}

--- a/packages/core/tests/Unit/Models/OrderLineTest.php
+++ b/packages/core/tests/Unit/Models/OrderLineTest.php
@@ -3,6 +3,8 @@
 namespace Lunar\Tests\Unit\Models;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\DataTypes\Price;
+use Lunar\DataTypes\ShippingOption;
 use Lunar\Exceptions\NonPurchasableItemException;
 use Lunar\Models\CartLine;
 use Lunar\Models\Channel;
@@ -10,6 +12,8 @@ use Lunar\Models\Currency;
 use Lunar\Models\Order;
 use Lunar\Models\OrderLine;
 use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
+use Lunar\Tests\Stubs\DataTypes\TestPurchasable;
 use Lunar\Tests\TestCase;
 
 /**
@@ -90,5 +94,73 @@ class OrderLineTest extends TestCase
         OrderLine::factory()->create($data);
 
         $this->assertDatabaseMissing((new CartLine())->getTable(), $data);
+    }
+
+    /** @test */
+    public function purchasable_non_eloquent_models_can_be_added_to_an_order()
+    {
+        $order = Order::factory()->create();
+
+        $currency = Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        $taxClass = TaxClass::factory()->create();
+
+        $shippingOption = new ShippingOption(
+            name: 'Basic Delivery',
+            description: 'Basic Delivery',
+            identifier: 'BASDEL',
+            price: new Price(500, $currency, 1),
+            taxClass: $taxClass
+        );
+
+        $data = [
+            'order_id' => $order->id,
+            'quantity' => 1,
+            'type' => $shippingOption->getType(),
+            'purchasable_type' => ShippingOption::class,
+            'purchasable_id' => $shippingOption->getIdentifier(),
+            'unit_price' => $shippingOption->getPrice()->value,
+            'unit_quantity' => $shippingOption->getUnitQuantity(),
+        ];
+
+        $orderLine = OrderLine::factory()->create($data);
+
+        $this->assertDatabaseHas(
+            (new OrderLine())->getTable(),
+            $data
+        );
+
+        $this->assertEquals(5.0, $orderLine->unit_price->decimal);
+        $this->assertEquals(5.0, $orderLine->unit_price->unitDecimal);
+
+        $testPurchasable = new TestPurchasable(
+            name: 'Test Purchasable',
+            description: 'Test Purchasable',
+            identifier: 'TESTPUR',
+            price: new Price(650, $currency, 1),
+            taxClass: $taxClass
+        );
+
+        $data = [
+            'order_id' => $order->id,
+            'quantity' => 1,
+            'type' => $testPurchasable->getType(),
+            'purchasable_type' => TestPurchasable::class,
+            'purchasable_id' => $testPurchasable->getIdentifier(),
+            'unit_price' => $testPurchasable->getPrice()->value,
+            'unit_quantity' => $testPurchasable->getUnitQuantity(),
+        ];
+
+        $orderLine = OrderLine::factory()->create($data);
+
+        $this->assertDatabaseHas(
+            (new OrderLine())->getTable(),
+            $data
+        );
+
+        $this->assertEquals(6.5, $orderLine->unit_price->decimal);
+        $this->assertEquals(6.5, $orderLine->unit_price->unitDecimal);
     }
 }


### PR DESCRIPTION
## Problem

This PR fixes the issue with adding non-eloquent purchasable data types to orders. It was possible to add only `shipping` type, which was hardcoded.

## Solution

If we check if a class implements `Purchasable` contract instead of checking for type or calling `instanceof` on already resolved class, we have more general checking mechanism which opens the doors for custom non-eloquent purchasables.

## Tests

* Added tests which prove that any non-eloquent purchasables can be added to orders.

