### PR TITLE
Closure Added to ShippingModifier

### DIFF
--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,6 +18,21 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
+## [Unreleased]
+
+### Medium Impact
+
+The `\Lunar\Base\ShippingModifier` `handle` method now correctly passes a closure as the second parameter. You will need to update any custom shipping modifiers that extend this as follows:
+
+```php
+public function handle(\Lunar\Models\Cart $cart, \Closure $next)
+{
+    //..
+    
+    return $next($cart);
+}
+```
+
 ## 1.0.0-alpha.x
 
 ### High Impact

--- a/packages/core/src/Base/ShippingModifier.php
+++ b/packages/core/src/Base/ShippingModifier.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Base;
 
+use Closure;
 use Lunar\Models\Cart;
 
 abstract class ShippingModifier
@@ -11,7 +12,7 @@ abstract class ShippingModifier
      *
      * @return void
      */
-    public function handle(Cart $cart)
+    public function handle(Cart $cart, Closure $next)
     {
         //
     }

--- a/tests/core/Unit/Base/ShippingModifiersTest.php
+++ b/tests/core/Unit/Base/ShippingModifiersTest.php
@@ -20,9 +20,9 @@ beforeEach(function () {
 
     $this->class = new class extends ShippingModifier
     {
-        public function handle(Cart $cart)
+        public function handle(Cart $cart, \Closure $next)
         {
-            //
+            return $next($cart);
         }
     };
 
@@ -35,9 +35,8 @@ test('can add modifier', function () {
     expect($this->shippingModifiers->getModifiers())->toHaveCount(1);
 });
 
-function can_remove_modifier()
-{
+test('can remove modifier', function () {
     $this->shippingModifiers->remove($this->class::class);
 
     expect($this->shippingModifiers->getModifiers())->toHaveCount(0);
-}
+});


### PR DESCRIPTION
Fixing following error:  Declaration of App\Modifiers\CustomShippingModifier::handle(Lunar\Models\Cart $cart, \Closure $next) must be compatible with Lunar\Base\ShippingModifier::handle(Lunar\Models\Cart $cart))