### PR TITLE
Fix - Upload media to external disk

### DIFF
--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -40,6 +40,7 @@ class MediaRelationManager extends BaseRelationManager
                     ->hiddenOn('edit')
                     ->storeFiles(false)
                     ->imageEditor()
+                    ->required()
                     ->imageEditorAspectRatios([
                         null,
                         '16:9',
@@ -79,7 +80,11 @@ class MediaRelationManager extends BaseRelationManager
             ->headerActions([
                 Tables\Actions\CreateAction::make()
                     ->using(function (array $data, string $model): Model {
+
                         return $this->getOwnerRecord()->addMediaFromString($data['media']->get())
+                            ->usingFileName(
+                                $data['media']->getClientOriginalName()
+                            )
                             ->withCustomProperties([
                                 'name' => $data['custom_properties']['name'],
                                 'primary' => $data['custom_properties']['primary'],

--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -86,7 +86,7 @@ class MediaRelationManager extends RelationManager
                     ->using(function (array $data, string $model): Model {
                         $product = $this->getOwnerRecord();
 
-                        return $product->addMedia($data['media'])
+                        return $product->addMediaFromString($data['media']->get())
                             ->withCustomProperties([
                                 'name' => $data['custom_properties']['name'],
                                 'primary' => $data['custom_properties']['primary'],


### PR DESCRIPTION
This PR fix error Livewire temporaly file doesn't exist. 

If the dev uses several front instances, we need to use S3 or another temporary directory to upload temporary files on the external disk.

Currently, Livewire generate an exception with temporary file in S3.

Filament SpatieMediaLibraryFileUpload uses the same method :  
https://github.com/filamentphp/filament/blob/85594f3a37b37219d7b7f76a3f7a1a85fdb9cfad/packages/spatie-laravel-media-library-plugin/src/Forms/Components/SpatieMediaLibraryFileUpload.php#L143