### PR TITLE
Update to correct `Builder` class for Url default scope.

### DIFF
--- a/packages/core/src/Models/Url.php
+++ b/packages/core/src/Models/Url.php
@@ -2,10 +2,10 @@
 
 namespace Lunar\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
-use Illuminate\Database\Query\Builder;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\UrlFactory;


### PR DESCRIPTION
Closes #1728 