### PR TITLE
fix: product variants `getKey` on array

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -105,7 +105,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
         $options = [];
 
         foreach ($productOptions as $productOption) {
-            $values = $productOption->values->map(function ($value) {
+            $values = $productOption->values->count() ? $productOption->values->map(function ($value) {
                 return $this->mapOptionValue($value, true);
             })->merge(
                 $disabledSharedOptionValues->filter(
@@ -113,7 +113,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                 )->map(
                     fn ($value) => $this->mapOptionValue($value, false)
                 )
-            )->sortBy('position')->values()->toArray();
+            )->sortBy('position')->values()->toArray() : [];
 
             $options[] = $this->mapOption($productOption, $values);
         }


### PR DESCRIPTION
when a manually creating product from code, if product_product_option is created but variants are not setup with optionValues, the panel will throw an exception when go to the Variant page

although this is a user and incomplete manual creation, I think it would be good to handle error screen