### PR TITLE
Fixes postgres compatibility

### DIFF
--- a/packages/core/database/state/PopulateProductOptionLabelWithName.php
+++ b/packages/core/database/state/PopulateProductOptionLabelWithName.php
@@ -20,8 +20,7 @@ class PopulateProductOptionLabelWithName
         }
 
         DB::transaction(function () {
-            ProductOption::where('label', '')
-                ->orWhereNull('label')
+            ProductOption::whereNull('label')
                 ->update([
                     'label' => DB::raw('name'),
                 ]);
@@ -37,6 +36,6 @@ class PopulateProductOptionLabelWithName
 
     protected function shouldRun()
     {
-        return ProductOption::whereJsonLength('label', 0)->count() > 0;
+        return ProductOption::whereNull('label')->count() > 0;
     }
 }


### PR DESCRIPTION
fixes #1849 so that Lunar can be upgraded without issue using PostgreSQL.

This has only been manually testing against Postgres 15.

The intent of the original version was, no doubt, to be more robust than a simple null check. However the case of a non-valid, non-null value existing in the product_options.label seems to be beyond the scope of a simple script meant to backfill new columns with default data.

Implementing a check for an empty object or non-object value is tricky without writting different checks for each DB engines.
