### PR TITLE
Remove obsolete gravatar url in staff model

### DIFF
--- a/packages/admin/src/Models/Staff.php
+++ b/packages/admin/src/Models/Staff.php
@@ -67,7 +67,7 @@ class Staff extends Authenticatable implements FilamentUser, HasName
      *
      * @var array
      */
-    protected $appends = ['fullName', 'gravatar'];
+    protected $appends = ['fullName'];
 
     /**
      * Create a new instance of the Model.
@@ -122,16 +122,6 @@ class Staff extends Authenticatable implements FilamentUser, HasName
     public function getFullNameAttribute(): string
     {
         return $this->firstname.' '.$this->lastname;
-    }
-
-    /**
-     * Get staff member's Gravatar URLs.
-     */
-    public function getGravatarAttribute(): string
-    {
-        $hash = md5(strtolower(trim($this->attributes['email'])));
-
-        return "https://www.gravatar.com/avatar/{$hash}?d=mp";
     }
 
     public function canAccessPanel(Panel $panel): bool


### PR DESCRIPTION
filament panel support configurable avatar provider, so it is no longer make sense to append gravatar

and filament has helper function to retrieve the avatar url: filament()->getUserAvatarUrl($user)
