### PR TITLE
Remove invalid and unused namespaces from test files

### DIFF
--- a/tests/admin/Unit/Livewire/ActivityLogFeedTest.php
+++ b/tests/admin/Unit/Livewire/ActivityLogFeedTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Lunar\Tests\Admin\Unit\Livewire;
-
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Infolists\Concerns\InteractsWithInfolists;

--- a/tests/admin/Unit/Support/Forms/AttributeDataTest.php
+++ b/tests/admin/Unit/Support/Forms/AttributeDataTest.php
@@ -1,5 +1,3 @@
-namespace Lunar\Tests\Admin\Unit\Support\Forms;
-
 <?php
 
 uses(\Lunar\Tests\Admin\Unit\Livewire\TestCase::class)


### PR DESCRIPTION
I found one namespace that was defined outside of the `<?php` tag, and one that is not needed, since the tests are using Pest.