### PR TITLE
Add unique index to collectionGroup handle

### DIFF
--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,6 +18,15 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.7`.
 
+## 1.0.0-alpha.x
+
+### High Impact
+
+#### Unique index for Collection Group handle
+
+Collection Group now have unique index on the column `handle`.
+If you are creating Collection Group from the admin panel, there is no changes required.
+
 ## 1.0.0-alpha.20
 
 ### High Impact

--- a/packages/core/database/migrations/2024_05_25_100000_update_collection_group_handle_unique.php
+++ b/packages/core/database/migrations/2024_05_25_100000_update_collection_group_handle_unique.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table($this->prefix . 'collection_groups', function (Blueprint $table) {
+            $table->dropIndex(['handle']);
+        });
+
+        Schema::table($this->prefix . 'collection_groups', function (Blueprint $table) {
+            $table->unique(['handle']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table($this->prefix . 'collection_groups', function (Blueprint $table) {
+            $table->dropUnique(['handle']);
+        });
+
+        Schema::table($this->prefix . 'collection_groups', function (Blueprint $table) {
+            $table->index(['handle']);
+        });
+    }
+};


### PR DESCRIPTION
currently it does not have unique check on db level and only the admin form have unique validation.

was writing test suite and not aware of created duplicate group handles and page unable to fetch the correct group attached to products...

