### PR TITLE
Display product variants' option values flex-col

### DIFF
--- a/packages/admin/resources/views/resources/product-resource/widgets/product-options.blade.php
+++ b/packages/admin/resources/views/resources/product-resource/widgets/product-options.blade.php
@@ -122,7 +122,7 @@
                     @endif
                     <x-filament-tables::cell>
                       <div class="fi-ta-text grid w-full gap-y-1 px-3 py-4">
-                        <span class="fi-ta-text-item-label text-sm leading-6 text-gray-950 dark:text-white  ">
+                        <span class="fi-ta-text-item-label flex flex-col text-sm leading-6 text-gray-950 dark:text-white">
                           @foreach($permutation['values'] as $option => $value)
                             <small><strong>{{ $option }}:</strong> {{ $value }}</small>
                           @endforeach


### PR DESCRIPTION
When the variant's is a combination of multiple options or having long values, it makes the display hard to read and use


Before
<img width="820" alt="image" src="https://github.com/user-attachments/assets/9ab43c91-6f12-4321-8af4-fad7b5bb9f54">


After
<img width="823" alt="image" src="https://github.com/user-attachments/assets/a2fb4a36-50fc-4bae-87a9-75a5d44ab7e8">
