### PR TITLE
Fix -  Add preservingOriginal to upload media

### DIFF
--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -91,6 +91,7 @@ class MediaRelationManager extends RelationManager
                                 'name' => $data['custom_properties']['name'],
                                 'primary' => $data['custom_properties']['primary'],
                             ])
+                            ->preservingOriginal()
                             ->toMediaCollection($this->mediaCollection);
                     })->after(
                         fn () => ModelMediaUpdated::dispatch(


### PR DESCRIPTION
This PR fix media doesn't preserving original images, it's usefull fo regenerate the derived images of media