### PR TITLE
Additional fixes and improvements to Stripe

### DIFF
--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -102,10 +102,35 @@ Below is a list of the available configuration options this package uses in `con
 ```php
 use \Lunar\Stripe\Facades\Stripe;
 
-Stripe::createIntent(\Lunar\Models\Cart $cart);
+Stripe::createIntent(\Lunar\Models\Cart $cart, $options = []);
 ```
 
 This method will create a Stripe PaymentIntent from a Cart and add the resulting ID to the meta for retrieval later. If a PaymentIntent already exists for a cart this will fetch it from Stripe and return that instead to avoid duplicate PaymentIntents being created.
+
+You can pass any additional parameters you need, by default the following are sent:
+
+```php
+[
+    'amount' => 1099,
+    'currency' => 'GBP',
+    'automatic_payment_methods' => ['enabled' => true],
+    'capture_method' => config('lunar.stripe.policy', 'automatic'),
+    // If a shipping address exists on a cart
+    // $shipping = $cart->shippingAddress
+    'shipping' => [
+        'name' => "{$shipping->first_name} {$shipping->last_name}",
+        'phone' => $shipping->contact_phone,
+        'address' => [
+            'city' => $shipping->city,
+            'country' => $shipping->country->iso2,
+            'line1' => $shipping->line_one,
+            'line2' => $shipping->line_two,
+            'postal_code' => $shipping->postcode,
+            'state' => $shipping->state,
+        ],
+    ]
+]
+```
 
 ```php
 $paymentIntentId = $cart->meta['payment_intent']; // The resulting ID from the method above.
@@ -130,6 +155,49 @@ If a payment intent has been created and there are changes to the cart, you will
 use \Lunar\Stripe\Facades\Stripe;
 
 Stripe::syncIntent(\Lunar\Models\Cart $cart);
+```
+
+
+### Update an existing intent
+
+For when you want to update certain properties on the PaymentIntent, without needing to recalculate the cart.
+
+See https://docs.stripe.com/api/payment_intents/update
+
+```php
+use \Lunar\Stripe\Facades\Stripe;
+
+Stripe::updateIntent(\Lunar\Models\Cart $cart, [
+    'shipping' => [/*..*/]
+]);
+```
+
+### Update the address on Stripe
+
+So you don't have to manually specify all the shipping address fields you can use the helper function to do it for you.
+
+```php
+use \Lunar\Stripe\Facades\Stripe;
+
+Stripe::updateShippingAddress(\Lunar\Models\Cart $cart);
+```
+
+## Charges
+
+### Retrieve a specific charge
+
+```php
+use \Lunar\Stripe\Facades\Stripe;
+
+Stripe::getCharge(string $chargeId);
+```
+
+### Get all charges for a payment intent
+
+```php
+use \Lunar\Stripe\Facades\Stripe;
+
+Stripe::getCharges(string $paymentIntentId);
 ```
 
 ## Webhooks

--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -8,8 +8,11 @@ use Stripe\ApiRequestor;
 
 /**
  * @method static getClient(): \Stripe\StripeClient
- * @method static createIntent(\Lunar\Models\Cart $cart): \Stripe\PaymentIntent
+ * @method static createIntent(\Lunar\Models\Cart $cart, array $opts): \Stripe\PaymentIntent
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
+ * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void
+ * @method static updateShippingAddress(\Lunar\Models\Cart $cart): void
+ * @method static fetchIntent(string $intentId, $options = null): ?PaymentIntent
  * @method static getCharges(string $paymentIntentId): \Illuminate\Support\Collection
  * @method static getCharge(string $chargeId): \Stripe\Charge
  * @method static buildIntent(int $value, string $currencyCode, \Lunar\Models\CartAddress $shipping): \Stripe\PaymentIntent

--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -12,7 +12,6 @@ use Stripe\ApiRequestor;
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
  * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void
  * @method static updateShippingAddress(\Lunar\Models\Cart $cart): void
- * @method static fetchIntent(string $intentId, $options = null): ?PaymentIntent
  * @method static getCharges(string $paymentIntentId): \Illuminate\Support\Collection
  * @method static getCharge(string $chargeId): \Stripe\Charge
  * @method static buildIntent(int $value, string $currencyCode, \Lunar\Models\CartAddress $shipping): \Stripe\PaymentIntent

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -33,8 +33,6 @@ class StripeManager
      */
     public function createIntent(Cart $cart, array $opts = []): PaymentIntent
     {
-        $shipping = $cart->shippingAddress;
-
         $meta = (array) $cart->meta;
 
         if ($meta && ! empty($meta['payment_intent'])) {
@@ -50,7 +48,7 @@ class StripeManager
         $paymentIntent = $this->buildIntent(
             $cart->total->value,
             $cart->currency->code,
-            $shipping,
+            $cart->shippingAddress,
             $opts
         );
 
@@ -67,6 +65,42 @@ class StripeManager
         }
 
         return $paymentIntent;
+    }
+
+    public function updateShippingAddress(Cart $cart): void
+    {
+        $address = $cart->shippingAddress;
+
+        if (! $address) {
+            $this->updateIntent($cart, [
+                'shipping' => [
+                    'name' => "{$address->first_name} {$address->last_name}",
+                    'phone' => $address->contact_phone,
+                    'address' => [
+                        'city' => $address->city,
+                        'country' => $address->country->iso2,
+                        'line1' => $address->line_one,
+                        'line2' => $address->line_two,
+                        'postal_code' => $address->postcode,
+                        'state' => $address->state,
+                    ],
+                ],
+            ]);
+        }
+    }
+
+    public function updateIntent(Cart $cart, array $values): void
+    {
+        $meta = (array) $cart->meta;
+
+        if (empty($meta['payment_intent'])) {
+            return;
+        }
+
+        $this->getClient()->paymentIntents->update(
+            $meta['payment_intent'],
+            $values
+        );
     }
 
     public function syncIntent(Cart $cart): void
@@ -122,26 +156,33 @@ class StripeManager
     /**
      * Build the intent
      */
-    protected function buildIntent(int $value, string $currencyCode, CartAddress $shipping, array $opts = []): PaymentIntent
+    protected function buildIntent(int $value, string $currencyCode, ?CartAddress $shipping, array $opts = []): PaymentIntent
     {
-        return PaymentIntent::create(
-            [
-                'amount' => $value,
-                'currency' => $currencyCode,
-                'automatic_payment_methods' => ['enabled' => true],
-                'capture_method' => config('lunar.stripe.policy', 'automatic'),
-                'shipping' => [
-                    'name' => "{$shipping->first_name} {$shipping->last_name}",
-                    'address' => [
-                        'city' => $shipping->city,
-                        'country' => $shipping->country->iso2,
-                        'line1' => $shipping->line_one,
-                        'line2' => $shipping->line_two,
-                        'postal_code' => $shipping->postcode,
-                        'state' => $shipping->state,
-                    ],
+        $params = [
+            'amount' => $value,
+            'currency' => $currencyCode,
+            'automatic_payment_methods' => ['enabled' => true],
+            'capture_method' => config('lunar.stripe.policy', 'automatic'),
+        ];
+
+        if ($shipping) {
+            $params['shipping'] = [
+                'name' => "{$shipping->first_name} {$shipping->last_name}",
+                'phone' => $shipping->contact_phone,
+                'address' => [
+                    'city' => $shipping->city,
+                    'country' => $shipping->country->iso2,
+                    'line1' => $shipping->line_one,
+                    'line2' => $shipping->line_two,
+                    'postal_code' => $shipping->postcode,
+                    'state' => $shipping->state,
                 ],
-                ...$opts,
-            ]);
+            ];
+        }
+
+        return PaymentIntent::create([
+            ...$params,
+            ...$opts,
+        ]);
     }
 }

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -31,7 +31,7 @@ class StripeManager
     /**
      * Create a payment intent from a Cart
      */
-    public function createIntent(Cart $cart): PaymentIntent
+    public function createIntent(Cart $cart, array $opts = []): PaymentIntent
     {
         $shipping = $cart->shippingAddress;
 
@@ -51,6 +51,7 @@ class StripeManager
             $cart->total->value,
             $cart->currency->code,
             $shipping,
+            $opts
         );
 
         if (! $meta) {
@@ -121,24 +122,26 @@ class StripeManager
     /**
      * Build the intent
      */
-    protected function buildIntent(int $value, string $currencyCode, CartAddress $shipping): PaymentIntent
+    protected function buildIntent(int $value, string $currencyCode, CartAddress $shipping, array $opts = []): PaymentIntent
     {
-        return PaymentIntent::create([
-            'amount' => $value,
-            'currency' => $currencyCode,
-            'automatic_payment_methods' => ['enabled' => true],
-            'capture_method' => config('lunar.stripe.policy', 'automatic'),
-            'shipping' => [
-                'name' => "{$shipping->first_name} {$shipping->last_name}",
-                'address' => [
-                    'city' => $shipping->city,
-                    'country' => $shipping->country->iso2,
-                    'line1' => $shipping->line_one,
-                    'line2' => $shipping->line_two,
-                    'postal_code' => $shipping->postcode,
-                    'state' => $shipping->state,
+        return PaymentIntent::create(
+            [
+                'amount' => $value,
+                'currency' => $currencyCode,
+                'automatic_payment_methods' => ['enabled' => true],
+                'capture_method' => config('lunar.stripe.policy', 'automatic'),
+                'shipping' => [
+                    'name' => "{$shipping->first_name} {$shipping->last_name}",
+                    'address' => [
+                        'city' => $shipping->city,
+                        'country' => $shipping->country->iso2,
+                        'line1' => $shipping->line_one,
+                        'line2' => $shipping->line_two,
+                        'postal_code' => $shipping->postcode,
+                        'state' => $shipping->state,
+                    ],
                 ],
-            ],
-        ]);
+                ...$opts,
+            ]);
     }
 }


### PR DESCRIPTION
- Improved docs to show more of what's available in the addon
- Added `updateIntent` method to allow updates without having to recalculate the cart
- Added `updateShippingAddress` helper method
- Added a check to only send a shipping address when an intent is created if one exists on the cart