### PR TITLE
Consider authenticated user when fetching cart from session

### DIFF
--- a/packages/core/src/Base/Traits/LunarUser.php
+++ b/packages/core/src/Base/Traits/LunarUser.php
@@ -4,6 +4,7 @@ namespace Lunar\Base\Traits;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Lunar\Models\Cart;
 use Lunar\Models\Customer;
 use Lunar\Models\Order;
 
@@ -14,6 +15,11 @@ trait LunarUser
         $prefix = config('lunar.database.table_prefix');
 
         return $this->belongsToMany(Customer::class, "{$prefix}customer_user");
+    }
+
+    public function carts(): HasMany
+    {
+        return $this->hasMany(Cart::class);
     }
 
     public function latestCustomer(): ?Customer

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -145,6 +145,8 @@ class CartSessionManager implements CartSessionInterface
             );
         }
 
+        $this->use($this->cart);
+
         return $this->cart->calculate();
     }
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -114,6 +114,10 @@ class CartSessionManager implements CartSessionInterface
             $this->getSessionKey()
         );
 
+        if (! $cartId && $user = $this->authManager->user()) {
+            $cartId = $user->carts()->active()->first()?->id;
+        }
+
         if (! $cartId) {
             return $create ? $this->cart = $this->createNewCart() : null;
         }


### PR DESCRIPTION
Currently the cart session manager doesn't try to fetch a users most recent and active cart if they don't already have a cart id in the session.

This PR adds a check to fallback on a users active cart before trying to create anything new.