### PR TITLE
Fix cart id hanging around in the session when not cleared

### DIFF
--- a/docs/core/reference/carts.md
+++ b/docs/core/reference/carts.md
@@ -220,10 +220,16 @@ Configuration for your cart is handled in `lunar/cart.php`
 
 | Field         | Description                                                                            | Default      |
 |:--------------|:---------------------------------------------------------------------------------------|:-------------|
-| `session_key` | What key to use when storing the cart id in the session                                | `lunar_cart` |
-| `auto_create` | If no current basket exists, should we create one in the database?                     | `false`      |
 | `auth_policy` | When a user logs in, how should we handle merging of the basket?                       | `merge`      |
 | `eager_load`  | Which relationships should be eager loaded by default when calculating the cart totals |
+
+There is additional, separate, config specifically for when using the `CartSession` located in `lunar/cart_session.php`.
+
+| Field                            | Description                                                        | Default      |
+|:---------------------------------|:-------------------------------------------------------------------|:-------------|
+| `session_key`                    | What key to use when storing the cart id in the session            | `lunar_cart` |
+| `auto_create`                    | If no current basket exists, should we create one in the database? | `false`      |
+| `allow_multiple_orders_per_cart` | Whether carts can have multiple orders associated to them.         | `false`      |
 
 ### Getting the cart session instance
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,7 +18,7 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
-## 1.0.0-alpha.x
+## 1.0.0-alpha.31
 
 ### High Impact
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,6 +18,19 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
+## 1.0.0-alpha.x
+
+### High Impact
+
+Certain parts of `config/cart.php` which are more specific to when you are interacting with carts via the session have been relocated to a new `config/cart_session.php` file.
+
+```php
+// Move to config/cart_session.php
+'session_key' => 'lunar_cart',
+'auto_create' => false,
+```
+
+You should also check this file for any new config values you may need to add.
 
 ## 1.0.0-alpha.29
 

--- a/packages/core/config/cart.php
+++ b/packages/core/config/cart.php
@@ -3,17 +3,6 @@
 use Lunar\Actions\Carts\GenerateFingerprint;
 
 return [
-
-    /*
-    |--------------------------------------------------------------------------
-    | Session Key
-    |--------------------------------------------------------------------------
-    |
-    | Specify the session key used when fetching the cart.
-    |
-    */
-    'session_key' => 'lunar_cart',
-
     /*
     |--------------------------------------------------------------------------
     | Fingerprint Generator
@@ -23,20 +12,6 @@ return [
     |
     */
     'fingerprint_generator' => GenerateFingerprint::class,
-
-    /*
-    |--------------------------------------------------------------------------
-    | Auto create a cart when none exists for user.
-    |--------------------------------------------------------------------------
-    |
-    | Determines whether you want to automatically create a cart for a user if
-    | they do not currently have one in the session. By default this is false
-    | to minimise the amount of cart lines added to the database.
-    |
-    */
-    'auto_create' => false,
-
-    'allow_multiple_per_order' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/core/config/cart.php
+++ b/packages/core/config/cart.php
@@ -36,6 +36,8 @@ return [
     */
     'auto_create' => false,
 
+    'allow_multiple_per_order' => false,
+
     /*
     |--------------------------------------------------------------------------
     | Authentication policy

--- a/packages/core/config/cart_session.php
+++ b/packages/core/config/cart_session.php
@@ -17,8 +17,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Determines whether you want to automatically create a cart for a user if
-    | they do not currently have one in the session. By default this is false
-    | to minimise the amount of cart lines added to the database.
+    | they do not currently have one in the session. By default, this is false
+    | to minimise the amount of carts added to the database.
     |
     */
     'auto_create' => false,
@@ -29,7 +29,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Determines whether the same cart instance will be returned if there is already
-    | a completed orders associated to the cart which is retrieved in the session.
+    | a completed order associated to the cart which is retrieved in the session.
     | When set to false, if a cart has a completed order, then a new instance
     | of a cart will be returned, even if auto_create is set to false
     |

--- a/packages/core/config/cart_session.php
+++ b/packages/core/config/cart_session.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Session Key
+    |--------------------------------------------------------------------------
+    |
+    | Specify the session key used when fetching the cart.
+    |
+    */
+    'session_key' => 'lunar_cart',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto create a cart when none exists for user.
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether you want to automatically create a cart for a user if
+    | they do not currently have one in the session. By default this is false
+    | to minimise the amount of cart lines added to the database.
+    |
+    */
+    'auto_create' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allow Carts to have multiple orders associated.
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether the same cart instance will be returned if there is already
+    | a completed orders associated to the cart which is retrieved in the session.
+    | When set to false, if a cart has a completed order, then a new instance
+    | of a cart will be returned, even if auto_create is set to false
+    |
+    */
+    'allow_multiple_orders_per_cart' => false,
+];

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -92,6 +92,7 @@ class LunarServiceProvider extends ServiceProvider
 {
     protected $configFiles = [
         'cart',
+        'cart_session',
         'database',
         'media',
         'orders',

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -135,6 +135,10 @@ class CartSessionManager implements CartSessionInterface
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
+        if ($cart->hasCompletedOrders() && !config('lunar.cart.allow_multiple_per_order', false)) {
+            return $this->createNewCart();
+        }
+
         if (! $cart) {
             return $create ? $this->createNewCart() : null;
         }

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -31,7 +31,7 @@ class CartSessionManager implements CartSessionInterface
     public function current(bool $estimateShipping = false, bool $calculate = true): ?Cart
     {
         return $this->fetchOrCreate(
-            config('lunar.cart.auto_create', false),
+            config('lunar.cart_session.auto_create', false),
             estimateShipping: $estimateShipping,
             calculate: $calculate,
         );

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -25,6 +25,11 @@ class CartSessionManager implements CartSessionInterface
         //
     }
 
+    public function allowsMultipleOrdersPerCart(): bool
+    {
+        return config('lunar.cart.allow_multiple_per_order', false);
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -135,7 +140,7 @@ class CartSessionManager implements CartSessionInterface
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
-        if ($cart->hasCompletedOrders() && ! config('lunar.cart.allow_multiple_per_order', false)) {
+        if ($cart->hasCompletedOrders() && !$this->allowsMultipleOrdersPerCart()) {
             return $this->createNewCart();
         }
 
@@ -236,12 +241,12 @@ class CartSessionManager implements CartSessionInterface
 
     /**
      * Create an order from a cart instance.
-     *
-     * @param  bool  $forget
      */
-    public function createOrder($forget = true): Order
+    public function createOrder(bool $forget = true): Order
     {
-        $order = $this->manager()->createOrder();
+        $order = $this->manager()->createOrder(
+            allowMultipleOrders: $this->allowsMultipleOrdersPerCart()
+        );
 
         if ($forget) {
             $this->forget();
@@ -252,10 +257,8 @@ class CartSessionManager implements CartSessionInterface
 
     /**
      * Create a new cart instance.
-     *
-     * @return \Lunar\Models\Cart
      */
-    protected function createNewCart()
+    protected function createNewCart(): Cart
     {
         $user = $this->authManager->user();
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -135,7 +135,7 @@ class CartSessionManager implements CartSessionInterface
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
-        if ($cart->hasCompletedOrders() && !config('lunar.cart.allow_multiple_per_order', false)) {
+        if ($cart->hasCompletedOrders() && ! config('lunar.cart.allow_multiple_per_order', false)) {
             return $this->createNewCart();
         }
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -140,7 +140,7 @@ class CartSessionManager implements CartSessionInterface
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
-        if ($cart->hasCompletedOrders() && !$this->allowsMultipleOrdersPerCart()) {
+        if ($cart->hasCompletedOrders() && ! $this->allowsMultipleOrdersPerCart()) {
             return $this->createNewCart();
         }
 

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -177,7 +177,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function getSessionKey(): string
     {
-        return config('lunar.cart.session_key');
+        return config('lunar.cart_session.session_key');
     }
 
     /**

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -27,7 +27,7 @@ class CartSessionManager implements CartSessionInterface
 
     public function allowsMultipleOrdersPerCart(): bool
     {
-        return config('lunar.cart.allow_multiple_per_order', false);
+        return config('lunar.cart_session.allow_multiple_per_order', false);
     }
 
     /**

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -43,6 +43,7 @@ use Lunar\Facades\ShippingManifest;
 use Lunar\Pipelines\Cart\Calculate;
 use Lunar\Validation\Cart\ValidateCartForOrderCreation;
 use Lunar\Validation\CartLine\CartLineStock;
+use Throwable;
 
 /**
  * @property int $id
@@ -465,6 +466,7 @@ class Cart extends BaseModel
 
     /**
      * Associate a user to the cart
+     * @throws Exception
      */
     public function associate(User $user, string $policy = 'merge', bool $refresh = true): Cart
     {
@@ -643,7 +645,7 @@ class Cart extends BaseModel
     /**
      * Check whether a given fingerprint matches the one being generated for the cart.
      *
-     * @throws FingerprintMismatchException
+     * @throws FingerprintMismatchException|Throwable
      */
     public function checkFingerprint(string $fingerprint): bool
     {

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -466,6 +466,7 @@ class Cart extends BaseModel
 
     /**
      * Associate a user to the cart
+     *
      * @throws Exception
      */
     public function associate(User $user, string $policy = 'merge', bool $refresh = true): Cart

--- a/tests/core/Unit/Managers/CartSessionManagerTest.php
+++ b/tests/core/Unit/Managers/CartSessionManagerTest.php
@@ -11,7 +11,9 @@ use Lunar\Models\CartAddress;
 use Lunar\Models\Channel;
 use Lunar\Models\Currency;
 use Lunar\Models\Order;
-use function Pest\Laravel\{actingAs, assertDatabaseMissing};
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseMissing;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -316,9 +318,9 @@ test('can return new instance when current cart has completed order', function (
     $cart = CartSession::current()->calculate();
 
     expect($order->cart_id)->not->toBe($cart->id)
-    ->and($cart->subTotal->value)->toBe(0)
-    ->and(Session::get(config('lunar.cart_session.session_key')))
-    ->toBe($cart->id);
+        ->and($cart->subTotal->value)->toBe(0)
+        ->and(Session::get(config('lunar.cart_session.session_key')))
+        ->toBe($cart->id);
 
     assertDatabaseMissing(Order::class, [
         'cart_id' => $cart->id,

--- a/tests/core/Unit/Managers/CartSessionManagerTest.php
+++ b/tests/core/Unit/Managers/CartSessionManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-uses(\Lunar\Tests\Core\TestCase::class);
+uses(\Lunar\Tests\Core\TestCase::class)->group('cart_session');
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
@@ -11,8 +11,7 @@ use Lunar\Models\CartAddress;
 use Lunar\Models\Channel;
 use Lunar\Models\Currency;
 use Lunar\Models\Order;
-
-use function Pest\Laravel\{actingAs};
+use function Pest\Laravel\{actingAs, assertDatabaseMissing};
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -32,19 +31,19 @@ test('can fetch current cart', function () {
         'default' => true,
     ]);
 
-    Config::set('lunar.cart.auto_create', false);
+    Config::set('lunar.cart_session.auto_create', false);
 
     $cart = $manager->current();
 
     expect($cart)->toBeNull();
 
-    Config::set('lunar.cart.auto_create', true);
+    Config::set('lunar.cart_session.auto_create', true);
 
     $cart = $manager->current();
 
     expect($cart)->toBeInstanceOf(Cart::class);
 
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($sessionCart)->not->toBeNull();
     expect($sessionCart)->toEqual($cart->id);
@@ -59,7 +58,7 @@ test('can create order from session cart and cleanup', function () {
         'default' => true,
     ]);
 
-    Config::set('lunar.cart.auto_create', true);
+    Config::set('lunar.cart_session.auto_create', true);
 
     $cart = CartSession::current();
 
@@ -76,7 +75,7 @@ test('can create order from session cart and cleanup', function () {
     $cart->setShippingAddress($shipping);
     $cart->setBillingAddress($billing);
 
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($sessionCart)->not->toBeNull();
     expect($sessionCart)->toEqual($cart->id);
@@ -86,7 +85,7 @@ test('can create order from session cart and cleanup', function () {
     expect($order)->toBeInstanceOf(Order::class);
     expect($cart->id)->toEqual($order->cart_id);
 
-    expect(Session::get(config('lunar.cart.session_key')))->toBeNull();
+    expect(Session::get(config('lunar.cart_session.session_key')))->toBeNull();
 });
 
 test('can create order from session cart and retain cart', function () {
@@ -98,7 +97,7 @@ test('can create order from session cart and retain cart', function () {
         'default' => true,
     ]);
 
-    Config::set('lunar.cart.auto_create', true);
+    Config::set('lunar.cart_session.auto_create', true);
 
     $cart = CartSession::current();
 
@@ -115,7 +114,7 @@ test('can create order from session cart and retain cart', function () {
     $cart->setShippingAddress($shipping);
     $cart->setBillingAddress($billing);
 
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($sessionCart)->not->toBeNull();
     expect($sessionCart)->toEqual($cart->id);
@@ -127,7 +126,7 @@ test('can create order from session cart and retain cart', function () {
     expect($order)->toBeInstanceOf(Order::class);
     expect($cart->id)->toEqual($order->cart_id);
 
-    expect(Session::get(config('lunar.cart.session_key')))->toEqual($cart->id);
+    expect(Session::get(config('lunar.cart_session.session_key')))->toEqual($cart->id);
 });
 
 test('can fetch authenticated users cart and set in session', function () {
@@ -139,11 +138,11 @@ test('can fetch authenticated users cart and set in session', function () {
         'default' => true,
     ]);
 
-    Config::set('lunar.cart.auto_create', false);
+    Config::set('lunar.cart_session.auto_create', false);
 
     $cart = CartSession::current();
 
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($sessionCart)->toBeNull();
     expect($cart)->toBeNull();
@@ -157,7 +156,7 @@ test('can fetch authenticated users cart and set in session', function () {
     ]);
 
     $cart = CartSession::current();
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($cart)->not->toBeNull();
     expect($cart->id)->toBe($userCart->id);
@@ -175,7 +174,7 @@ test('can forget a cart and soft delete it', function () {
         'default' => true,
     ]);
 
-    Config::set('lunar.cart.auto_create', true);
+    Config::set('lunar.cart_session.auto_create', true);
 
     $cart = CartSession::current();
 
@@ -192,7 +191,7 @@ test('can forget a cart and soft delete it', function () {
     $cart->setShippingAddress($shipping);
     $cart->setBillingAddress($billing);
 
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($sessionCart)
         ->not
@@ -203,7 +202,7 @@ test('can forget a cart and soft delete it', function () {
     CartSession::forget();
 
     expect(
-        Session::get(config('lunar.cart.session_key'))
+        Session::get(config('lunar.cart_session.session_key'))
     )
         ->toBeNull()
         ->and($cart->refresh()->deleted_at)
@@ -221,7 +220,7 @@ test('can forget a cart an optionally prevent soft deleting', function () {
         'default' => true,
     ]);
 
-    Config::set('lunar.cart.auto_create', true);
+    Config::set('lunar.cart_session.auto_create', true);
 
     $cart = CartSession::current();
 
@@ -238,7 +237,7 @@ test('can forget a cart an optionally prevent soft deleting', function () {
     $cart->setShippingAddress($shipping);
     $cart->setBillingAddress($billing);
 
-    $sessionCart = Session::get(config('lunar.cart.session_key'));
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
 
     expect($sessionCart)
         ->not
@@ -249,7 +248,7 @@ test('can forget a cart an optionally prevent soft deleting', function () {
     CartSession::forget(delete: false);
 
     expect(
-        Session::get(config('lunar.cart.session_key'))
+        Session::get(config('lunar.cart_session.session_key'))
     )
         ->toBeNull()
         ->and($cart->refresh()->deleted_at)
@@ -265,4 +264,63 @@ test('can set shipping estimate meta', function () {
     $meta = CartSession::getShippingEstimateMeta();
     expect($meta)->toBeArray();
     expect($meta['postcode'])->toEqual('NP1 1TX');
+});
+
+test('can return new instance when current cart has completed order', function () {
+    Currency::factory()->create([
+        'default' => true,
+    ]);
+
+    Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    Config::set('lunar.cart_session.auto_create', true);
+    Config::set('lunar.cart_session.allow_multiple_orders_per_cart', false);
+
+    $cart = CartSession::current();
+
+    $shipping = CartAddress::factory()->create([
+        'cart_id' => $cart->id,
+        'type' => 'shipping',
+    ]);
+
+    $billing = CartAddress::factory()->create([
+        'cart_id' => $cart->id,
+        'type' => 'billing',
+    ]);
+
+    $cart->setShippingAddress($shipping);
+    $cart->setBillingAddress($billing);
+
+    $sessionCart = Session::get(config('lunar.cart_session.session_key'));
+
+    expect($sessionCart)->not->toBeNull();
+    expect($sessionCart)->toEqual($cart->id);
+
+    $order = CartSession::createOrder(
+        forget: false
+    );
+
+    expect($order)
+        ->toBeInstanceOf(Order::class)
+        ->and($cart->id)
+        ->toEqual($order->cart_id)
+        ->and(Session::get(config('lunar.cart_session.session_key')))
+        ->toEqual($cart->id);
+
+    $order->update([
+        'placed_at' => now(),
+    ]);
+
+    $cart = CartSession::current()->calculate();
+
+    expect($order->cart_id)->not->toBe($cart->id)
+    ->and($cart->subTotal->value)->toBe(0)
+    ->and(Session::get(config('lunar.cart_session.session_key')))
+    ->toBe($cart->id);
+
+    assertDatabaseMissing(Order::class, [
+        'cart_id' => $cart->id,
+    ]);
 });


### PR DESCRIPTION
Currently if a cart has a completed order but wasn't cleared from the session it will seize up and cause problems when users try to interact with it. This also causes data issues as the cart no longer maps to the completed order correctly.