### PR TITLE
Fix typo in email-notification partial component reference

### DIFF
--- a/packages/admin/resources/views/partials/orders/activity/email-notification.blade.php
+++ b/packages/admin/resources/views/partials/orders/activity/email-notification.blade.php
@@ -1,5 +1,5 @@
 <div>
-    @livewire('hub.components.orders.emil-notification', [
+    @livewire('hub.components.orders.email-notification', [
         'log' => $log,
     ])
 </div>


### PR DESCRIPTION
Tris PR fixes a typo in reference to `email-nofification` partial.

Ad defined here: https://github.com/lunarphp/lunar/blob/e0f9fd5f6c5b9a0d6ff8689839b0ec33b31c7366/packages/admin/src/AdminHubServiceProvider.php#L341