### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/admin_tests.yml
+++ b/.github/workflows/admin_tests.yml
@@ -14,7 +14,7 @@ jobs:
         phpunit-versions: ['latest']
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
         with:
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -14,7 +14,7 @@ jobs:
         phpunit-versions: ['latest']
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
         with:
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/fix-code-style.yml
+++ b/.github/workflows/fix-code-style.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/split_packages.yml
+++ b/.github/workflows/split_packages.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         package: ["admin", "core", "opayo", "paypal", "table-rate-shipping", "stripe", "meilisearch"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
 
       - name: "Setup PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/stripe_tests.yml
+++ b/.github/workflows/stripe_tests.yml
@@ -14,7 +14,7 @@ jobs:
         phpunit-versions: ['latest']
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
         with:
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/table_rate_shipping_tests.yml
+++ b/.github/workflows/table_rate_shipping_tests.yml
@@ -14,7 +14,7 @@ jobs:
         phpunit-versions: ['latest']
     name: PHP:${{ matrix.php }} / Laravel:${{ matrix.laravel }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
         with:
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
Updates `actions/checkout` and `actions/cache` to latest versions.

One more warning that should be addressed. It's used to cache the composer dependencies.

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/