### PR TITLE
Fix - Cart session manager 

### DIFF
--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -140,12 +140,12 @@ class CartSessionManager implements CartSessionInterface
             config('lunar.cart.eager_load', [])
         )->find($cartId);
 
-        if ($cart->hasCompletedOrders() && ! $this->allowsMultipleOrdersPerCart()) {
-            return $this->createNewCart();
-        }
-
         if (! $cart) {
             return $create ? $this->createNewCart() : null;
+        }
+
+        if ($cart->hasCompletedOrders() && ! $this->allowsMultipleOrdersPerCart()) {
+            return $this->createNewCart();
         }
 
         $this->cart = $cart;

--- a/tests/core/Unit/Managers/CartSessionManagerTest.php
+++ b/tests/core/Unit/Managers/CartSessionManagerTest.php
@@ -51,6 +51,25 @@ test('can fetch current cart', function () {
     expect($sessionCart)->toEqual($cart->id);
 });
 
+test('can fetch current cart if session exist', function () {
+    $manager = app(CartSessionManager::class);
+
+    Currency::factory()->create([
+        'default' => true,
+    ]);
+
+    Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    Config::set('lunar.cart_session.auto_create', false);
+    Session::put(config('lunar.cart_session.session_key'), 1);
+
+    $cart = $manager->current();
+
+    expect($cart)->toBeNull();
+});
+
 test('can create order from session cart and cleanup', function () {
     Currency::factory()->create([
         'default' => true,


### PR DESCRIPTION
Introduce in the PR https://github.com/lunarphp/lunar/pull/1854. If user have a session with deleted cart, the session manager generate error Call to a member function hasCompletedOrders() on null
