### PR TITLE
Bump dependencies in `monorepo-builder.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,16 +34,16 @@
         "spatie/laravel-blink": "^1.7",
         "spatie/laravel-medialibrary": "^11.0.0",
         "spatie/laravel-permission": "^6.4",
-        "stripe/stripe-php": "^7.114",
+        "stripe/stripe-php": "^14.4",
         "technikermathe/blade-lucide-icons": "^v3.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9",
-        "laravel/pint": "1.13.1",
-        "mockery/mockery": "^1.4.4",
+        "laravel/pint": "^1.16.1",
+        "mockery/mockery": "^1.6.9",
         "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest": "^2.34.7",
+        "pestphp/pest-plugin-laravel": "^2.4",
         "symplify/monorepo-builder": "^10.0"
     },
     "autoload": {
@@ -81,22 +81,22 @@
     "extra": {
         "lunar": {
             "name": [
-                "Table Rate Shipping",
-                "Opayo Payments",
                 "Meilisearch",
+                "Opayo Payments",
                 "Paypal Payments",
-                "Stripe Payments"
+                "Stripe Payments",
+                "Table Rate Shipping"
             ]
         },
         "laravel": {
             "providers": [
+                "Lunar\\Shipping\\ShippingServiceProvider",
                 "Lunar\\Stripe\\StripePaymentsServiceProvider",
                 "Lunar\\Paypal\\PaypalServiceProvider",
-                "Lunar\\Meilisearch\\MeilisearchServiceProvider",
-                "Lunar\\Admin\\LunarPanelProvider",
                 "Lunar\\Opayo\\OpayoServiceProvider",
-                "Lunar\\Shipping\\ShippingServiceProvider",
-                "Lunar\\LunarServiceProvider"
+                "Lunar\\Meilisearch\\MeilisearchServiceProvider",
+                "Lunar\\LunarServiceProvider",
+                "Lunar\\Admin\\LunarPanelProvider"
             ]
         }
     },

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -39,10 +39,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // for "merge" command
     $parameters->set(Option::DATA_TO_APPEND, [
         ComposerJsonSection::REQUIRE_DEV => [
-            'laravel/pint' => '1.13.1',
-            'mockery/mockery' => '^1.4.4',
-            'pestphp/pest' => '^2.0',
-            'pestphp/pest-plugin-laravel' => '^2.0',
+            'laravel/pint' => '^1.16.1',
+            'mockery/mockery' => '^1.6.9',
+            'pestphp/pest' => '^2.34.7',
+            'pestphp/pest-plugin-laravel' => '^2.4',
             'symplify/monorepo-builder' => '^10.0',
         ],
     ]);


### PR DESCRIPTION
This PR updates the dependencies listed in `monorepo-builder.php`, and runs the `monorepo-builder merge` command.

**Question:** What is the benefit of having these dev dependencies defined in `monorepo-builder.php`, instead of just in `composer.json`?