### PR TITLE
Set payment order to null when setting the cart

### DIFF
--- a/packages/core/src/PaymentTypes/AbstractPayment.php
+++ b/packages/core/src/PaymentTypes/AbstractPayment.php
@@ -47,6 +47,7 @@ abstract class AbstractPayment implements PaymentTypeInterface
     public function order(Order $order): self
     {
         $this->order = $order;
+        $this->cart = null;
 
         return $this;
     }

--- a/packages/core/src/PaymentTypes/AbstractPayment.php
+++ b/packages/core/src/PaymentTypes/AbstractPayment.php
@@ -36,6 +36,7 @@ abstract class AbstractPayment implements PaymentTypeInterface
     public function cart(Cart $cart): self
     {
         $this->cart = $cart;
+        $this->order = null;
 
         return $this;
     }


### PR DESCRIPTION
There is a potential for a payment provider to have access to a previously set order when calling the `order()` method on a payment type.

Since we always need a cart but not always an order we should be okay with setting the order to `null` when calling the `cart()` method.