### PR TITLE
Fix: install command not publishing panel config

### DIFF
--- a/packages/core/src/Console/InstallLunar.php
+++ b/packages/core/src/Console/InstallLunar.php
@@ -300,7 +300,6 @@ class InstallLunar extends Command
     private function publishConfiguration(bool $forcePublish = false): void
     {
         $params = [
-            '--provider' => "Lunar\LunarServiceProvider",
             '--tag' => 'lunar',
         ];
 


### PR DESCRIPTION
currently `lunar:install` command when publish config, it is scoped to only core's configs, this change will publish both core and panel config by removing the provider option
