### PR TITLE
Handle cart value mismatch on Stripe

### DIFF
--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -13,6 +13,7 @@ use Stripe\ApiRequestor;
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
  * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void
  * @method static cancelIntent(\Lunar\Models\Cart $cart, CancellationReason $reason): void
+ * @method static refundCharge(string $chargeId): ?\Stripe\Refund
  * @method static updateShippingAddress(\Lunar\Models\Cart $cart): void
  * @method static getCharges(string $paymentIntentId): \Illuminate\Support\Collection
  * @method static getCharge(string $chargeId): \Stripe\Charge

--- a/packages/stripe/src/Http/Controllers/WebhookController.php
+++ b/packages/stripe/src/Http/Controllers/WebhookController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Log;
+use Lunar\Base\DataTransferObjects\PaymentAuthorize;
 use Lunar\Events\PaymentAttemptEvent;
 use Lunar\Facades\Payments;
 use Lunar\Models\Cart;
@@ -59,6 +60,15 @@ final class WebhookController extends Controller
             Stripe::updateIntent($cart, [
                 'description' => 'Cart value mismatch',
             ]);
+
+            PaymentAttemptEvent::dispatch(
+                new PaymentAuthorize(
+                    success: false,
+                    message: 'Cart value mismatch',
+                    orderId: null,
+                    paymentType: 'stripe'
+                )
+            );
 
             return response()->json([
                 'webhook_successful' => false,

--- a/packages/stripe/src/Http/Controllers/WebhookController.php
+++ b/packages/stripe/src/Http/Controllers/WebhookController.php
@@ -60,12 +60,6 @@ final class WebhookController extends Controller
                 'description' => 'Cart value mismatch',
             ]);
 
-            $meta = $cart->meta;
-            unset($meta['payment_intent']);
-            $cart->updateQuietly([
-                'meta' => $meta,
-            ]);
-
             return response()->json([
                 'webhook_successful' => false,
                 'message' => 'Charge refunded due to value mismatch',

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -9,6 +9,7 @@ use Lunar\Stripe\Enums\CancellationReason;
 use Stripe\Charge;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
+use Stripe\Refund;
 use Stripe\Stripe;
 use Stripe\StripeClient;
 
@@ -135,6 +136,17 @@ class StripeManager
             );
         } catch (\Exception $e) {
 
+        }
+    }
+
+    public function refundCharge(string $chargeId): ?Refund
+    {
+        try {
+            return $this->getClient()->refunds->create(
+                ['charge' => $chargeId]
+            );
+        } catch (\Exception $e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
There are rare cases where the cart value is not the same as the amount which has been captured, in this instance we need to refund the amount and reset the cart.