### PR TITLE
Fix/empty attributes

### DIFF
--- a/packages/admin/src/Support/FieldTypes/Toggle.php
+++ b/packages/admin/src/Support/FieldTypes/Toggle.php
@@ -18,7 +18,6 @@ class Toggle extends BaseFieldType
                 $attribute->translate('description')
             )
             ->default(false)
-            ->rule('boolean')
-            ->live();
+            ->rule('boolean');
     }
 }

--- a/packages/admin/src/Support/FieldTypes/Toggle.php
+++ b/packages/admin/src/Support/FieldTypes/Toggle.php
@@ -13,10 +13,12 @@ class Toggle extends BaseFieldType
 
     public static function getFilamentComponent(Attribute $attribute): Component
     {
-        return ToggleInput::make($attribute->handle)->default('true')
+        return ToggleInput::make($attribute->handle)
             ->helperText(
                 $attribute->translate('description')
             )
+            ->default(false)
+            ->rule('boolean')
             ->live();
     }
 }

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -44,10 +44,15 @@ class AttributeData
             $attribute->type
         ] ?? TextField::class;
 
-        return $fieldType::getFilamentComponent($attribute)->label(
-            $attribute->translate('name')
-        )
+        /** @var Component $component */
+        $component = $fieldType::getFilamentComponent($attribute);
+
+        return $component
+            ->label(
+                $attribute->translate('name')
+            )
             ->formatStateUsing(fn ($state) => ($state ?: new $attribute->type))
+            ->mutateDehydratedStateUsing(fn ($state) => ($state ?: new $attribute->type))
             ->required($attribute->required)
             ->default($attribute->default_value);
     }

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -2,7 +2,6 @@
 
 namespace Lunar\Admin\Support\Forms\Components;
 
-use Closure;
 use Filament\Forms;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component as Livewire;
@@ -15,85 +14,85 @@ use Lunar\Models\ProductVariant;
 
 class Attributes extends Forms\Components\Group
 {
-    public static function make(Closure|array $schema = []): static
+    protected function setUp(): void
     {
-        return app(
-            static::class,
-            [
-                'schema' => ! blank($schema) ? $schema : function (\Filament\Forms\Get $get, Livewire $livewire, ?Model $record) {
-                    $modelClass = $livewire::getResource()::getModel();
+        parent::setUp();
 
-                    $productTypeId = null;
+        $this->key('attributeData');
 
-                    $attributeQuery = Attribute::where('attribute_type', $modelClass);
+        if (blank($this->childComponents)) {
+            $this->schema(function (\Filament\Forms\Get $get, Livewire $livewire, ?Model $record) {
+                $modelClass = $livewire::getResource()::getModel();
 
-                    // Products are unique in that they use product types to map attributes, so we need
-                    // to try and find the product type ID
-                    if ($modelClass == Product::class) {
-                        $productTypeId = $record?->product_type_id ?: ProductType::first()->id;
+                $productTypeId = null;
 
-                        // If we have a product type, the attributes should be based off that.
-                        if ($productTypeId) {
-                            $attributeQuery = ProductType::find($productTypeId)->productAttributes();
-                        }
+                $attributeQuery = Attribute::where('attribute_type', $modelClass);
+
+                // Products are unique in that they use product types to map attributes, so we need
+                // to try and find the product type ID
+                if ($modelClass == Product::class) {
+                    $productTypeId = $record?->product_type_id ?: ProductType::first()->id;
+
+                    // If we have a product type, the attributes should be based off that.
+                    if ($productTypeId) {
+                        $attributeQuery = ProductType::find($productTypeId)->productAttributes();
                     }
-
-                    if ($modelClass == ProductVariant::class) {
-                        $productTypeId = $record->product?->product_type_id ?: ProductType::first()->id;
-
-                        // If we have a product type, the attributes should be based off that.
-                        if ($productTypeId) {
-                            $attributeQuery = ProductType::find($productTypeId)->variantAttributes();
-                        }
-                    }
-
-                    $attributes = $attributeQuery->orderBy('position')->get();
-
-                    $groups = AttributeGroup::where(
-                        'attributable_type',
-                        $modelClass
-                    )->orderBy('position', 'asc')
-                        ->get()
-                        ->map(function ($group) use ($attributes) {
-                            return [
-                                'model' => $group,
-                                'fields' => $attributes->groupBy('attribute_group_id')->get($group->id, []),
-                            ];
-                        });
-
-                    $groupComponents = [];
-
-                    foreach ($groups as $group) {
-                        $sectionFields = [];
-
-                        foreach ($group['fields'] as $field) {
-                            $sectionFields[] = AttributeData::getFilamentComponent($field);
-                        }
-
-                        $groupComponents[] = Forms\Components\Section::make($group['model']->translate('name'))
-                            ->schema($sectionFields);
-                    }
-
-                    return $groupComponents;
-                },
-            ]
-        )
-            ->configure()
-            ->key('attributeData')
-            ->mutateStateForValidationUsing(function ($state) {
-                if (! is_array($state)) {
-                    return $state;
                 }
 
-                foreach ($state as $key => $value) {
-                    if (! $value instanceof \Lunar\Base\Fieldtype) {
-                        continue;
-                    }
+                if ($modelClass == ProductVariant::class) {
+                    $productTypeId = $record->product?->product_type_id ?: ProductType::first()->id;
 
-                    $state[$key] = $value->getValue();
+                    // If we have a product type, the attributes should be based off that.
+                    if ($productTypeId) {
+                        $attributeQuery = ProductType::find($productTypeId)->variantAttributes();
+                    }
                 }
 
-                return $state;
+                $attributes = $attributeQuery->orderBy('position')->get();
+
+                $groups = AttributeGroup::where(
+                    'attributable_type',
+                    $modelClass
+                )->orderBy('position', 'asc')
+                    ->get()
+                    ->map(function ($group) use ($attributes) {
+                        return [
+                            'model' => $group,
+                            'fields' => $attributes->groupBy('attribute_group_id')->get($group->id, []),
+                        ];
+                    });
+
+                $groupComponents = [];
+
+                foreach ($groups as $group) {
+                    $sectionFields = [];
+
+                    foreach ($group['fields'] as $field) {
+                        $sectionFields[] = AttributeData::getFilamentComponent($field);
+                    }
+
+                    $groupComponents[] = Forms\Components\Section::make($group['model']->translate('name'))
+                        ->schema($sectionFields);
+                }
+
+                return $groupComponents;
             });
+        }
+
+        $this->mutateStateForValidationUsing(function ($state) {
+            if (! is_array($state)) {
+                return $state;
+            }
+
+            foreach ($state as $key => $value) {
+                if (! $value instanceof \Lunar\Base\Fieldtype) {
+                    continue;
+                }
+
+                $state[$key] = $value->getValue();
+            }
+
+            return $state;
+        });
     }
 }

--- a/packages/core/src/FieldTypes/Toggle.php
+++ b/packages/core/src/FieldTypes/Toggle.php
@@ -9,7 +9,7 @@ use Lunar\Exceptions\FieldTypeException;
 class Toggle implements FieldType, JsonSerializable
 {
     /**
-     * @var string
+     * @var bool
      */
     protected $value;
 
@@ -24,11 +24,11 @@ class Toggle implements FieldType, JsonSerializable
     }
 
     /**
-     * Create a new instance of Text field type.
+     * Create a new instance of Toggle field type.
      *
      * @param  string  $value
      */
-    public function __construct($value = '')
+    public function __construct($value = false)
     {
         $this->setValue($value);
     }
@@ -40,7 +40,7 @@ class Toggle implements FieldType, JsonSerializable
      */
     public function __toString()
     {
-        return $this->getValue() ?? '';
+        return (int) ($this->getValue() ?? false);
     }
 
     /**
@@ -72,11 +72,6 @@ class Toggle implements FieldType, JsonSerializable
      */
     public function getConfig(): array
     {
-        return [
-            'options' => [
-                'on_value' => 'nullable|string',
-                'off_value' => 'nullable|string',
-            ],
-        ];
+        return [];
     }
 }


### PR DESCRIPTION
Fix error `get_class(): Argument #1 ($object) must be of type object, null given`

this happens when added a new attribute to a resource.
the fix https://github.com/lunarphp/lunar/pull/1776/commits/7b19a0e4c213c065f6520209074c4375d06bcfc0 is to mutate the state during field dehydration to return new field type instance when state is null
`formatStateUsing` doesnt set the instance during field hydration as it only apply when the state is not null

other commits are some inconsistency that I found while troubleshooting, it should still works without those commits