### PR TITLE
Cart performance improvements

### DIFF
--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -16,11 +16,17 @@ php artisan migrate
 
 ## Support Policy
 
-Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.7`.
+Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
 ## 1.0.0-alpha.x
 
 ### High Impact
+
+#### Cart calculate function will no longer recalculate
+
+If you have been using the `$cart->calculate()` function it has previously always run the calculations regardless of 
+whether the cart has already been calculated. Now the calculate function will only run if we don't have cart totals. 
+To allow for recalculation we have now introduced `$cart->recalculate()` to force the cart to recalculate.
 
 #### Unique index for Collection Group handle
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -18,9 +18,9 @@ class CartSessionManager implements CartSessionInterface
     public function __construct(
         protected SessionManager $sessionManager,
         protected AuthManager $authManager,
-        protected $channel = null,
-        protected $currency = null,
-        public $cart = null
+        protected ?Channel $channel = null,
+        protected ?Currency $currency = null,
+        public ?Cart $cart = null
     ) {
         //
     }
@@ -72,7 +72,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function manager(): ?Cart
     {
-        if (! $this->cart) {
+        if (! $this->cart?->exists) {
             $this->fetchOrCreate(create: true);
         }
 
@@ -119,11 +119,11 @@ class CartSessionManager implements CartSessionInterface
             return $create ? $this->cart = $this->createNewCart() : null;
         }
 
-        $this->cart = $this->cart ?: Cart::with(
+        $this->cart = $this->cart?->exists ? $this->cart : Cart::with(
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
-        if (! $this->cart) {
+        if (! $this->cart?->exists) {
             if (! $create) {
                 return null;
             }
@@ -188,7 +188,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function getCurrency(): Currency
     {
-        return $this->currency ?: Currency::getDefault();
+        return $this->currency?->exists ? $this->currency :  Currency::getDefault();
     }
 
     /**
@@ -196,7 +196,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function getChannel(): Channel
     {
-        return $this->channel ?: Channel::getDefault();
+        return $this->channel?->exists ? $this->channel : Channel::getDefault();
     }
 
     /**

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -18,9 +18,9 @@ class CartSessionManager implements CartSessionInterface
     public function __construct(
         protected SessionManager $sessionManager,
         protected AuthManager $authManager,
-        protected ?Channel $channel = null,
-        protected ?Currency $currency = null,
-        public ?Cart $cart = null
+        protected Channel $channel,
+        protected Currency $currency,
+        public Cart $cart,
     ) {
         //
     }

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -18,9 +18,9 @@ class CartSessionManager implements CartSessionInterface
     public function __construct(
         protected SessionManager $sessionManager,
         protected AuthManager $authManager,
-        protected ?Channel $channel = null,
-        protected ?Currency $currency = null,
-        public ?Cart $cart = null
+        protected $channel = null,
+        protected $currency = null,
+        public $cart = null
     ) {
         //
     }

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -188,7 +188,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function getCurrency(): Currency
     {
-        return $this->currency?->exists ? $this->currency :  Currency::getDefault();
+        return $this->currency?->exists ? $this->currency : Currency::getDefault();
     }
 
     /**

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -124,11 +124,7 @@ class CartSessionManager implements CartSessionInterface
         )->find($cartId);
 
         if (! $this->cart?->exists) {
-            if (! $create) {
-                return null;
-            }
-
-            return $this->createNewCart();
+            return $create ? $this->createNewCart() : null;
         }
 
         if ($calculate) {

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -123,7 +123,7 @@ class CartSessionManager implements CartSessionInterface
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
-        if (! $this->cart?->exists) {
+        if (! $this->cart) {
             return $create ? $this->createNewCart() : null;
         }
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -244,7 +244,7 @@ class CartSessionManager implements CartSessionInterface
 
     public function __call($method, $args)
     {
-        if (! $this->cart) {
+        if (! $this->cart?->exists) {
             $this->cart = $this->fetchOrCreate(true);
         }
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -28,7 +28,7 @@ class CartSessionManager implements CartSessionInterface
     /**
      * {@inheritDoc}
      */
-    public function current($estimateShipping = false): Cart|null
+    public function current($estimateShipping = false): ?Cart
     {
         return $this->fetchOrCreate(
             config('lunar.cart.auto_create', false),
@@ -70,7 +70,7 @@ class CartSessionManager implements CartSessionInterface
     /**
      * {@inheritDoc}
      */
-    public function manager(): Cart|null
+    public function manager(): ?Cart
     {
         if (! $this->cart) {
             $this->fetchOrCreate(create: true);
@@ -105,7 +105,7 @@ class CartSessionManager implements CartSessionInterface
     /**
      * Fetches a cart and optionally creates one if it doesn't exist.
      */
-    private function fetchOrCreate(bool $create = false, bool $estimateShipping = false): Cart|null
+    private function fetchOrCreate(bool $create = false, bool $estimateShipping = false): ?Cart
     {
         $cartId = $this->sessionManager->get(
             $this->getSessionKey()
@@ -213,7 +213,6 @@ class CartSessionManager implements CartSessionInterface
      * Create an order from a cart instance.
      *
      * @param  bool  $forget
-     * @return \Lunar\Models\Order
      */
     public function createOrder($forget = true): Order
     {

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -135,9 +135,7 @@ class CartSessionManager implements CartSessionInterface
             $this->estimateShipping();
         }
 
-        $this->use($this->cart);
-
-        return $this->cart;
+        return $this->use($this->cart);
     }
 
     public function estimateShipping(): void

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -346,7 +346,7 @@ class Cart extends BaseModel
 
     public function isCalculated(): bool
     {
-        if (!$this->total) {
+        if (! $this->total) {
             return false;
         }
 
@@ -354,7 +354,7 @@ class Cart extends BaseModel
             return $line->total;
         });
 
-        if (!$linesCalculated) {
+        if (! $linesCalculated) {
             return false;
         }
 

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -320,7 +320,7 @@ class Cart extends BaseModel
      */
     public function calculate(bool $force = false): Cart
     {
-        if (! $force && $this->total) {
+        if (! $force && $this->isCalculated()) {
             // Don't recalculate
             return $this;
         }
@@ -342,6 +342,23 @@ class Cart extends BaseModel
     public function recalculate(): Cart
     {
         return $this->calculate(force: true);
+    }
+
+    public function isCalculated(): bool
+    {
+        if (!$this->total) {
+            return false;
+        }
+
+        $linesCalculated = $this->lines->every(function (CartLine $line) {
+            return $line->total;
+        });
+
+        if (!$linesCalculated) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -320,7 +320,7 @@ class Cart extends BaseModel
      */
     public function calculate(bool $force = false): Cart
     {
-        if (!$force && $this->total) {
+        if (! $force && $this->total) {
             // Don't recalculate
             return $this;
         }

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -346,19 +346,9 @@ class Cart extends BaseModel
 
     public function isCalculated(): bool
     {
-        if ($this->total === null) {
-            return false;
-        }
-
-        $linesCalculated = $this->lines->every(function (CartLine $line) {
-            return $line->total !== null;
-        });
-
-        if (! $linesCalculated) {
-            return false;
-        }
-
-        return true;
+        return !blank($this->total) && $this->lines->every(
+            fn (CartLine $line) => !blank($line->total)
+        );
     }
 
     /**

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -346,8 +346,8 @@ class Cart extends BaseModel
 
     public function isCalculated(): bool
     {
-        return !blank($this->total) && $this->lines->every(
-            fn (CartLine $line) => !blank($line->total)
+        return ! blank($this->total) && $this->lines->every(
+            fn (CartLine $line) => ! blank($line->total)
         );
     }
 

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -346,12 +346,12 @@ class Cart extends BaseModel
 
     public function isCalculated(): bool
     {
-        if (! $this->total) {
+        if ($this->total === null) {
             return false;
         }
 
         $linesCalculated = $this->lines->every(function (CartLine $line) {
-            return $line->total;
+            return $line->total !== null;
         });
 
         if (! $linesCalculated) {

--- a/packages/core/src/Pipelines/Order/Creation/CreateOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateOrderLines.php
@@ -19,7 +19,7 @@ class CreateOrderLines
 
         $cart = $order->cart;
 
-        $cart->calculate();
+        $cart->recalculate();
 
         foreach ($cart->lines as $cartLine) {
             $orderLine = $order->lines->first(function ($line) use ($cartLine) {

--- a/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
@@ -14,7 +14,7 @@ class CreateShippingLine
      */
     public function handle(Order $order, Closure $next)
     {
-        $cart = $order->cart->calculate();
+        $cart = $order->cart->recalculate();
 
         // If we have a shipping address with a shipping option.
         if (($shippingAddress = $cart->shippingAddress) &&

--- a/tests/core/Unit/DiscountTypes/AmountOffTest.php
+++ b/tests/core/Unit/DiscountTypes/AmountOffTest.php
@@ -1752,7 +1752,7 @@ test('can apply discount dynamically', function () {
     $cart = CartSession::current();
 
     // Calculate method called for the third time
-    $cart = $cart->calculate();
+    $cart = $cart->recalculate();
 
     expect($cart->discountTotal->value)->toEqual(1050);
     expect($cart->total->value)->toEqual(1140);

--- a/tests/core/Unit/Models/CartTest.php
+++ b/tests/core/Unit/Models/CartTest.php
@@ -724,7 +724,7 @@ test('can calculate shipping', function () {
 
     Config::set('lunar.pricing.stored_inclusive_of_tax', true);
 
-    $cart->calculate();
+    $cart->recalculate();
 
     expect($cart->shippingTotal->value)->toEqual(500);
     expect($cart->total->value)->toEqual(600);
@@ -893,7 +893,7 @@ test('can override shipping calculation', function () {
 
     $cart->shippingOptionOverride = $shippingOption;
 
-    $cart->calculate();
+    $cart->recalculate();
 
     expect($cart->shippingSubTotal->value)->toEqual(500);
 });

--- a/tests/core/Unit/Models/CartTest.php
+++ b/tests/core/Unit/Models/CartTest.php
@@ -436,8 +436,11 @@ test('can calculate the cart', function () {
         StubUser::factory()->create()
     );
 
+    expect($cart->isCalculated())->toEqual(false);
+
     $cart->calculate();
 
+    expect($cart->isCalculated())->toEqual(true);
     expect($cart->lines[0]->unitPrice->value)->toEqual(100);
     expect($cart->lines[0]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6))->toEqual('$1.00');
     expect($cart->lines[0]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6, false))->toEqual('$1.000000');

--- a/tests/core/Unit/Pipelines/Order/Creation/CreateOrderLinesTest.php
+++ b/tests/core/Unit/Pipelines/Order/Creation/CreateOrderLinesTest.php
@@ -38,7 +38,7 @@ test('can run pipeline', function () {
         'cart_id' => $cart->id,
     ]);
 
-    $cart->calculate();
+    $cart->recalculate();
 
     app(CreateOrderLines::class)->handle($order, function ($order) {
         return $order;


### PR DESCRIPTION
Previously calling `->calculate()` would force the cart pipelines to always run. This update will only re-run the cart pipelines if the cart hasn't been calculated previously, or we're forcing it to.