### PR TITLE
Fixing a misconfiguration problem for ListField type

### DIFF
--- a/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
+++ b/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
@@ -136,7 +136,7 @@ class AttributesRelationManager extends RelationManager
                     $data['system'] = false;
                     $data['attribute_type'] = $livewire->ownerRecord->attributable_type;
                     $data['position'] = $livewire->ownerRecord->attributes()->count() + 1;
-
+                    $data['configuration'] = $data['configuration'] === null ? [] : $data['configuration'];
                     return $data;
                 }),
             ])


### PR DESCRIPTION
1. Create a new attribute in the group
2. Select the type: List Field
3. Save
4. Activate
5. After entering the product displayed an error:

![image](https://github.com/user-attachments/assets/1e66019f-a575-4c5f-9cea-e757761f82b8)


This happened because a null was written to the database, not an array, and the configuration is loaded in the function Lunar\Admin\Support\FieldTypes::getFilamentComponent.
https://github.com/lunarphp/lunar/blob/2b4d127e3d475cffa22f46c7a3e8bbc54cac87b3/packages/admin/src/Support/FieldTypes/ListField.php#L14


The solution to this problem, is to check during the creation if the value is null, if so, we replace it with an empty array.

The problem will also arise, for example, with the Youtube field and others that have no configuration.
