### PR TITLE
Fixed discount medium priority label

### DIFF
--- a/packages/admin/resources/lang/en/discount.php
+++ b/packages/admin/resources/lang/en/discount.php
@@ -33,7 +33,7 @@ return [
                     'label' => 'Low',
                 ],
                 'medium' => [
-                    'label' => 'Low',
+                    'label' => 'Medium',
                 ],
                 'high' => [
                     'label' => 'High',


### PR DESCRIPTION
Fixing the label for the discount's medium priority, which currently says "low"