### PR TITLE
Adds the ability to specify the order statuses for the navigation count

### DIFF
--- a/packages/admin/config/panel.php
+++ b/packages/admin/config/panel.php
@@ -46,6 +46,6 @@ return [
     | to include in the count below.
     |
     */
-    'order_count_statuses' => ['in-progress'],
+    'order_count_statuses' => ['payment-received'],
 
 ];

--- a/packages/admin/config/panel.php
+++ b/packages/admin/config/panel.php
@@ -35,4 +35,17 @@ return [
     |
     */
     'scout_enabled' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Navigation counts
+    |--------------------------------------------------------------------------
+    |
+    | The admin panel will show a count of orders in the left navigation.
+    | This is based upon specific order statuses. You can define the statuses
+    | to include in the count below.
+    |
+    */
+    'order_count_statuses' => ['in-progress'],
+
 ];

--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -51,7 +51,7 @@ class OrderResource extends BaseResource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::whereIn('status', config('lunar.panel.order_count_statuses', 'in-progress'))->count();
+        return static::getModel()::whereIn('status', config('lunar.panel.order_count_statuses', 'payment-received'))->count();
     }
 
     public static function getDefaultTable(Table $table): Table

--- a/packages/admin/src/Filament/Resources/OrderResource.php
+++ b/packages/admin/src/Filament/Resources/OrderResource.php
@@ -51,7 +51,7 @@ class OrderResource extends BaseResource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('status', '=', 'in-process')->count();
+        return static::getModel()::whereIn('status', config('lunar.panel.order_count_statuses', 'in-progress'))->count();
     }
 
     public static function getDefaultTable(Table $table): Table


### PR DESCRIPTION
You can now add the statuses the admin panel should use for the order count.