### PR TITLE
Fix shipping rate resolver variable override

### DIFF
--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -138,7 +138,7 @@ class ShippingRateResolver
         $shippingRates = collect();
 
         foreach ($zones as $zone) {
-            $shippingRates = $zone->rates
+            $zoneShippingRates = $zone->rates
                 ->reject(function ($rate) {
                     $method = $rate->shippingMethod;
 
@@ -161,7 +161,7 @@ class ShippingRateResolver
                     return true;
                 });
 
-            foreach ($shippingRates as $shippingRate) {
+            foreach ($zoneShippingRates as $shippingRate) {
                 $shippingRates->push(
                     $shippingRate
                 );


### PR DESCRIPTION
Currently in `ShippingRateResolver` we are resetting the `$shippingRates` collection variable within the loop, which means it'll only ever be equal to the last shipping zone's rates.