### PR TITLE
Stripe - Add method to cancel payment intents

### DIFF
--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -176,10 +176,22 @@ Stripe::updateIntent(\Lunar\Models\Cart $cart, [
 
 If you need to cancel a PaymentIntent, you can do so. You will need to provide a valid reason, those of which can be found in the Stripe docs: https://docs.stripe.com/api/payment_intents/cancel.
 
-```php
-use \Lunar\Stripe\Facades\Stripe;
+Lunar Stripe includes a PHP Enum to make this easier for you:
 
-Stripe::cancelIntent(\Lunar\Models\Cart $cart, string $reason);
+```php
+use Lunar\Stripe\Enums\CancellationReason;
+
+CancellationReason::ABANDONED;
+CancellationReason::DUPLICATE;
+CancellationReason::REQUESTED_BY_CUSTOMER;
+CancellationReason::FRAUDULENT;
+```
+
+```php
+use Lunar\Stripe\Facades\Stripe;
+use Lunar\Stripe\Enums\CancellationReason;
+
+Stripe::cancelIntent(\Lunar\Models\Cart $cart, CancellationReason $reason);
 ```
 
 ### Update the address on Stripe

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -172,6 +172,16 @@ Stripe::updateIntent(\Lunar\Models\Cart $cart, [
 ]);
 ```
 
+### Cancel an existing intent
+
+If you need to cancel a PaymentIntent, you can do so. You will need to provide a valid reason, those of which can be found in the Stripe docs: https://docs.stripe.com/api/payment_intents/cancel.
+
+```php
+use \Lunar\Stripe\Facades\Stripe;
+
+Stripe::cancelIntent(\Lunar\Models\Cart $cart, string $reason);
+```
+
 ### Update the address on Stripe
 
 So you don't have to manually specify all the shipping address fields you can use the helper function to do it for you.

--- a/packages/stripe/src/Enums/CancellationReason.php
+++ b/packages/stripe/src/Enums/CancellationReason.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lunar\Stripe\Enums;
+
+enum CancellationReason: string
+{
+    case DUPLICATE = 'duplicate';
+    case FRAUDULENT = 'fraudulent';
+    case REQUESTED_BY_CUSTOMER = 'requested_by_customer';
+    case ABANDONED = 'abandoned';
+}

--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -3,6 +3,7 @@
 namespace Lunar\Stripe\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Lunar\Stripe\Enums\CancellationReason;
 use Lunar\Stripe\MockClient;
 use Stripe\ApiRequestor;
 
@@ -11,7 +12,7 @@ use Stripe\ApiRequestor;
  * @method static createIntent(\Lunar\Models\Cart $cart, array $opts): \Stripe\PaymentIntent
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
  * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void
- * @method static cancelIntent(\Lunar\Models\Cart $cart, string $reason): void
+ * @method static cancelIntent(\Lunar\Models\Cart $cart, CancellationReason $reason): void
  * @method static updateShippingAddress(\Lunar\Models\Cart $cart): void
  * @method static getCharges(string $paymentIntentId): \Illuminate\Support\Collection
  * @method static getCharge(string $chargeId): \Stripe\Charge

--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -11,6 +11,7 @@ use Stripe\ApiRequestor;
  * @method static createIntent(\Lunar\Models\Cart $cart, array $opts): \Stripe\PaymentIntent
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
  * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void
+ * @method static cancelIntent(\Lunar\Models\Cart $cart, string $reason): void
  * @method static updateShippingAddress(\Lunar\Models\Cart $cart): void
  * @method static getCharges(string $paymentIntentId): \Illuminate\Support\Collection
  * @method static getCharge(string $chargeId): \Stripe\Charge

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -119,6 +119,24 @@ class StripeManager
         );
     }
 
+    public function cancelIntent(Cart $cart, string $reason): void
+    {
+        $meta = (array) $cart->meta;
+
+        if (empty($meta['payment_intent'])) {
+            return;
+        }
+
+        try {
+            $this->getClient()->paymentIntents->cancel(
+                $meta['payment_intent'],
+                ['cancellation_reason' => $reason]
+            );
+        } catch (\Exception $e) {
+
+        }
+    }
+
     /**
      * Fetch an intent from the Stripe API.
      */

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -5,6 +5,7 @@ namespace Lunar\Stripe\Managers;
 use Illuminate\Support\Collection;
 use Lunar\Models\Cart;
 use Lunar\Models\CartAddress;
+use Lunar\Stripe\Enums\CancellationReason;
 use Stripe\Charge;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
@@ -119,7 +120,7 @@ class StripeManager
         );
     }
 
-    public function cancelIntent(Cart $cart, string $reason): void
+    public function cancelIntent(Cart $cart, CancellationReason $reason): void
     {
         $meta = (array) $cart->meta;
 
@@ -130,7 +131,7 @@ class StripeManager
         try {
             $this->getClient()->paymentIntents->cancel(
                 $meta['payment_intent'],
-                ['cancellation_reason' => $reason]
+                ['cancellation_reason' => $reason->value]
             );
         } catch (\Exception $e) {
 


### PR DESCRIPTION
Sometimes it is useful to be able to cancel a payment intent, this PR sets this up.