### PR TITLE
Fix: Unknown Match in CustomerGroupRelationManager

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -75,9 +75,11 @@ class CustomerGroupRelationManager extends RelationManager
                 ->color(fn (string $state): string => match ($state) {
                     '1' => 'success',
                     '0' => 'warning',
+                    default => 'gray'
                 })->icon(fn (string $state): string => match ($state) {
                     '0' => 'heroicon-o-x-circle',
                     '1' => 'heroicon-o-check-circle',
+                    default => 'heroicon-o-exclamation-circle'
                 });
         })->toArray();
 


### PR DESCRIPTION
Not sure this is a correct way to fix or no. But, happened an exception/issue during installation and testing when attach a customer group to product in availability section:

Here is the exception;

<img width="1394" alt="Screenshot 2024-05-15 at 9 26 02 PM" src="https://github.com/lunarphp/lunar/assets/3388422/55a6a3be-c891-40d5-bd29-dadf9ada2d79">


After this, it will look like this.

<img width="1254" alt="Screenshot 2024-05-15 at 9 42 55 PM" src="https://github.com/lunarphp/lunar/assets/3388422/0e8487a2-8421-4978-8da6-321f44b8d86d">


