### PR TITLE
Allow order screens to be extended

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -141,10 +141,10 @@ export default defineConfig({
                         {text: 'Access Control', link: '/admin/extending/access-control'},
                         {text: 'Add-ons', link: '/admin/extending/addons'},
                         {text: 'Attributes', link: '/admin/extending/attributes'},
-                        {text: 'Order Management', link: '/admin/extending/order-management'},
-                        {text: 'Pages', link: '/admin/extending/pages'},
                         {text: 'Panel', link: '/admin/extending/panel'},
-                        {text: 'Resources', link: '/admin/extending/resources'}
+                        {text: 'Pages', link: '/admin/extending/pages'},
+                        {text: 'Resources', link: '/admin/extending/resources'},
+                        {text: 'Order Management', link: '/admin/extending/order-management'}
                     ]
                 }
             ],

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -141,6 +141,7 @@ export default defineConfig({
                         {text: 'Access Control', link: '/admin/extending/access-control'},
                         {text: 'Add-ons', link: '/admin/extending/addons'},
                         {text: 'Attributes', link: '/admin/extending/attributes'},
+                        {text: 'Order Management', link: '/admin/extending/order-management'},
                         {text: 'Pages', link: '/admin/extending/pages'},
                         {text: 'Panel', link: '/admin/extending/panel'},
                         {text: 'Resources', link: '/admin/extending/resources'}

--- a/docs/admin/extending/order-management.md
+++ b/docs/admin/extending/order-management.md
@@ -1,0 +1,62 @@
+## Extending Order Management
+
+Although orders have access to the same customisation as [Pages](/admin/extending/pages) there are some additional methods available and an additional class to allow order lines to be customised.
+
+To register your extension:
+
+```php
+LunarPanel::extensions([
+    \Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder::class => MyManageOrderExtension::class,
+]);
+```
+
+You then have access to these methods in your class to override area's of the order view screen.
+
+- `extendInfolistSchema(): array`
+
+- `extendInfolistAsideSchema(): array`
+    - `extendCustomerEntry(): Infolists\Components\Component`
+    - `extendTagsSection(): Infolists\Components\Component`
+    - `extendAdditionalInfoSection(): Infolists\Components\Component`
+    - `extendShippingAddressInfolist(): Infolists\Components\Component`
+    - `extendBillingAddressInfolist(): Infolists\Components\Component`
+    -  `extendAddressEditSchema(): array`
+
+- `exendOrderSummaryInfolist(): Infolists\Components\Section`
+- `extendOrderSummarySchema(): array`
+    - `extendOrderSummaryNewCustomerEntry(): Infolists\Components\Entry`
+    - `extendOrderSummaryStatusEntry(): Infolists\Components\Entry`
+    - `extendOrderSummaryReferenceEntry(): Infolists\Components\Entry`
+    - `extendOrderSummaryCustomerReferenceEntry(): Infolists\Components\Entry`
+    - `extendOrderSummaryChannelEntry(): Infolists\Components\Entry`
+    - `extendOrderSummaryCreatedAtEntry(): Infolists\Components\Entry`
+    - `extendOrderSummaryPlacedAtEntry(): Infolists\Components\Entry`
+- `extendTimelineInfolist(): Infolists\Components\Component`
+- `extendOrderTotalsAsideSchema(): array`
+    - `extendDeliveryInstructionsEntry(): Infolists\Components\TextEntry`
+    - `extendOrderNotesEntry(): Infolists\Components\TextEntry`
+- `extendOrderTotalsInfolist(): Infolists\Components\Section`
+- `extendOrderTotalsSchema(): array`
+    - `extendSubTotalEntry(): Infolists\Components\TextEntry`
+    - `extendDiscountTotalEntry(): Infolists\Components\TextEntry`
+    - `extendShippingBreakdownGroup(): Infolists\Components\Group`
+    - `extendTaxBreakdownGroup(): Infolists\Components\Group`
+    - `extendTotalEntry(): Infolists\Components\TextEntry`
+    - `extendPaidEntry(): Infolists\Components\TextEntry`
+    - `extendRefundEntry(): Infolists\Components\TextEntry`
+
+- `extendShippingInfolist(): Infolists\Components\Section`
+- `extendTransactionsInfolist(): Infolists\Components\Component`
+- `extendTransactionsRepeatableEntry(): Infolists\Components\RepeatableEntry`
+
+## Extending `OrderItemsTable`
+
+```php
+\Lunar\Facades\LunarPanel::extensions([
+    \Lunar\Admin\Filament\Resources\OrderResource\Pages\Components\OrderItemsTable::class => OrderItemsTableExtension::class
+]);
+```
+### Available Methods
+
+- `extendOrderLinesTableColumns(): array`
+- `extendTable(): Table`

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderAddresses.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderAddresses.php
@@ -37,7 +37,7 @@ trait DisplaysOrderAddresses
 
     public static function getAddressEditSchema(): array
     {
-        return self::callLunarHook('exendAddressEditSchema', [
+        return self::callLunarHook('extendAddressEditSchema', [
             Forms\Components\Grid::make()
                 ->schema([
                     Forms\Components\TextInput::make('first_name')

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderAddresses.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderAddresses.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\OrderResource\Concerns;
+
+use Filament\Facades\Filament;
+use Filament\Forms;
+use Filament\Infolists;
+use Filament\Infolists\Components\Actions\Action;
+use Filament\Support\Colors\Color;
+use Filament\Support\Enums\FontWeight;
+use Illuminate\Support\Arr;
+use Lunar\Models\Country;
+use Lunar\Models\OrderAddress;
+use Lunar\Models\State;
+
+trait DisplaysOrderAddresses
+{
+    public static function getDefaultShippingAddressInfoList(): Infolists\Components\Component
+    {
+        return self::getOrderAddressInfolistSchema('shipping');
+    }
+
+    public static function getShippingAddressInfolist(): Infolists\Components\Component
+    {
+        return self::callLunarHook('extendShippingAddressInfolist', static::getDefaultShippingAddressInfoList());
+    }
+
+    public static function getDefaultBillingAddressInfoList(): Infolists\Components\Component
+    {
+        return self::getOrderAddressInfolistSchema('billing');
+    }
+
+    public static function getBillingAddressInfoList(): Infolists\Components\Component
+    {
+        return self::callLunarHook('extendBillingAddressInfolist', static::getDefaultBillingAddressInfoList());
+    }
+
+    public static function getAddressEditSchema(): array
+    {
+        return self::callLunarHook('exendAddressEditSchema', [
+            Forms\Components\Grid::make()
+                ->schema([
+                    Forms\Components\TextInput::make('first_name')
+                        ->label(__('lunarpanel::order.form.address.first_name.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255)
+                        ->required(),
+                    Forms\Components\TextInput::make('last_name')
+                        ->label(__('lunarpanel::order.form.address.last_name.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255),
+                ]),
+            Forms\Components\TextInput::make('company_name')
+                ->label(__('lunarpanel::order.form.address.company_name.label'))
+                ->autocomplete(false)
+                ->maxLength(255),
+            Forms\Components\Grid::make()
+                ->schema([
+                    Forms\Components\TextInput::make('contact_phone')
+                        ->label(__('lunarpanel::order.form.address.contact_phone.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('contact_email')
+                        ->label(__('lunarpanel::order.form.address.contact_email.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255),
+                ]),
+            Forms\Components\TextInput::make('line_one')
+                ->label(__('lunarpanel::order.form.address.line_one.label'))
+                ->autocomplete(false)
+                ->maxLength(255)
+                ->required(),
+            Forms\Components\Grid::make()
+                ->schema([
+                    Forms\Components\TextInput::make('line_two')
+                        ->label(__('lunarpanel::order.form.address.line_two.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('line_three')
+                        ->label(__('lunarpanel::order.form.address.line_three.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255),
+                ]),
+            Forms\Components\Grid::make(3)
+                ->schema([
+                    Forms\Components\TextInput::make('city')
+                        ->label(__('lunarpanel::order.form.address.city.label'))
+                        ->maxLength(255)
+                        ->autocomplete(false)
+                        ->required(),
+                    Forms\Components\TextInput::make('state')
+                        ->label(__('lunarpanel::order.form.address.state.label'))
+                        ->autocomplete('state') // to disable browser input history while keeping datalist
+                        ->datalist(fn ($get) => State::whereCountryId($get('country_id'))->pluck('name')->toArray())
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('postcode')
+                        ->label(__('lunarpanel::order.form.address.postcode.label'))
+                        ->autocomplete(false)
+                        ->maxLength(255),
+                ]),
+            Forms\Components\Select::make('country_id')
+                ->label(__('lunarpanel::order.form.address.country_id.label'))
+                ->options(fn () => Country::get()->pluck('name', 'id'))
+                ->live()
+                ->searchable()
+                ->required(),
+        ]);
+    }
+
+    public static function getOrderAddressInfolistSchema(string $type): Infolists\Components\Section
+    {
+        $sameAsShipping = fn ($record) => $type == 'billing' && static::addressesMatch($record->shippingAddress, $record->billingAddress);
+
+        $getAddress = fn ($record) => match ($type) {
+            'billing' => $record->billingAddress,
+            default => $record->shippingAddress,
+        };
+
+        return Infolists\Components\Section::make(__("lunarpanel::order.infolist.{$type}_address.label"))
+            ->statePath($type.'Address')
+            ->compact()
+            ->headerActions([
+                fn ($record) => static::getEditAddressAction($type)->hidden($sameAsShipping($record)),
+            ])
+            ->schema(fn ($record) => $sameAsShipping($record) ? [
+                Infolists\Components\TextEntry::make('billing_matches_shipping')
+                    ->hiddenLabel()
+                    ->weight(FontWeight::SemiBold)
+                    ->getStateUsing(fn () => __('lunarpanel::order.infolist.billing_matches_shipping.label')),
+
+            ] : [
+                Infolists\Components\TextEntry::make($type.'_address')
+                    ->hiddenLabel()
+                    ->listWithLineBreaks()
+                    ->getStateUsing(function ($record) use ($getAddress) {
+                        $address = $getAddress($record);
+
+                        if ($address?->id ?? false) {
+                            return collect([
+                                'company_name' => $address->company_name,
+                                'fullName' => $address->fullName,
+                                'line_one' => $address->line_one,
+                                'line_two' => $address->line_two,
+                                'line_three' => $address->line_three,
+                                'city' => $address->city,
+                                'state' => $address->state,
+                                'postcode' => $address->postcode,
+                                'country.name' => $address->country->name,
+                            ])
+                                ->filter(fn ($value, $key) => filled($value) || in_array($key, [
+                                    'fullName', 'line_one', 'postcode', 'country.name',
+                                ]))
+                                ->toArray();
+                        } else {
+                            return __('lunarpanel::order.infolist.address_not_set.label');
+                        }
+                    }),
+                Infolists\Components\TextEntry::make($type.'_phone')
+                    ->hiddenLabel()
+                    ->icon('heroicon-o-phone')
+                    ->getStateUsing(fn ($record) => $getAddress($record)?->contact_phone ?? '-')
+                    ->url(fn ($state) => $state !== '-' ? 'tel:'.$state : false)
+                    ->color(fn ($state) => $state !== '-' ? Color::Sky : null)
+                    ->iconColor(fn ($state) => $state !== '-' ? Color::Green : null),
+                Infolists\Components\TextEntry::make($type.'_email')
+                    ->hiddenLabel()
+                    ->icon('heroicon-o-envelope')
+                    ->getStateUsing(fn ($record) => $getAddress($record)?->contact_email ?? '-')
+                    ->url(fn ($state) => $state !== '-' ? 'mailto:'.$state : false)
+                    ->color(fn ($state) => $state !== '-' ? Color::Sky : null)
+                    ->iconColor(fn ($state) => $state !== '-' ? Color::Amber : null),
+            ]);
+    }
+
+    private static function addressesMatch(OrderAddress $original = null, OrderAddress $comparison = null): bool
+    {
+        if (! $original || ! $comparison) {
+            return false;
+        }
+
+        $fieldsToCheck = Arr::except(
+            $comparison->getAttributes(),
+            ['id', 'created_at', 'updated_at', 'order_id', 'type', 'meta', 'shipping_option']
+        );
+
+        // Is the same until proven otherwise
+        $isSame = true;
+        foreach ($fieldsToCheck as $field => $value) {
+            if ($original->getAttribute($field) != $value) {
+                $isSame = false;
+            }
+        }
+
+        return $isSame;
+    }
+
+    public static function getEditAddressAction(string $type): Action
+    {
+        return Action::make("edit_{$type}_address")
+            ->modalHeading(__("lunarpanel::order.infolist.{$type}_address.label"))
+            ->modalWidth('2xl')
+            ->label(__('lunarpanel::order.action.edit_address.label'))
+            ->button()
+            ->fillForm(fn ($record) => match ($type) {
+                'shipping' => $record->shippingAddress->toArray(),
+                'billing' => $record->billingAddress->toArray(),
+                default => []
+            })
+            ->form(function () {
+                return static::getAddressEditSchema();
+            })
+            ->action(function (Action $action, $record, $data) use ($type) {
+                $addressType = match ($type) {
+                    'shipping' => 'shippingAddress',
+                    'billing' => 'billingAddress',
+                    default => null,
+                };
+
+                if (blank($addressType)) {
+                    $action->failureNotificationTitle(__('lunarpanel::order.action.edit_address.notification.error'));
+                    $action->failure();
+
+                    $action->halt();
+
+                    return;
+                }
+
+                $oldData = $record->$addressType->toArray();
+                $formFields = array_keys($data);
+
+                $record->$addressType->order_id = $record->id;
+                $record->$addressType->update($data);
+                $refreshed = $record->$addressType->refresh();
+
+                // should this be in Core as model observer?
+                $diff = collect($oldData)->only($formFields)->diff(collect($refreshed->toArray())->only($formFields));
+                if ($diff->count()) {
+                    activity()
+                        ->causedBy(Filament::auth()->user())
+                        ->performedOn($record)
+                        ->event('order-address-update')
+                        ->withProperties([
+                            'fields' => $formFields,
+                            'type' => $addressType,
+                            'new' => $record->$addressType->toArray(),
+                            'previous' => $oldData,
+                        ])->log('order-address-update');
+                }
+
+                $action->successNotificationTitle(__("lunarpanel::order.action.edit_address.notification.{$type}_address.saved"));
+
+                $action->success();
+            })
+            ->slideOver();
+    }
+}

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderSummary.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderSummary.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\OrderResource\Concerns;
+
+use Filament\Infolists;
+use Filament\Support\Enums\IconPosition;
+use Lunar\Admin\Support\OrderStatus;
+
+trait DisplaysOrderSummary
+{
+    public static function getDefaultOrderSummaryNewCustomerEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('new_customer')
+            ->label(__('lunarpanel::order.infolist.new_returning.label'))
+            ->alignEnd()
+            ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.'.($state ? 'new' : 'returning').'_customer.label'));
+    }
+
+    public static function getOrderSummaryNewCustomerEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryNewCustomerEntry', static::getDefaultOrderSummaryNewCustomerEntry());
+    }
+
+    public static function getDefaultOrderSummaryStatusEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('status')
+            ->label(__('lunarpanel::order.infolist.status.label'))
+            ->formatStateUsing(fn ($state) => OrderStatus::getLabel($state))
+            ->alignEnd()
+            ->color(fn ($state) => OrderStatus::getColor($state))
+            ->badge();
+    }
+
+    public static function getOrderSummaryStatusEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryStatusEntry', static::getDefaultOrderSummaryStatusEntry());
+    }
+
+    public static function getDefaultOrderReferenceEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('reference')
+            ->label(__('lunarpanel::order.infolist.reference.label'))
+            ->alignEnd()
+            ->icon('heroicon-o-clipboard')
+            ->iconPosition(IconPosition::After)
+            ->copyable();
+    }
+
+    public static function getOrderSummaryReferenceEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryReferenceEntry', static::getDefaultOrderReferenceEntry());
+    }
+
+    public static function getDefaultOrderSummaryCustomerReferenceEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('customer_reference')
+            ->label(__('lunarpanel::order.infolist.customer_reference.label'))
+            ->alignEnd()
+            ->icon('heroicon-o-clipboard')
+            ->iconPosition(IconPosition::After)
+            ->copyable();
+    }
+
+    public static function getOrderSummaryCustomerReferenceEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryCustomerReferenceEntry', static::getDefaultOrderSummaryCustomerReferenceEntry());
+    }
+
+    public static function getDefaultOrderSummaryChannelEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('channel.name')
+            ->label(__('lunarpanel::order.infolist.channel.label'))
+            ->alignEnd();
+    }
+
+    public static function getOrderSummaryChannelEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryChannelEntry', static::getDefaultOrderSummaryChannelEntry());
+    }
+
+    public static function getDefaultOrderSummaryCreatedAtEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('created_at')
+            ->label(__('lunarpanel::order.infolist.date_created.label'))
+            ->alignEnd()
+            ->dateTime('Y-m-d h:i a')
+            ->visible(fn ($record) => ! $record->placed_at);
+    }
+
+    public static function getOrderSummaryCreatedAtEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryCreatedAtEntry', static::getDefaultOrderSummaryCreatedAtEntry());
+    }
+
+    public static function getDefaultOrderSummaryPlacedAtEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('placed_at')
+            ->label(__('lunarpanel::order.infolist.date_placed.label'))
+            ->alignEnd()
+            ->dateTime('Y-m-d h:i a')
+            ->placeholder('-');
+    }
+
+    public static function getOrderSummaryPlacedAtEntry(): Infolists\Components\Entry
+    {
+        return self::callLunarHook('extendOrderSummaryPlacedAtEntry', static::getDefaultOrderSummaryPlacedAtEntry());
+    }
+
+    public static function getOrderSummarySchema(): array
+    {
+        return self::callLunarHook('extendOrderSummarySchema', [
+            static::getOrderSummaryNewCustomerEntry(),
+            static::getOrderSummaryStatusEntry(),
+            static::getOrderSummaryReferenceEntry(),
+            static::getOrderSummaryCustomerReferenceEntry(),
+            static::getOrderSummaryChannelEntry(),
+            static::getOrderSummaryCreatedAtEntry(),
+            static::getOrderSummaryPlacedAtEntry(),
+        ]);
+    }
+
+    public static function getDefaultOrderSummaryInfolist(): Infolists\Components\Section
+    {
+        return Infolists\Components\Section::make()
+            ->compact()
+            ->inlineLabel()
+            ->schema(
+                static::getOrderSummarySchema()
+            );
+    }
+
+    public static function getOrderSummaryInfolist(): Infolists\Components\Section
+    {
+        return self::callLunarHook('exendOrderSummaryInfolist', static::getDefaultOrderSummaryInfolist());
+    }
+}

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderSummary.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderSummary.php
@@ -89,7 +89,7 @@ trait DisplaysOrderSummary
 
     public static function getOrderSummaryCreatedAtEntry(): Infolists\Components\Entry
     {
-        return self::callLunarHook('extendOrderSummaryCreatedAtEntry', static::getDefaultOrderSummaryCreatedAtEntry());
+            return self::callLunarHook('extendOrderSummaryCreatedAtEntry', static::getDefaultOrderSummaryCreatedAtEntry());
     }
 
     public static function getDefaultOrderSummaryPlacedAtEntry(): Infolists\Components\TextEntry

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderSummary.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderSummary.php
@@ -89,7 +89,7 @@ trait DisplaysOrderSummary
 
     public static function getOrderSummaryCreatedAtEntry(): Infolists\Components\Entry
     {
-            return self::callLunarHook('extendOrderSummaryCreatedAtEntry', static::getDefaultOrderSummaryCreatedAtEntry());
+        return self::callLunarHook('extendOrderSummaryCreatedAtEntry', static::getDefaultOrderSummaryCreatedAtEntry());
     }
 
     public static function getDefaultOrderSummaryPlacedAtEntry(): Infolists\Components\TextEntry

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderTimeline.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderTimeline.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\OrderResource\Concerns;
+
+use Filament\Infolists;
+use Lunar\Admin\Support\Infolists\Components\Timeline;
+
+trait DisplaysOrderTimeline
+{
+    public static function getTimelineInfolist(): Infolists\Components\Component
+    {
+        return self::callLunarHook('extendTimelineInfolist', static::getDefaultTimelineInfolist());
+    }
+
+    public static function getDefaultTimelineInfolist(): Infolists\Components\Component
+    {
+        return Infolists\Components\Grid::make()
+            ->schema([
+                Timeline::make('timeline')
+                    ->label(__('lunarpanel::order.infolist.timeline.label')),
+            ]);
+    }
+}

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderTotals.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderTotals.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\OrderResource\Concerns;
+
+use Filament\Infolists;
+use Filament\Support\Enums\FontWeight;
+use Illuminate\Support\HtmlString;
+use Lunar\DataTypes\Price;
+
+trait DisplaysOrderTotals
+{
+    public static function getDefaultDeliveryInstructionsEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('shippingAddress.delivery_instructions')
+            ->label(__('lunarpanel::order.infolist.delivery_instructions.label'))
+            ->hidden(fn ($state) => blank($state));
+    }
+
+    public static function getDeliveryInstructionsEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendDeliveryInstructionsEntry', static::getDefaultDeliveryInstructionsEntry());
+    }
+
+    public static function getDefaultOrderNotesEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('notes')
+            ->label(__('lunarpanel::order.infolist.notes.label'))
+            ->placeholder(__('lunarpanel::order.infolist.notes.placeholder'));
+    }
+
+    public static function getOrderNotesEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendOrderNotesEntry', static::getDefaultOrderNotesEntry());
+    }
+
+    public static function getOrderTotalsAsideSchema(): array
+    {
+        return self::callLunarHook('extendOrderTotalsAsideSchema', [
+            static::getDeliveryInstructionsEntry(),
+            static::getOrderNotesEntry(),
+        ]);
+    }
+
+    public static function getDefaultSubTotalEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('sub_total')
+            ->label(__('lunarpanel::order.infolist.sub_total.label'))
+            ->inlineLabel()
+            ->alignEnd()
+            ->formatStateUsing(fn ($state) => $state->formatted);
+    }
+
+    public static function getSubTotalEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendSubTotalEntry', static::getDefaultSubTotalEntry());
+    }
+
+    public static function getDefaultDiscountTotalEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('discount_total')
+            ->label(__('lunarpanel::order.infolist.discount_total.label'))
+            ->inlineLabel()
+            ->alignEnd()
+            ->formatStateUsing(fn ($state) => $state->formatted);
+    }
+
+    public static function getDiscountTotalEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendDiscountTotalEntry', static::getDefaultDiscountTotalEntry());
+    }
+
+    public static function getDefaultShippingBreakdownGroup(): Infolists\Components\Group
+    {
+        return Infolists\Components\Group::make()
+            ->statePath('shipping_breakdown')
+            ->schema(function ($state) {
+                $shipping = [];
+                foreach ($state->items ?? [] as $shippingIndex => $shippingItem) {
+                    $shipping[] = Infolists\Components\TextEntry::make('shipping_'.$shippingIndex)
+                        ->label(fn () => $shippingItem->name)
+                        ->inlineLabel()
+                        ->alignEnd()
+                        ->state(fn () => $shippingItem->price->formatted);
+                }
+
+                return $shipping;
+            });
+    }
+
+    public static function getShippingBreakdownGroup(): Infolists\Components\Group
+    {
+        return self::callLunarHook('extendShippingBreakdownGroup', static::getDefaultShippingBreakdownGroup());
+    }
+
+    public static function getDefaultTaxBreakdownGroup(): Infolists\Components\Group
+    {
+        return Infolists\Components\Group::make()
+            ->statePath('tax_breakdown')
+            ->schema(function ($state) {
+                $taxes = [];
+                foreach ($state->amounts ?? [] as $taxIndex => $tax) {
+                    $taxes[] = Infolists\Components\TextEntry::make('tax_'.$taxIndex)
+                        ->label(fn () => $tax->description)
+                        ->inlineLabel()
+                        ->alignEnd()
+                        ->state(fn () => $tax->price->formatted);
+                }
+
+                return $taxes;
+            });
+    }
+
+    public static function getTaxBreakdownGroup(): Infolists\Components\Group
+    {
+        return self::callLunarHook('extendTaxBreakdownGroup', static::getDefaultTaxBreakdownGroup());
+    }
+
+    public static function getDefaultTotalEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('total')
+            ->label(fn () => new HtmlString('<b>'.__('lunarpanel::order.infolist.total.label').'</b>'))
+            ->inlineLabel()
+            ->alignEnd()
+            ->weight(FontWeight::Bold)
+            ->formatStateUsing(fn ($state) => $state->formatted);
+    }
+
+    public static function getTotalEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendTotalEntry', static::getDefaultTotalEntry());
+    }
+
+    public static function getDefaultPaidEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('paid')
+            ->label(fn () => __('lunarpanel::order.infolist.paid.label'))
+            ->inlineLabel()
+            ->alignEnd()
+            ->weight(FontWeight::SemiBold)
+            ->getStateUsing(function ($record) {
+                $paid = $record->transactions()
+                    ->whereType('capture')
+                    ->whereSuccess(true)
+                    ->get()
+                    ->sum('amount.value');
+
+                return (new Price($paid, $record->currency))->formatted;
+            });
+    }
+
+    public static function getPaidEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendPaidEntry', static::getDefaultPaidEntry());
+    }
+
+    public static function getDefaultRefundEntry(): Infolists\Components\TextEntry
+    {
+        return Infolists\Components\TextEntry::make('refund')
+            ->label(fn () => __('lunarpanel::order.infolist.refund.label'))
+            ->inlineLabel()
+            ->alignEnd()
+            ->color('warning')
+            ->weight(FontWeight::SemiBold)
+            ->getStateUsing(function ($record) {
+                $paid = $record->transactions()
+                    ->whereType('refund')
+                    ->get()
+                    ->sum('amount.value');
+
+                return (new Price($paid, $record->currency))->formatted;
+            });
+    }
+
+    public static function getRefundEntry(): Infolists\Components\TextEntry
+    {
+        return self::callLunarHook('extendPaidEntry', static::getDefaultRefundEntry());
+    }
+
+    public static function getOrderTotalsSchema(): array
+    {
+        return self::callLunarHook('extendOrderTotalsSchema', [
+            static::getSubTotalEntry(),
+            static::getDiscountTotalEntry(),
+            static::getShippingBreakdownGroup(),
+            static::getTaxBreakdownGroup(),
+            static::getTotalEntry(),
+            static::getPaidEntry(),
+            static::getRefundEntry(),
+        ]);
+    }
+
+    public static function getDefaultOrderTotalsInfolist(): Infolists\Components\Component
+    {
+        return Infolists\Components\Section::make()
+            ->schema([
+                Infolists\Components\Grid::make()
+                    ->columns(2)
+                    ->schema([
+                        Infolists\Components\Grid::make()
+                            ->columns(1)
+                            ->columnSpan(1)
+                            ->schema(
+                                static::getOrderTotalsAsideSchema()
+                            ),
+                        Infolists\Components\Grid::make()
+                            ->columns(1)
+                            ->columnSpan(1)
+                            ->schema(
+                                static::getOrderTotalsSchema()
+                            ),
+                    ]),
+            ]);
+    }
+
+    public static function getOrderTotalsInfolist(): Infolists\Components\Section
+    {
+        return self::callLunarHook('extendOrderTotalsInfolist', static::getDefaultOrderTotalsInfolist());
+    }
+}

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderTotals.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderTotals.php
@@ -173,7 +173,7 @@ trait DisplaysOrderTotals
 
     public static function getRefundEntry(): Infolists\Components\TextEntry
     {
-        return self::callLunarHook('extendPaidEntry', static::getDefaultRefundEntry());
+        return self::callLunarHook('extendRefundEntry', static::getDefaultRefundEntry());
     }
 
     public static function getOrderTotalsSchema(): array

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysShippingInfo.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysShippingInfo.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\OrderResource\Concerns;
+
+use Filament\Infolists;
+use Filament\Support\Enums\IconPosition;
+
+trait DisplaysShippingInfo
+{
+    public static function getShippingInfolist(): Infolists\Components\Section
+    {
+        return self::callLunarHook('extendShippingInfolist', static::getDefaultShippingInfolist());
+    }
+
+    public static function getDefaultShippingInfolist(): Infolists\Components\Section
+    {
+        return Infolists\Components\Section::make()
+            ->schema([
+                Infolists\Components\RepeatableEntry::make('shippingLines')
+                    ->hiddenLabel()
+                    ->contained(false)
+                    ->columns(2)
+                    ->columnSpan(12)
+                    ->schema([
+                        Infolists\Components\TextEntry::make('description')
+                            ->icon('heroicon-s-truck')
+                            ->html()
+                            ->iconPosition(IconPosition::Before)
+                            ->hiddenLabel(),
+                        Infolists\Components\TextEntry::make('sub_total')
+                            ->hiddenLabel()
+                            ->alignEnd()
+                            ->formatStateUsing(fn ($state) => $state->formatted),
+                        Infolists\Components\TextEntry::make('notes')
+                            ->hidden(
+                                fn ($state) => ! $state
+                            )
+                            ->placeholder(
+                                __('lunarpanel::order.infolist.notes.placeholder')
+                            ),
+                    ]),
+            ]);
+    }
+}

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysTransactions.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysTransactions.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Lunar\Admin\Filament\Resources\OrderResource\Concerns;
+
+use Filament\Infolists;
+use Lunar\Admin\Support\Infolists\Components\Transaction as InfolistsTransaction;
+
+trait DisplaysTransactions
+{
+    public static function getDefaultTransactionsRepeatableEntry(): Infolists\Components\RepeatableEntry
+    {
+        return Infolists\Components\RepeatableEntry::make('transactions')
+            ->hiddenLabel()
+            ->placeholder(__('lunarpanel::order.infolist.transactions.placeholder'))
+            ->getStateUsing(fn ($record) => $record->transactions)
+            ->contained(false)
+            ->schema([
+                InfolistsTransaction::make('transactions'),
+            ]);
+    }
+
+    public static function getTransactionsRepeatableEntry(): Infolists\Components\RepeatableEntry
+    {
+        return self::callLunarHook('extendTransactionsRepeatableEntry', static::getDefaultTransactionsRepeatableEntry());
+    }
+
+    public static function getDefaultTransactionsInfolist(): Infolists\Components\Component
+    {
+        return Infolists\Components\Section::make('transactions')
+            ->heading(__('lunarpanel::order.infolist.transactions.label'))
+            ->compact()
+            ->collapsed(fn ($state) => filled($state))
+            ->collapsible(fn ($state) => filled($state))
+            ->schema([
+                static::getTransactionsRepeatableEntry(),
+            ]);
+    }
+
+    public static function getTransactionsInfolist(): Infolists\Components\Component
+    {
+        return self::callLunarHook('extendTransactionsInfolist', static::getDefaultTransactionsInfolist());
+    }
+}

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -33,69 +33,69 @@ class OrderItemsTable extends TableComponent
             Tables\Columns\Layout\Split::make([
                 Tables\Columns\ImageColumn::make('image')
                     ->defaultImageUrl(fn () => 'data:image/svg+xml;base64, '.base64_encode(
-                            Blade::render('<x-filament::icon icon="heroicon-o-photo" style="color:rgb('.Color::Gray[400].');"/>')
-                        ))
+                        Blade::render('<x-filament::icon icon="heroicon-o-photo" style="color:rgb('.Color::Gray[400].');"/>')
+                    ))
                     ->grow(false)
                     ->getStateUsing(fn ($record) => $record->purchasable?->getThumbnail()?->getUrl('small')),
 
                 Tables\Columns\Layout\Stack::make([
                     Tables\Columns\Layout\Split::make([
-                        Tables\Columns\Layout\Stack::make([
-                            Tables\Columns\TextColumn::make('description')
-                                ->weight(FontWeight::Bold),
-                            Tables\Columns\TextColumn::make('identifier')
-                                ->color(Color::Gray),
-                            Tables\Columns\TextColumn::make('options')
-                                ->getStateUsing(fn ($record) => $record->purchasable?->getOptions())
-                                ->badge(),
-                        ]),
-                        Tables\Columns\Layout\Stack::make([
-                            Tables\Columns\TextColumn::make('unit')
-                                ->alignEnd()
-                                ->getStateUsing(fn ($record) => "{$record->quantity} @ {$record->sub_total->formatted}"),
-                        ]),
+                    Tables\Columns\Layout\Stack::make([
+                        Tables\Columns\TextColumn::make('description')
+                            ->weight(FontWeight::Bold),
+                        Tables\Columns\TextColumn::make('identifier')
+                            ->color(Color::Gray),
+                        Tables\Columns\TextColumn::make('options')
+                            ->getStateUsing(fn ($record) => $record->purchasable?->getOptions())
+                            ->badge(),
+                    ]),
+                    Tables\Columns\Layout\Stack::make([
+                        Tables\Columns\TextColumn::make('unit')
+                            ->alignEnd()
+                            ->getStateUsing(fn ($record) => "{$record->quantity} @ {$record->sub_total->formatted}"),
+                    ]),
                     ])
-                        ->extraAttributes(['style' => 'align-items: start;']),
+                    ->extraAttributes(['style' => 'align-items: start;']),
                 ])
                     ->columnSpanFull(),
             ])->extraAttributes(['style' => 'align-items: start;']),
             Tables\Columns\Layout\Panel::make([
                 Tables\Columns\Layout\Stack::make([
                     Tables\Columns\TextColumn::make('stock')
-                        ->getStateUsing(fn ($record) => $record->purchasable?->stock)
-                        ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.current_stock_level.message', [
-                            'count' => $state,
-                        ]))
-                        ->colors(fn () => [
-                            'danger' => fn ($state) => $state < 50,
-                            'success' => fn ($state) => $state >= 50,
-                        ]),
+                    ->getStateUsing(fn ($record) => $record->purchasable?->stock)
+                    ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.current_stock_level.message', [
+                        'count' => $state,
+                    ]))
+                    ->colors(fn () => [
+                        'danger' => fn ($state) => $state < 50,
+                        'success' => fn ($state) => $state >= 50,
+                    ]),
                     Tables\Columns\TextColumn::make('meta.stock_level')
-                        ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.purchase_stock_level.message', [
-                            'count' => $state,
-                        ]))
-                        ->color(Color::Gray),
+                    ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.purchase_stock_level.message', [
+                        'count' => $state,
+                    ]))
+                    ->color(Color::Gray),
                     Tables\Columns\TextColumn::make('notes')
-                        ->description(new HtmlString('<b>'.__('lunarpanel::order.infolist.notes.label').'</b>'), 'above'),
+                    ->description(new HtmlString('<b>'.__('lunarpanel::order.infolist.notes.label').'</b>'), 'above'),
 
                     KeyValue::make('price_breakdowns')
-                        ->getStateUsing(function ($record) {
+                    ->getStateUsing(function ($record) {
 
-                            $states = [];
+                        $states = [];
 
-                            $states['unit_price'] = "{$record->unit_price->unitFormatted(decimalPlaces: 4)}";
-                            $states['quantity'] = $record->quantity;
-                            $states['sub_total'] = $record->sub_total?->formatted;
-                            $states['discount_total'] = $record->discount_total?->formatted;
+                        $states['unit_price'] = "{$record->unit_price->unitFormatted(decimalPlaces: 4)}";
+                        $states['quantity'] = $record->quantity;
+                        $states['sub_total'] = $record->sub_total?->formatted;
+                        $states['discount_total'] = $record->discount_total?->formatted;
 
-                            foreach ($record->tax_breakdown?->amounts ?? [] as $tax) {
-                                $states[$tax->description] = $tax->price->formatted;
-                            }
+                        foreach ($record->tax_breakdown?->amounts ?? [] as $tax) {
+                            $states[$tax->description] = $tax->price->formatted;
+                        }
 
-                            $states['total'] = $record->total?->formatted;
+                        $states['total'] = $record->total?->formatted;
 
-                            return $states;
-                        }),
+                        return $states;
+                    }),
                 ]),
             ])
                 ->collapsed()

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -40,62 +40,62 @@ class OrderItemsTable extends TableComponent
 
                 Tables\Columns\Layout\Stack::make([
                     Tables\Columns\Layout\Split::make([
-                    Tables\Columns\Layout\Stack::make([
-                        Tables\Columns\TextColumn::make('description')
-                            ->weight(FontWeight::Bold),
-                        Tables\Columns\TextColumn::make('identifier')
-                            ->color(Color::Gray),
-                        Tables\Columns\TextColumn::make('options')
-                            ->getStateUsing(fn ($record) => $record->purchasable?->getOptions())
-                            ->badge(),
-                    ]),
-                    Tables\Columns\Layout\Stack::make([
-                        Tables\Columns\TextColumn::make('unit')
-                            ->alignEnd()
-                            ->getStateUsing(fn ($record) => "{$record->quantity} @ {$record->sub_total->formatted}"),
-                    ]),
+                        Tables\Columns\Layout\Stack::make([
+                            Tables\Columns\TextColumn::make('description')
+                                ->weight(FontWeight::Bold),
+                            Tables\Columns\TextColumn::make('identifier')
+                                ->color(Color::Gray),
+                            Tables\Columns\TextColumn::make('options')
+                                ->getStateUsing(fn ($record) => $record->purchasable?->getOptions())
+                                ->badge(),
+                        ]),
+                        Tables\Columns\Layout\Stack::make([
+                            Tables\Columns\TextColumn::make('unit')
+                                ->alignEnd()
+                                ->getStateUsing(fn ($record) => "{$record->quantity} @ {$record->sub_total->formatted}"),
+                        ]),
                     ])
-                    ->extraAttributes(['style' => 'align-items: start;']),
+                        ->extraAttributes(['style' => 'align-items: start;']),
                 ])
                     ->columnSpanFull(),
             ])->extraAttributes(['style' => 'align-items: start;']),
             Tables\Columns\Layout\Panel::make([
                 Tables\Columns\Layout\Stack::make([
                     Tables\Columns\TextColumn::make('stock')
-                    ->getStateUsing(fn ($record) => $record->purchasable?->stock)
-                    ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.current_stock_level.message', [
-                        'count' => $state,
-                    ]))
-                    ->colors(fn () => [
-                        'danger' => fn ($state) => $state < 50,
-                        'success' => fn ($state) => $state >= 50,
-                    ]),
+                        ->getStateUsing(fn ($record) => $record->purchasable?->stock)
+                        ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.current_stock_level.message', [
+                            'count' => $state,
+                        ]))
+                        ->colors(fn () => [
+                            'danger' => fn ($state) => $state < 50,
+                            'success' => fn ($state) => $state >= 50,
+                        ]),
                     Tables\Columns\TextColumn::make('meta.stock_level')
-                    ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.purchase_stock_level.message', [
-                        'count' => $state,
-                    ]))
-                    ->color(Color::Gray),
+                        ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.purchase_stock_level.message', [
+                            'count' => $state,
+                        ]))
+                        ->color(Color::Gray),
                     Tables\Columns\TextColumn::make('notes')
-                    ->description(new HtmlString('<b>'.__('lunarpanel::order.infolist.notes.label').'</b>'), 'above'),
+                        ->description(new HtmlString('<b>'.__('lunarpanel::order.infolist.notes.label').'</b>'), 'above'),
 
                     KeyValue::make('price_breakdowns')
-                    ->getStateUsing(function ($record) {
+                        ->getStateUsing(function ($record) {
 
-                        $states = [];
+                            $states = [];
 
-                        $states['unit_price'] = "{$record->unit_price->unitFormatted(decimalPlaces: 4)}";
-                        $states['quantity'] = $record->quantity;
-                        $states['sub_total'] = $record->sub_total?->formatted;
-                        $states['discount_total'] = $record->discount_total?->formatted;
+                            $states['unit_price'] = "{$record->unit_price->unitFormatted(decimalPlaces: 4)}";
+                            $states['quantity'] = $record->quantity;
+                            $states['sub_total'] = $record->sub_total?->formatted;
+                            $states['discount_total'] = $record->discount_total?->formatted;
 
-                        foreach ($record->tax_breakdown?->amounts ?? [] as $tax) {
-                            $states[$tax->description] = $tax->price->formatted;
-                        }
+                            foreach ($record->tax_breakdown?->amounts ?? [] as $tax) {
+                                $states[$tax->description] = $tax->price->formatted;
+                            }
 
-                        $states['total'] = $record->total?->formatted;
+                            $states['total'] = $record->total?->formatted;
 
-                        return $states;
-                    }),
+                            return $states;
+                        }),
                 ]),
             ])
                 ->collapsed()

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -6,37 +6,27 @@ use Awcodes\Shout\Components\Shout;
 use Awcodes\Shout\Components\ShoutEntry;
 use Closure;
 use Filament\Actions;
-use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Infolists;
 use Filament\Infolists\Components\Actions\Action;
 use Filament\Infolists\Components\TextEntry\TextEntrySize;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
-use Filament\Support\Colors\Color;
 use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\FontWeight;
-use Filament\Support\Enums\IconPosition;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\Arr;
-use Illuminate\Support\HtmlString;
 use Livewire\Attributes\Computed;
 use Lunar\Admin\Filament\Resources\CustomerResource;
 use Lunar\Admin\Filament\Resources\OrderResource;
 use Lunar\Admin\Support\Actions\Orders\UpdateStatusAction;
 use Lunar\Admin\Support\Actions\PdfDownload;
 use Lunar\Admin\Support\ActivityLog\Concerns\CanDispatchActivityUpdated;
+use Lunar\Admin\Support\Concerns\CallsHooks;
 use Lunar\Admin\Support\Forms\Components\Tags as TagsComponent;
 use Lunar\Admin\Support\Infolists\Components\Livewire;
 use Lunar\Admin\Support\Infolists\Components\Tags;
-use Lunar\Admin\Support\Infolists\Components\Timeline;
-use Lunar\Admin\Support\Infolists\Components\Transaction as InfolistsTransaction;
-use Lunar\Admin\Support\OrderStatus;
 use Lunar\Admin\Support\Pages\BaseViewRecord;
-use Lunar\DataTypes\Price;
-use Lunar\Models\Country;
-use Lunar\Models\State;
 use Lunar\Models\Tag;
 use Lunar\Models\Transaction;
 
@@ -56,7 +46,14 @@ use Lunar\Models\Transaction;
  */
 class ManageOrder extends BaseViewRecord
 {
+    use CallsHooks;
     use CanDispatchActivityUpdated;
+    use OrderResource\Concerns\DisplaysOrderAddresses;
+    use OrderResource\Concerns\DisplaysOrderSummary;
+    use OrderResource\Concerns\DisplaysOrderTimeline;
+    use OrderResource\Concerns\DisplaysOrderTotals;
+    use OrderResource\Concerns\DisplaysShippingInfo;
+    use OrderResource\Concerns\DisplaysTransactions;
 
     protected static string $resource = OrderResource::class;
 
@@ -80,208 +77,6 @@ class ManageOrder extends BaseViewRecord
     {
         return Livewire::make('lines')
             ->content(OrderResource\Pages\Components\OrderItemsTable::class);
-    }
-
-    public static function getShippingInfolist(): Infolists\Components\Section
-    {
-        return Infolists\Components\Section::make()
-            ->schema([
-                Infolists\Components\RepeatableEntry::make('shippingLines')
-                    ->hiddenLabel()
-                    ->contained(false)
-                    ->columns(2)
-                    ->columnSpan(12)
-                    ->schema([
-                        Infolists\Components\TextEntry::make('description')
-                            ->icon('heroicon-s-truck')
-                            ->html()
-                            ->iconPosition(IconPosition::Before)
-                            ->hiddenLabel(),
-                        Infolists\Components\TextEntry::make('sub_total')
-                            ->hiddenLabel()
-                            ->alignEnd()
-                            ->formatStateUsing(fn ($state) => $state->formatted),
-                        Infolists\Components\TextEntry::make('notes')
-                            ->hidden(
-                                fn ($state) => ! $state
-                            )
-                            ->placeholder(
-                                __('lunarpanel::order.infolist.notes.placeholder')
-                            ),
-                    ]),
-            ]);
-    }
-
-    public static function getOrderTotalsInfolist(): Infolists\Components\Component
-    {
-        return Infolists\Components\Section::make()
-            ->schema([
-                Infolists\Components\Grid::make()
-                    ->columns(2)
-                    ->schema([
-                        Infolists\Components\Grid::make()
-                            ->columns(1)
-                            ->columnSpan(1)
-                            ->schema([
-                                Infolists\Components\TextEntry::make('shippingAddress.delivery_instructions')
-                                    ->label(__('lunarpanel::order.infolist.delivery_instructions.label'))
-                                    ->hidden(fn ($state) => blank($state)),
-                                Infolists\Components\TextEntry::make('notes')
-                                    ->label(__('lunarpanel::order.infolist.notes.label'))
-                                    ->placeholder(__('lunarpanel::order.infolist.notes.placeholder')),
-                            ]),
-                        Infolists\Components\Grid::make()
-                            ->columns(1)
-                            ->columnSpan(1)
-                            ->schema([
-                                Infolists\Components\TextEntry::make('sub_total')
-                                    ->label(__('lunarpanel::order.infolist.sub_total.label'))
-                                    ->inlineLabel()
-                                    ->alignEnd()
-                                    ->formatStateUsing(fn ($state) => $state->formatted),
-                                Infolists\Components\TextEntry::make('discount_total')
-                                    ->label(__('lunarpanel::order.infolist.discount_total.label'))
-                                    ->inlineLabel()
-                                    ->alignEnd()
-                                    ->formatStateUsing(fn ($state) => $state->formatted),
-                                Infolists\Components\Group::make()
-                                    ->statePath('shipping_breakdown')
-                                    ->schema(function ($state) {
-                                        $shipping = [];
-                                        foreach ($state->items ?? [] as $shippingIndex => $shippingItem) {
-                                            $shipping[] = Infolists\Components\TextEntry::make('shipping_'.$shippingIndex)
-                                                ->label(fn () => $shippingItem->name)
-                                                ->inlineLabel()
-                                                ->alignEnd()
-                                                ->state(fn () => $shippingItem->price->formatted);
-                                        }
-
-                                        return $shipping;
-                                    }),
-
-                                Infolists\Components\Group::make()
-                                    ->statePath('tax_breakdown')
-                                    ->schema(function ($state) {
-                                        $taxes = [];
-                                        foreach ($state->amounts ?? [] as $taxIndex => $tax) {
-                                            $taxes[] = Infolists\Components\TextEntry::make('tax_'.$taxIndex)
-                                                ->label(fn () => $tax->description)
-                                                ->inlineLabel()
-                                                ->alignEnd()
-                                                ->state(fn () => $tax->price->formatted);
-                                        }
-
-                                        return $taxes;
-                                    }),
-                                Infolists\Components\TextEntry::make('total')
-                                    ->label(fn () => new HtmlString('<b>'.__('lunarpanel::order.infolist.total.label').'</b>'))
-                                    ->inlineLabel()
-                                    ->alignEnd()
-                                    ->weight(FontWeight::Bold)
-                                    ->formatStateUsing(fn ($state) => $state->formatted),
-                                Infolists\Components\TextEntry::make('paid')
-                                    ->label(fn () => __('lunarpanel::order.infolist.paid.label'))
-                                    ->inlineLabel()
-                                    ->alignEnd()
-                                    ->weight(FontWeight::SemiBold)
-                                    ->getStateUsing(function ($record) {
-                                        $paid = $record->transactions()
-                                            ->whereType('capture')
-                                            ->whereSuccess(true)
-                                            ->get()
-                                            ->sum('amount.value');
-
-                                        return (new Price($paid, $record->currency))->formatted;
-                                    }),
-                                Infolists\Components\TextEntry::make('refund')
-                                    ->label(fn () => __('lunarpanel::order.infolist.refund.label'))
-                                    ->inlineLabel()
-                                    ->alignEnd()
-                                    ->color('warning')
-                                    ->weight(FontWeight::SemiBold)
-                                    ->getStateUsing(function ($record) {
-                                        $paid = $record->transactions()
-                                            ->whereType('refund')
-                                            ->get()
-                                            ->sum('amount.value');
-
-                                        return (new Price($paid, $record->currency))->formatted;
-                                    }),
-                            ]),
-                    ]),
-            ]);
-    }
-
-    public static function getTransactionsInfolist(): Infolists\Components\Component
-    {
-        return Infolists\Components\Section::make('transactions')
-            ->heading(__('lunarpanel::order.infolist.transactions.label'))
-            ->compact()
-            ->collapsed(fn ($state) => filled($state))
-            ->collapsible(fn ($state) => filled($state))
-            ->schema([
-                Infolists\Components\RepeatableEntry::make('transactions')
-                    ->hiddenLabel()
-                    ->placeholder(__('lunarpanel::order.infolist.transactions.placeholder'))
-                    ->getStateUsing(fn ($record) => $record->transactions)
-                    ->contained(false)
-                    ->schema([
-                        InfolistsTransaction::make('transactions'),
-                    ]),
-            ]);
-    }
-
-    public static function getTimelineInfolist(): Infolists\Components\Component
-    {
-        return Infolists\Components\Grid::make()
-            ->schema([
-                Timeline::make('timeline')
-                    ->label(__('lunarpanel::order.infolist.timeline.label')),
-            ]);
-    }
-
-    public static function getOrderSummaryInfolist(): Infolists\Components\Component
-    {
-        return Infolists\Components\Section::make()
-            ->compact()
-            ->inlineLabel()
-            ->schema([
-                Infolists\Components\TextEntry::make('new_customer')
-                    ->label(__('lunarpanel::order.infolist.new_returning.label'))
-                    ->alignEnd()
-                    ->formatStateUsing(fn ($state) => __('lunarpanel::order.infolist.'.($state ? 'new' : 'returning').'_customer.label')),
-                Infolists\Components\TextEntry::make('status')
-                    ->label(__('lunarpanel::order.infolist.status.label'))
-                    ->formatStateUsing(fn ($state) => OrderStatus::getLabel($state))
-                    ->alignEnd()
-                    ->color(fn ($state) => OrderStatus::getColor($state))
-                    ->badge(),
-                Infolists\Components\TextEntry::make('reference')
-                    ->label(__('lunarpanel::order.infolist.reference.label'))
-                    ->alignEnd()
-                    ->icon('heroicon-o-clipboard')
-                    ->iconPosition(IconPosition::After)
-                    ->copyable(),
-                Infolists\Components\TextEntry::make('customer_reference')
-                    ->label(__('lunarpanel::order.infolist.customer_reference.label'))
-                    ->alignEnd()
-                    ->icon('heroicon-o-clipboard')
-                    ->iconPosition(IconPosition::After)
-                    ->copyable(),
-                Infolists\Components\TextEntry::make('channel.name')
-                    ->label(__('lunarpanel::order.infolist.channel.label'))
-                    ->alignEnd(),
-                Infolists\Components\TextEntry::make('created_at')
-                    ->label(__('lunarpanel::order.infolist.date_created.label'))
-                    ->alignEnd()
-                    ->dateTime('Y-m-d h:i a')
-                    ->visible(fn ($record) => ! $record->placed_at),
-                Infolists\Components\TextEntry::make('placed_at')
-                    ->label(__('lunarpanel::order.infolist.date_placed.label'))
-                    ->alignEnd()
-                    ->dateTime('Y-m-d h:i a')
-                    ->placeholder('-'),
-            ]);
     }
 
     public function getDefaultInfolist(Infolist $infolist): Infolist
@@ -333,8 +128,10 @@ class ManageOrder extends BaseViewRecord
                                 ->size(ActionSize::ExtraSmall)
                                 ->url(CustomerResource::getUrl('edit', ['record' => $state->id]))),
                         static::getOrderSummaryInfolist(),
-                        $this->getOrderAddressInfolistSchema('shipping'),
-                        $this->getOrderAddressInfolistSchema('billing'),
+                        static::getShippingAddressInfolist(),
+                        static::getBillingAddressInfoList(),
+                        //                        $this->getOrderAddressInfolistSchema('shipping'),
+                        //                        $this->getOrderAddressInfolistSchema('billing'),
                         Infolists\Components\Section::make('tags')
                             ->heading(__('lunarpanel::order.infolist.tags.label'))
                             ->headerActions([
@@ -473,95 +270,6 @@ class ManageOrder extends BaseViewRecord
         })->sum('amount.value');
     }
 
-    private function isShippingEqualsBilling($shippingAddress, $billingAddress): bool
-    {
-        if (! $shippingAddress || ! $billingAddress) {
-            return false;
-        }
-
-        $fieldsToCheck = Arr::except(
-            $billingAddress->getAttributes(),
-            ['id', 'created_at', 'updated_at', 'order_id', 'type', 'meta']
-        );
-
-        // Is the same until proven otherwise
-        $isSame = true;
-
-        foreach ($fieldsToCheck as $field => $value) {
-            if ($shippingAddress->getAttribute($field) != $value) {
-                $isSame = false;
-            }
-        }
-
-        return $isSame;
-    }
-
-    public function getOrderAddressInfolistSchema(string $type)
-    {
-        $sameAsShipping = fn ($record) => $type == 'billing' && $this->isShippingEqualsBilling($record->shippingAddress, $record->billingAddress);
-
-        $getAddress = fn ($record) => match ($type) {
-            'billing' => $record->billingAddress,
-            'shipping' => $record->shippingAddress,
-            default => null,
-        };
-
-        return Infolists\Components\Section::make(__("lunarpanel::order.infolist.{$type}_address.label"))
-            ->statePath($type.'Address')
-            ->compact()
-            ->headerActions([
-                fn ($record) => $this->getEditAddressAction($type)->hidden($sameAsShipping($record)),
-            ])
-            ->schema(fn ($record) => $sameAsShipping($record) ? [
-                Infolists\Components\TextEntry::make('billing_matches_shipping')
-                    ->hiddenLabel()
-                    ->weight(FontWeight::SemiBold)
-                    ->getStateUsing(fn () => __('lunarpanel::order.infolist.billing_matches_shipping.label')),
-
-            ] : [
-                Infolists\Components\TextEntry::make($type.'_address')
-                    ->hiddenLabel()
-                    ->listWithLineBreaks()
-                    ->getStateUsing(function ($record) use ($getAddress) {
-                        $address = $getAddress($record);
-
-                        if ($address?->id ?? false) {
-                            return collect([
-                                'company_name' => $address->company_name,
-                                'fullName' => $address->fullName,
-                                'line_one' => $address->line_one,
-                                'line_two' => $address->line_two,
-                                'line_three' => $address->line_three,
-                                'city' => $address->city,
-                                'state' => $address->state,
-                                'postcode' => $address->postcode,
-                                'country.name' => $address->country->name,
-                            ])
-                                ->filter(fn ($value, $key) => filled($value) || in_array($key, [
-                                    'fullName', 'line_one', 'postcode', 'country.name',
-                                ]))
-                                ->toArray();
-                        } else {
-                            return __('lunarpanel::order.infolist.address_not_set.label');
-                        }
-                    }),
-                Infolists\Components\TextEntry::make($type.'_phone')
-                    ->hiddenLabel()
-                    ->icon('heroicon-o-phone')
-                    ->getStateUsing(fn ($record) => $getAddress($record)?->contact_phone ?? '-')
-                    ->url(fn ($state) => $state !== '-' ? 'tel:'.$state : false)
-                    ->color(fn ($state) => $state !== '-' ? Color::Sky : null)
-                    ->iconColor(fn ($state) => $state !== '-' ? Color::Green : null),
-                Infolists\Components\TextEntry::make($type.'_email')
-                    ->hiddenLabel()
-                    ->icon('heroicon-o-envelope')
-                    ->getStateUsing(fn ($record) => $getAddress($record)?->contact_email ?? '-')
-                    ->url(fn ($state) => $state !== '-' ? 'mailto:'.$state : false)
-                    ->color(fn ($state) => $state !== '-' ? Color::Sky : null)
-                    ->iconColor(fn ($state) => $state !== '-' ? Color::Amber : null),
-            ]);
-    }
-
     public function getEditTagsActions(): Action
     {
         return Action::make('edit_tags')
@@ -580,135 +288,6 @@ class ManageOrder extends BaseViewRecord
             })->action(function (Action $action, $record, $data) {
                 $this->dispatchActivityUpdated();
             });
-    }
-
-    public function getEditAddressAction(string $type): Action
-    {
-        return Action::make("edit_{$type}_address")
-            ->modalHeading(__("lunarpanel::order.infolist.{$type}_address.label"))
-            ->modalWidth('2xl')
-            ->label(__('lunarpanel::order.action.edit_address.label'))
-            ->button()
-            ->fillForm(fn ($record) => match ($type) {
-                'shipping' => $record->shippingAddress->toArray(),
-                'billing' => $record->billingAddress->toArray(),
-                default => []
-            })
-            ->form(function () {
-                return [
-                    Forms\Components\Grid::make()
-                        ->schema([
-                            Forms\Components\TextInput::make('first_name')
-                                ->label(__('lunarpanel::order.form.address.first_name.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255)
-                                ->required(),
-                            Forms\Components\TextInput::make('last_name')
-                                ->label(__('lunarpanel::order.form.address.last_name.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255),
-                        ]),
-                    Forms\Components\TextInput::make('company_name')
-                        ->label(__('lunarpanel::order.form.address.company_name.label'))
-                        ->autocomplete(false)
-                        ->maxLength(255),
-                    Forms\Components\Grid::make()
-                        ->schema([
-                            Forms\Components\TextInput::make('contact_phone')
-                                ->label(__('lunarpanel::order.form.address.contact_phone.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255),
-                            Forms\Components\TextInput::make('contact_email')
-                                ->label(__('lunarpanel::order.form.address.contact_email.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255),
-                        ]),
-                    Forms\Components\TextInput::make('line_one')
-                        ->label(__('lunarpanel::order.form.address.line_one.label'))
-                        ->autocomplete(false)
-                        ->maxLength(255)
-                        ->required(),
-                    Forms\Components\Grid::make()
-                        ->schema([
-                            Forms\Components\TextInput::make('line_two')
-                                ->label(__('lunarpanel::order.form.address.line_two.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255),
-                            Forms\Components\TextInput::make('line_three')
-                                ->label(__('lunarpanel::order.form.address.line_three.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255),
-                        ]),
-                    Forms\Components\Grid::make(3)
-                        ->schema([
-                            Forms\Components\TextInput::make('city')
-                                ->label(__('lunarpanel::order.form.address.city.label'))
-                                ->maxLength(255)
-                                ->autocomplete(false)
-                                ->required(),
-                            Forms\Components\TextInput::make('state')
-                                ->label(__('lunarpanel::order.form.address.state.label'))
-                                ->autocomplete('state') // to disable browser input history while keeping datalist
-                                ->datalist(fn ($get) => State::whereCountryId($get('country_id'))->pluck('name')->toArray())
-                                ->maxLength(255),
-                            Forms\Components\TextInput::make('postcode')
-                                ->label(__('lunarpanel::order.form.address.postcode.label'))
-                                ->autocomplete(false)
-                                ->maxLength(255),
-                        ]),
-                    Forms\Components\Select::make('country_id')
-                        ->label(__('lunarpanel::order.form.address.country_id.label'))
-                        ->options(fn () => Country::get()->pluck('name', 'id'))
-                        ->live()
-                        ->searchable()
-                        ->required(),
-                ];
-            })
-            ->action(function (Action $action, $record, $data) use ($type) {
-                $addressType = match ($type) {
-                    'shipping' => 'shippingAddress',
-                    'billing' => 'billingAddress',
-                    default => null,
-                };
-
-                if (blank($addressType)) {
-                    $action->failureNotificationTitle(__('lunarpanel::order.action.edit_address.notification.error'));
-                    $action->failure();
-
-                    $action->halt();
-
-                    return;
-                }
-
-                $oldData = $record->$addressType->toArray();
-                $formFields = array_keys($data);
-
-                $record->$addressType->order_id = $record->id;
-                $record->$addressType->update($data);
-                $refreshed = $record->$addressType->refresh();
-
-                // should this be in Core as model observer?
-                $diff = collect($oldData)->only($formFields)->diff(collect($refreshed->toArray())->only($formFields));
-                if ($diff->count()) {
-                    activity()
-                        ->causedBy(Filament::auth()->user())
-                        ->performedOn($record)
-                        ->event('order-address-update')
-                        ->withProperties([
-                            'fields' => $formFields,
-                            'type' => $addressType,
-                            'new' => $record->$addressType->toArray(),
-                            'previous' => $oldData,
-                        ])->log('order-address-update');
-
-                    $this->dispatchActivityUpdated();
-                }
-
-                $action->successNotificationTitle(__("lunarpanel::order.action.edit_address.notification.{$type}_address.saved"));
-
-                $action->success();
-            })
-            ->slideOver();
     }
 
     protected function getDefaultHeaderActions(): array

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -90,6 +90,18 @@ class ManageOrder extends BaseViewRecord
         ]);
     }
 
+    public static function getInfolistAsideSchema(): array
+    {
+        return self::callLunarHook('extendInfolistAsideSchema', [
+            static::getCustomerEntry(),
+            static::getOrderSummaryInfolist(),
+            static::getShippingAddressInfolist(),
+            static::getBillingAddressInfoList(),
+            static::getTagsSection(),
+            static::getAdditionalInfoSection(),
+        ]);
+    }
+
     public static function getDefaultCustomerEntry(): Infolists\Components\Entry
     {
         return Infolists\Components\TextEntry::make('customer')
@@ -195,14 +207,7 @@ class ManageOrder extends BaseViewRecord
                     ])
                     ->columnSpan(['lg' => 2]),
                 Infolists\Components\Group::make()
-                    ->schema([
-                        static::getCustomerEntry(),
-                        static::getOrderSummaryInfolist(),
-                        static::getShippingAddressInfolist(),
-                        static::getBillingAddressInfoList(),
-                        static::getTagsSection(),
-                        static::getAdditionalInfoSection(),
-                    ])
+                    ->schema(static::getInfolistAsideSchema())
                     ->columnSpan(['lg' => 1]),
             ])
             ->columns(3);


### PR DESCRIPTION
This PR looks to shake up the order screen so it's possible for a developer to extend each component to make it their own.

Currently it's only possible to customise a small subset of components when viewing an order, however it would be useful to be able to have a lot more control as a developer.

## Extending `ManageOrder`

```
\Lunar\Facades\LunarPanel::extensions([
    \Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder::class => ManageOrderExtension::class
]);
```
### Available Methods

- `extendInfolistSchema(): array`

- `extendInfolistAsideSchema(): array`
  - `extendCustomerEntry(): Infolists\Components\Component`
  - `extendTagsSection(): Infolists\Components\Component`
  - `extendAdditionalInfoSection(): Infolists\Components\Component`
  - `extendShippingAddressInfolist(): Infolists\Components\Component`
  - `extendBillingAddressInfolist(): Infolists\Components\Component`
  -  `extendAddressEditSchema(): array`

- `exendOrderSummaryInfolist(): Infolists\Components\Section`
- `extendOrderSummarySchema(): array` 
  - `extendOrderSummaryNewCustomerEntry(): Infolists\Components\Entry`
  - `extendOrderSummaryStatusEntry(): Infolists\Components\Entry`
  - `extendOrderSummaryReferenceEntry(): Infolists\Components\Entry`
  - `extendOrderSummaryCustomerReferenceEntry(): Infolists\Components\Entry`
  - `extendOrderSummaryChannelEntry(): Infolists\Components\Entry`
  - `extendOrderSummaryCreatedAtEntry(): Infolists\Components\Entry`
  - `extendOrderSummaryPlacedAtEntry(): Infolists\Components\Entry`
- `extendTimelineInfolist(): Infolists\Components\Component`
- `extendOrderTotalsAsideSchema(): array`
  - `extendDeliveryInstructionsEntry(): Infolists\Components\TextEntry`
  - `extendOrderNotesEntry(): Infolists\Components\TextEntry`
- `extendOrderTotalsInfolist(): Infolists\Components\Section`
- `extendOrderTotalsSchema(): array`
  - `extendSubTotalEntry(): Infolists\Components\TextEntry`
  - `extendDiscountTotalEntry(): Infolists\Components\TextEntry`
  - `extendShippingBreakdownGroup(): Infolists\Components\Group`
  - `extendTaxBreakdownGroup(): Infolists\Components\Group`
  - `extendTotalEntry(): Infolists\Components\TextEntry`
  - `extendPaidEntry(): Infolists\Components\TextEntry`
  - `extendRefundEntry(): Infolists\Components\TextEntry`

- `extendShippingInfolist(): Infolists\Components\Section`
- `extendTransactionsInfolist(): Infolists\Components\Component`
- `extendTransactionsRepeatableEntry(): Infolists\Components\RepeatableEntry`

## Extending `OrderItemsTable`

```
\Lunar\Facades\LunarPanel::extensions([
    \Lunar\Admin\Filament\Resources\OrderResource\Pages\Components\OrderItemsTable::class => OrderItemsTableExtension::class
]);
```
### Available Methods

- `extendOrderLinesTableColumns(): array`
- `extendTable(): Table`
