### PR TITLE
Allow for Text attribute type

### DIFF
--- a/packages/admin/src/Support/Actions/Collections/CreateChildCollection.php
+++ b/packages/admin/src/Support/Actions/Collections/CreateChildCollection.php
@@ -3,9 +3,11 @@
 namespace Lunar\Admin\Support\Actions\Collections;
 
 use Filament\Actions\CreateAction;
+use Filament\Forms\Components\TextInput;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Support\Actions\Traits\CreatesChildCollections;
 use Lunar\Admin\Support\Forms\Components\TranslatedText;
+use Lunar\Models\Attribute;
 use Lunar\Models\Collection;
 
 class CreateChildCollection extends CreateAction
@@ -24,8 +26,17 @@ class CreateChildCollection extends CreateAction
             $this->success();
         });
 
+        $attribute = Attribute::where('attribute_type', '=', Collection::class)
+            ->where('handle', '=', 'name')->first();
+
+        $formInput = TextInput::class;
+
+        if ($attribute?->type == \Lunar\FieldTypes\TranslatedText::class) {
+            $formInput = TranslatedText::class;
+        }
+
         $this->form([
-            TranslatedText::make('name')->required(),
+            $formInput::make('name')->required(),
         ]);
 
         $this->label(

--- a/packages/admin/src/Support/Actions/Traits/CreatesChildCollections.php
+++ b/packages/admin/src/Support/Actions/Traits/CreatesChildCollections.php
@@ -8,7 +8,7 @@ use Lunar\Models\Collection;
 
 trait CreatesChildCollections
 {
-    public function createChildCollection(Collection $parent, array $name)
+    public function createChildCollection(Collection $parent, array|string $name)
     {
         DB::beginTransaction();
 


### PR DESCRIPTION
Currently, if your collection's `name` attribute is using an attribute field type of Text, rather than TranslatedText, it will error.

This fixes that problem.

Long term, we wish to look at a dedicated database field for `name` which is cast in the models, so we don't have to have all these checks in the code.