### PR TITLE
Fix - Add support key/value in order additional information 

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -354,8 +354,12 @@ class ManageOrder extends BaseViewRecord
                                     ->hiddenLabel()
                                     ->getStateUsing(fn () => __('lunarpanel::order.infolist.no_additional_info.label')),
                             ] : collect($state)
-                                ->map(fn ($value, $key) => is_array($value) ? Infolists\Components\KeyValueEntry::make('meta_'.$key)->state($value) :
-                                    Infolists\Components\TextEntry::make('meta_'.$key)
+                                ->map(function ($value, $key) {
+                                    if (is_array($value)) {
+                                        return Infolists\Components\KeyValueEntry::make('meta_'.$key)->state($value);
+                                    }
+
+                                    return Infolists\Components\TextEntry::make('meta_'.$key)
                                         ->state($value)
                                         ->label($key)
                                         ->copyable()
@@ -366,9 +370,8 @@ class ManageOrder extends BaseViewRecord
                                             }
 
                                             return $state;
-                                        })
-
-                                )
+                                        });
+                                })
                                 ->toArray()),
 
                     ])

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -354,18 +354,25 @@ class ManageOrder extends BaseViewRecord
                                     ->hiddenLabel()
                                     ->getStateUsing(fn () => __('lunarpanel::order.infolist.no_additional_info.label')),
                             ] : collect($state)
-                                ->map(fn ($value, $key) => Infolists\Components\TextEntry::make('meta_'.$key)
-                                    ->state($value)
-                                    ->label($key)
-                                    ->copyable()
-                                    ->limit(50)->tooltip(function (Infolists\Components\TextEntry $component): ?string {
-                                        $state = $component->getState();
-                                        if (strlen($state) <= $component->getCharacterLimit()) {
-                                            return null;
-                                        }
+                                ->map(function ($value, $key) {
+                                    if (! is_array($value)) {
+                                        return Infolists\Components\TextEntry::make('meta_'.$key)
+                                            ->state($value)
+                                            ->label($key)
+                                            ->copyable()
+                                            ->limit(50)->tooltip(function (Infolists\Components\TextEntry $component): ?string {
+                                                $state = $component->getState();
+                                                if (strlen($state) <= $component->getCharacterLimit()) {
+                                                    return null;
+                                                }
 
-                                        return $state;
-                                    }))
+                                                return $state;
+                                            });
+                                    } else {
+                                        return Infolists\Components\KeyValueEntry::make('meta_'.$key)
+                                            ->state($value);
+                                    }
+                                })
                                 ->toArray()),
 
                     ])

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -354,25 +354,21 @@ class ManageOrder extends BaseViewRecord
                                     ->hiddenLabel()
                                     ->getStateUsing(fn () => __('lunarpanel::order.infolist.no_additional_info.label')),
                             ] : collect($state)
-                                ->map(function ($value, $key) {
-                                    if (! is_array($value)) {
-                                        return Infolists\Components\TextEntry::make('meta_'.$key)
-                                            ->state($value)
-                                            ->label($key)
-                                            ->copyable()
-                                            ->limit(50)->tooltip(function (Infolists\Components\TextEntry $component): ?string {
-                                                $state = $component->getState();
-                                                if (strlen($state) <= $component->getCharacterLimit()) {
-                                                    return null;
-                                                }
+                                ->map(fn ($value, $key) => is_array($value) ? Infolists\Components\KeyValueEntry::make('meta_'.$key)->state($value) :
+                                    Infolists\Components\TextEntry::make('meta_'.$key)
+                                        ->state($value)
+                                        ->label($key)
+                                        ->copyable()
+                                        ->limit(50)->tooltip(function (Infolists\Components\TextEntry $component): ?string {
+                                            $state = $component->getState();
+                                            if (strlen($state) <= $component->getCharacterLimit()) {
+                                                return null;
+                                            }
 
-                                                return $state;
-                                            });
-                                    } else {
-                                        return Infolists\Components\KeyValueEntry::make('meta_'.$key)
-                                            ->state($value);
-                                    }
-                                })
+                                            return $state;
+                                        })
+
+                                )
                                 ->toArray()),
 
                     ])


### PR DESCRIPTION
This PR fix error if meta data of order contain an array.

<img width="380" alt="Capture d’écran 2024-05-31 à 22 37 31" src="https://github.com/lunarphp/lunar/assets/6489718/21d0f6a8-95fc-4d87-a8bd-0a791dfacefb">
