### PR TITLE
fix: staff resource roles test

### DIFF
--- a/tests/admin/Feature/Filament/Resources/StaffResource/Pages/EditStaffTest.php
+++ b/tests/admin/Feature/Filament/Resources/StaffResource/Pages/EditStaffTest.php
@@ -53,7 +53,9 @@ it('can save staff data', function () {
 });
 
 it('can assign staff role and permissions', function () {
-    $staff = Staff::factory()->create();
+    $staff = Staff::factory()->create([
+        'admin' => false,
+    ]);
 
     $roles = ['staff'];
     $permissions = LunarAccessControl::getGroupedPermissions()->random(4)->mapWithKeys(fn ($perm) => [$perm->handle => true]);


### PR DESCRIPTION
because roles and permissions are hidden when `admin` is `true`, the state is not hydrated and is not `roles`'s `saveRelationshipsUsing` is not called...

https://github.com/lunarphp/lunar/blob/a941bafdff8a9c5dc543a60566a54cac5ce343ab/packages/admin/src/Filament/Resources/StaffResource.php#L149-L157

tested by repeating the test `->repeat(50)`
before
<img width="598" alt="image" src="https://github.com/lunarphp/lunar/assets/67364036/2bec67e4-acbd-451d-a6be-3be66b1b403d">

after
<img width="477" alt="image" src="https://github.com/lunarphp/lunar/assets/67364036/0bc70bdc-06bb-47d4-8164-f8078d0495b7">
