### PR TITLE
Fix StaffFactory default password

### DIFF
--- a/packages/admin/database/factories/StaffFactory.php
+++ b/packages/admin/database/factories/StaffFactory.php
@@ -3,6 +3,7 @@
 namespace Lunar\Admin\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Lunar\Admin\Models\Staff;
 
@@ -24,7 +25,7 @@ class StaffFactory extends Factory
             'admin' => $this->faker->boolean(5),
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'password' => Hash::make('password'),
             'remember_token' => Str::random(10),
         ];
     }


### PR DESCRIPTION
for some reason when using the factory to create staff and actingAs in test, I'm getting `Could not verify the hashed value's configuration` error. For context I'm using Laravel 11 with default bcrypt rounds 12.

Changing it to use `Hash::make('password')` solved this issue, and it also align with Laravel's default UserFactory class's password
