### PR TITLE
Fixes attribute description migration in postgresql

### DIFF
--- a/packages/core/database/migrations/2024_01_11_100000_add_description_to_attributes_table.php
+++ b/packages/core/database/migrations/2024_01_11_100000_add_description_to_attributes_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table($this->prefix.'attributes', function (Blueprint $table) {
-            $table->json('description')->after('name')->nullable(true);
+            $table->json('description')->after('name')->nullable();
         });
     }
 

--- a/packages/core/database/migrations/2024_01_11_100000_add_description_to_attributes_table.php
+++ b/packages/core/database/migrations/2024_01_11_100000_add_description_to_attributes_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table($this->prefix.'attributes', function (Blueprint $table) {
-            $table->json('description')->after('name');
+            $table->json('description')->after('name')->nullable(true);
         });
     }
 


### PR DESCRIPTION
fixes #1850 

Tested manually against postgresql 15

- Makes the column explicitly nullable to prevent migration failure for existing projects using Postgresql.
