### PR TITLE
Update `set-output` commands

### DIFF
--- a/.github/workflows/admin_tests.yml
+++ b/.github/workflows/admin_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/stripe_tests.yml
+++ b/.github/workflows/stripe_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v4

--- a/.github/workflows/table_rate_shipping_tests.yml
+++ b/.github/workflows/table_rate_shipping_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
This PR updates the use of `set-output`command in shipping package. Now uses the new recommended way: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Removes these warnings on the checks:
![image](https://github.com/lunarphp/lunar/assets/1066486/91af434c-0454-40f4-b217-0e981e87c41d)
