### PR TITLE
fix ListField editing ordering and enable list field reorderable

### DIFF
--- a/packages/admin/src/Support/FieldTypes/ListField.php
+++ b/packages/admin/src/Support/FieldTypes/ListField.php
@@ -13,8 +13,11 @@ class ListField extends BaseFieldType
 
     public static function getFilamentComponent(Attribute $attribute): Component
     {
-        return KeyValue::make($attribute->handle)->dehydrateStateUsing(function ($state) {
-            return $state;
-        })->helperText($attribute->translate('description'));
+        return KeyValue::make($attribute->handle)
+            ->live()
+            ->reorderable()
+            ->dehydrateStateUsing(function ($state) {
+                return $state;
+            })->helperText($attribute->translate('description'));
     }
 }


### PR DESCRIPTION
using `->live()` as a workaround for livewire/alpinejs bug until filament can fix it https://github.com/filamentphp/filament/pull/12943#issuecomment-2132863412

Before

https://github.com/lunarphp/lunar/assets/67364036/79f6c218-14ed-457a-b162-da8e1df09c64

After

https://github.com/lunarphp/lunar/assets/67364036/26a052c1-5096-4f58-a270-eb539575ffea
