### PR TITLE
Refactor Stripe payment intent checking and storage

### DIFF
--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -35,7 +35,7 @@ Currently, PaymentIntent information is stored in the Cart model's meta, which i
 
 Whilst this works okay it causes for limitations and also means that if the carts meta is ever updated elsewhere, or the intent information is removed, then it will cause unrecoverable loss.
 
-This PR looks to move away from the payment_intent key in the meta to a StripePaymentIntent model, this allows us more flexibility in how payment intents are handled and reacted on. A StripePaymentIntent will be associated to both a cart and an order.
+We have now looked to move away from the payment_intent key in the meta to a StripePaymentIntent model, this allows us more flexibility in how payment intents are handled and reacted on. A StripePaymentIntent will be associated to both a cart and an order.
 
 The information we store is now:
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,6 +18,12 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
+## [Unreleased]
+
+#### Stripe Addon
+
+The Stripe addon will now attempt to update an order's billing and shipping address based on what has been stored against the Payment Intent. This is due to Stripe not always returning this information during their express checkout flows. This can be disabled by setting the `lunar.stripe.sync_addresses` config value to `false`.
+
 ## 1.0.0-alpha.34
 
 ### Medium Impact

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -92,10 +92,10 @@ Make sure you have the Stripe credentials set in `config/services.php`
 
 Below is a list of the available configuration options this package uses in `config/lunar/stripe.php`
 
-| Key | Default | Description |
-| --- | --- | --- |
-| `policy` | `automatic` | Determines the policy for taking payments and whether you wish to capture the payment manually later or take payment straight away. Available options `manual` or `automatic` |
-
+| Key              | Default      | Description                                                                                                                                                                   |
+|------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `policy`         | `automatic`  | Determines the policy for taking payments and whether you wish to capture the payment manually later or take payment straight away. Available options `manual` or `automatic` |
+| `sync_addresses` | `true`       | When enabled, the Stripe addon will attempt to sync the billing and shipping addresses which have been stored against the payment intent on Stripe.                           |
 ---
 
 ## Backend Usage

--- a/packages/stripe/config/stripe.php
+++ b/packages/stripe/config/stripe.php
@@ -27,6 +27,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sync addresses
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the Stripe addon will attempt to sync the billing and shipping
+    | addresses which have been stored against the payment intent on Stripe.
+    | This is useful when you don't always get the full address during the
+    | checkout process, which can be the case when using express checkout.
+    |
+    */
+    'sync_addresses' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Status mapping
     |--------------------------------------------------------------------------
     |

--- a/packages/stripe/database/migrations/2024_07_31_100000_create_stripe_payment_intents_table.php
+++ b/packages/stripe/database/migrations/2024_07_31_100000_create_stripe_payment_intents_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create($this->prefix.'stripe_payment_intents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('cart_id')->constrained($this->prefix.'carts');
+            $table->foreignId('order_id')->nullable()->constrained($this->prefix.'orders');
+            $table->string('intent_id')->index();
+            $table->string('status')->nullable();
+            $table->string('event_id')->index()->nullable();
+            $table->timestamp('processing_at')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->prefix.'stripe_payment_intents');
+    }
+};

--- a/packages/stripe/resources/responses/payment_intent_created.json
+++ b/packages/stripe/resources/responses/payment_intent_created.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -38,7 +38,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+    "shipping": {
+        "address": {
+            "city": "ACME Shipping Land",
+            "country": "GB",
+            "line1": "123 ACME Shipping Lane",
+            "line2": null,
+            "postal_code": "AC2 2ME",
+            "state": "ACM3"
+        },
+        "phone": "123456",
+        "name": "Buggs Bunny"
+    },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "requires_payment_method",

--- a/packages/stripe/resources/responses/payment_intent_fetched.json
+++ b/packages/stripe/resources/responses/payment_intent_fetched.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+    "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -38,7 +38,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+  "shipping": {
+      "address": {
+          "city": "ACME Shipping Land",
+          "country": "GB",
+          "line1": "123 ACME Shipping Lane",
+          "line2": null,
+          "postal_code": "AC2 2ME",
+          "state": "ACM3"
+      },
+      "phone": "123456",
+      "name": "Buggs Bunny"
+  },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "requires_payment_method",

--- a/packages/stripe/resources/responses/payment_intent_paid.json
+++ b/packages/stripe/resources/responses/payment_intent_paid.json
@@ -217,7 +217,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -227,7 +227,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+  "shipping": {
+      "address": {
+          "city": "ACME Shipping Land",
+          "country": "GB",
+          "line1": "123 ACME Shipping Lane",
+          "line2": null,
+          "postal_code": "AC2 2ME",
+          "state": "ACM3"
+      },
+      "phone": "123456",
+      "name": "Buggs Bunny"
+  },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "{status}",

--- a/packages/stripe/resources/responses/payment_intent_requires_payment_method.json
+++ b/packages/stripe/resources/responses/payment_intent_requires_payment_method.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -38,7 +38,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+  "shipping": {
+      "address": {
+          "city": "ACME Shipping Land",
+          "country": "GB",
+          "line1": "123 ACME Shipping Lane",
+          "line2": null,
+          "postal_code": "AC2 2ME",
+          "state": "ACM3"
+      },
+      "phone": "123456",
+      "name": "Buggs Bunny"
+  },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "requires_payment_method",

--- a/packages/stripe/resources/responses/payment_method.json
+++ b/packages/stripe/resources/responses/payment_method.json
@@ -1,0 +1,47 @@
+{
+    "id": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
+    "object": "payment_method",
+    "billing_details": {
+        "address": {
+            "city": "ACME Land",
+            "country": "GB",
+            "line1": "123 ACME Lane",
+            "line2": null,
+            "postal_code": "AC1 1ME",
+            "state": "ACME"
+        },
+        "email": "sales@acme.com",
+        "name": "Elma Thudd",
+        "phone": "1234567"
+    },
+    "card": {
+        "brand": "visa",
+        "checks": {
+            "address_line1_check": null,
+            "address_postal_code_check": null,
+            "cvc_check": "unchecked"
+        },
+        "country": "US",
+        "exp_month": 8,
+        "exp_year": 2026,
+        "fingerprint": "mToisGZ01V71BCos",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+            "available": [
+                "visa"
+            ],
+            "preferred": null
+        },
+        "three_d_secure_usage": {
+            "supported": true
+        },
+        "wallet": null
+    },
+    "created": 1679945299,
+    "customer": null,
+    "livemode": false,
+    "metadata": {},
+    "type": "card"
+}

--- a/packages/stripe/src/Actions/StoreAddressInformation.php
+++ b/packages/stripe/src/Actions/StoreAddressInformation.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lunar\Stripe\Actions;
+
+use Lunar\Models\Country;
+use Lunar\Models\Order;
+use Lunar\Models\OrderAddress;
+use Lunar\Stripe\Facades\Stripe;
+use Stripe\PaymentIntent;
+
+class StoreAddressInformation
+{
+    public function store(Order $order, PaymentIntent $paymentIntent)
+    {
+        $billingAddress = $order->billingAddress ?: new OrderAddress([
+            'order_id' => $order->id,
+            'type' => 'billing',
+        ]);
+
+        $shippingAddress = $order->shippingAddress ?: new OrderAddress([
+            'order_id' => $order->id,
+            'type' => 'shipping',
+        ]);
+
+        $paymentMethod = Stripe::getPaymentMethod($paymentIntent->payment_method);
+
+        if ($paymentIntent->shipping && $stripeShipping = $paymentIntent->shipping->address) {
+            $country = Country::where('iso2', $stripeShipping->country)->first();
+            $shippingAddress->first_name = explode(' ', $paymentIntent->shipping->name)[0];
+            $shippingAddress->last_name = explode(' ', $paymentIntent->shipping->name)[1] ?? '';
+            $shippingAddress->line_one = $stripeShipping->line1;
+            $shippingAddress->line_two = $stripeShipping->line2;
+            $shippingAddress->city = $stripeShipping->city;
+            $shippingAddress->state = $stripeShipping->state;
+            $shippingAddress->postcode = $stripeShipping->postal_code;
+            $shippingAddress->country_id = $country?->id;
+            $shippingAddress->contact_phone = $paymentIntent->shipping->phone;
+            $shippingAddress->save();
+        }
+
+        if ($paymentMethod && $stripeBilling = $paymentMethod->billing_details?->address) {
+            $country = Country::where('iso2', $stripeBilling->country)->first();
+            $billingAddress->first_name = explode(' ', $paymentMethod->billing_details->name)[0];
+            $billingAddress->last_name = explode(' ', $paymentMethod->billing_details->name)[1] ?? '';
+            $billingAddress->line_one = $stripeBilling->line1;
+            $billingAddress->line_two = $stripeBilling->line2;
+            $billingAddress->city = $stripeBilling->city;
+            $billingAddress->state = $stripeBilling->state;
+            $billingAddress->postcode = $stripeBilling->postal_code;
+            $billingAddress->country_id = $country?->id;
+            $billingAddress->contact_phone = $paymentMethod->billing_details->phone;
+            $billingAddress->contact_email = $paymentMethod->billing_details->email;
+            $billingAddress->save();
+        }
+    }
+}

--- a/packages/stripe/src/Actions/UpdateOrderFromIntent.php
+++ b/packages/stripe/src/Actions/UpdateOrderFromIntent.php
@@ -26,6 +26,17 @@ class UpdateOrderFromIntent
 
             $placedAt = null;
 
+            $billingAddress = $order->billingAddress;
+
+            $paymentMethod = Stripe::getPaymentMethod($paymentIntent->payment_method);
+
+            $billingDetails = $paymentMethod->billing_details;
+            $postcode = $billingDetails->address->postal_code;
+
+            if ($postcode != $billingAddress->postcode) {
+                dd($billingDetails);
+            }
+
             if ($paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED) {
                 $placedAt = now();
             }

--- a/packages/stripe/src/Actions/UpdateOrderFromIntent.php
+++ b/packages/stripe/src/Actions/UpdateOrderFromIntent.php
@@ -26,17 +26,6 @@ class UpdateOrderFromIntent
 
             $placedAt = null;
 
-            $billingAddress = $order->billingAddress;
-
-            $paymentMethod = Stripe::getPaymentMethod($paymentIntent->payment_method);
-
-            $billingDetails = $paymentMethod->billing_details;
-            $postcode = $billingDetails->address->postal_code;
-
-            if ($postcode != $billingAddress->postcode) {
-                dd($billingDetails);
-            }
-
             if ($paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED) {
                 $placedAt = now();
             }

--- a/packages/stripe/src/Actions/UpdateOrderFromIntent.php
+++ b/packages/stripe/src/Actions/UpdateOrderFromIntent.php
@@ -34,6 +34,10 @@ class UpdateOrderFromIntent
                 return $order;
             }
 
+            if (config('lunar.stripe.sync_addresses', true) && $paymentIntent->payment_method) {
+                (new StoreAddressInformation)->store($order, $paymentIntent);
+            }
+
             $order->update([
                 'status' => $statuses[$paymentIntent->status] ?? $paymentIntent->status,
                 'placed_at' => $order->placed_at ?: $placedAt,

--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -11,7 +11,7 @@ use Stripe\ApiRequestor;
 /**
  * @method static getClient(): \Stripe\StripeClient
  * @method static getCartIntentId(Cart $cart): ?string
- * @method static fetchOrCreateIntent(Cart $cart, array $opts): ?string
+ * @method static fetchOrCreateIntent(Cart $cart, array $createOptions): ?string
  * @method static createIntent(\Lunar\Models\Cart $cart, array $createOptions): \Stripe\PaymentIntent
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
  * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void

--- a/packages/stripe/src/Facades/Stripe.php
+++ b/packages/stripe/src/Facades/Stripe.php
@@ -3,13 +3,16 @@
 namespace Lunar\Stripe\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Lunar\Models\Cart;
 use Lunar\Stripe\Enums\CancellationReason;
 use Lunar\Stripe\MockClient;
 use Stripe\ApiRequestor;
 
 /**
  * @method static getClient(): \Stripe\StripeClient
- * @method static createIntent(\Lunar\Models\Cart $cart, array $opts): \Stripe\PaymentIntent
+ * @method static getCartIntentId(Cart $cart): ?string
+ * @method static fetchOrCreateIntent(Cart $cart, array $opts): ?string
+ * @method static createIntent(\Lunar\Models\Cart $cart, array $createOptions): \Stripe\PaymentIntent
  * @method static syncIntent(\Lunar\Models\Cart $cart): void
  * @method static updateIntent(\Lunar\Models\Cart $cart, array $values): void
  * @method static cancelIntent(\Lunar\Models\Cart $cart, CancellationReason $reason): void

--- a/packages/stripe/src/Http/Controllers/WebhookController.php
+++ b/packages/stripe/src/Http/Controllers/WebhookController.php
@@ -46,7 +46,9 @@ final class WebhookController extends Controller
             $paymentIntentModel?->update([
                 'event_id' => $event->id,
             ]);
-            ProcessStripeWebhook::dispatch($paymentIntent, $orderId);
+            ProcessStripeWebhook::dispatch($paymentIntent, $orderId)->delay(
+                now()->addSeconds(5)
+            );
         }
 
         return response()->json([

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -61,6 +61,7 @@ class StripeManager
             return PaymentMethod::retrieve($paymentMethodId);
         } catch (ApiErrorException $e) {
         }
+
         return null;
     }
 
@@ -120,7 +121,7 @@ class StripeManager
     {
         $intentId = $this->getCartIntentId($cart);
 
-        if (!$intentId) {
+        if (! $intentId) {
             return;
         }
 
@@ -139,7 +140,7 @@ class StripeManager
     {
         $intentId = $this->getCartIntentId($cart);
 
-        if (!$intentId) {
+        if (! $intentId) {
             return;
         }
 
@@ -155,7 +156,7 @@ class StripeManager
     {
         $intentId = $this->getCartIntentId($cart);
 
-        if (!$intentId) {
+        if (! $intentId) {
             return;
         }
 

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -4,7 +4,6 @@ namespace Lunar\Stripe\Managers;
 
 use Illuminate\Support\Collection;
 use Lunar\Models\Cart;
-use Lunar\Models\CartAddress;
 use Lunar\Stripe\Enums\CancellationReason;
 use Stripe\Charge;
 use Stripe\Exception\ApiErrorException;
@@ -46,7 +45,7 @@ class StripeManager
          * If the payment intent is stored in the meta, we don't have a linked payment intent
          * then it's a "legacy" cart, we should make a new record.
          */
-        if (! empty($cartModel->meta['payment_intent']) && ! $cart->paymentIntents->first()) {
+        if (! empty($cart->meta['payment_intent']) && ! $cart->paymentIntents->first()) {
             $cart->paymentIntents()->create([
                 'intent_id' => $intent->id,
                 'status' => $intent->status,
@@ -62,7 +61,7 @@ class StripeManager
             return PaymentMethod::retrieve($paymentMethodId);
         } catch (ApiErrorException $e) {
         }
-
+        return null;
     }
 
     /**
@@ -70,22 +69,20 @@ class StripeManager
      */
     public function createIntent(Cart $cart, array $opts = []): PaymentIntent
     {
-        $meta = (array) $cart->meta;
+        $existingId = $this->getCartIntentId($cart);
 
-        if ($meta && ! empty($meta['payment_intent'])) {
+        if (
+            $existingId &&
             $intent = $this->fetchIntent(
-                $meta['payment_intent']
-            );
-
-            if ($intent) {
-                return $intent;
-            }
+                $existingId
+            )
+        ) {
+            return $intent;
         }
 
         $paymentIntent = $this->buildIntent(
             $cart->total->value,
             $cart->currency->code,
-            $cart->shippingAddress,
             $opts
         );
 
@@ -121,13 +118,13 @@ class StripeManager
 
     public function updateIntent(Cart $cart, array $values): void
     {
-        $meta = (array) $cart->meta;
+        $intentId = $this->getCartIntentId($cart);
 
-        if (empty($meta['payment_intent'])) {
+        if (!$intentId) {
             return;
         }
 
-        $this->updateIntentById($meta['payment_intent'], $values);
+        $this->updateIntentById($intentId, $values);
     }
 
     public function updateIntentById(string $id, array $values): void
@@ -140,31 +137,31 @@ class StripeManager
 
     public function syncIntent(Cart $cart): void
     {
-        $meta = (array) $cart->meta;
+        $intentId = $this->getCartIntentId($cart);
 
-        if (empty($meta['payment_intent'])) {
+        if (!$intentId) {
             return;
         }
 
         $cart = $cart->calculate();
 
         $this->getClient()->paymentIntents->update(
-            $meta['payment_intent'],
+            $intentId,
             ['amount' => $cart->total->value]
         );
     }
 
     public function cancelIntent(Cart $cart, CancellationReason $reason): void
     {
-        $meta = (array) $cart->meta;
+        $intentId = $this->getCartIntentId($cart);
 
-        if (empty($meta['payment_intent'])) {
+        if (!$intentId) {
             return;
         }
 
         try {
             $this->getClient()->paymentIntents->cancel(
-                $meta['payment_intent'],
+                $intentId,
                 ['cancellation_reason' => $reason->value]
             );
         } catch (\Exception $e) {
@@ -209,7 +206,7 @@ class StripeManager
     /**
      * Build the intent
      */
-    protected function buildIntent(int $value, string $currencyCode, ?CartAddress $shipping, array $opts = []): PaymentIntent
+    protected function buildIntent(int $value, string $currencyCode, array $opts = []): PaymentIntent
     {
         $params = [
             'amount' => $value,
@@ -217,21 +214,6 @@ class StripeManager
             'automatic_payment_methods' => ['enabled' => true],
             'capture_method' => config('lunar.stripe.policy', 'automatic'),
         ];
-
-        //        if ($shipping) {
-        //            $params['shipping'] = [
-        //                'name' => "{$shipping->first_name} {$shipping->last_name}",
-        //                'phone' => $shipping->contact_phone,
-        //                'address' => [
-        //                    'city' => $shipping->city,
-        //                    'country' => $shipping->country->iso2,
-        //                    'line1' => $shipping->line_one,
-        //                    'line2' => $shipping->line_two,
-        //                    'postal_code' => $shipping->postcode,
-        //                    'state' => $shipping->state,
-        //                ],
-        //            ];
-        //        }
 
         return PaymentIntent::create([
             ...$params,

--- a/packages/stripe/src/MockClient.php
+++ b/packages/stripe/src/MockClient.php
@@ -111,6 +111,14 @@ class MockClient implements ClientInterface
             return [$this->rBody, $this->rcode, $this->rheaders];
         }
 
+        if ($method == 'get' && str_contains($absUrl, 'payment_methods')) {
+            $this->rBody = $this->getResponse('payment_method', [
+                'id' => $id,
+            ]);
+
+            return [$this->rBody, $this->rcode, $this->rheaders];
+        }
+
         return [$this->rBody, $this->rcode, $this->rheaders];
     }
 

--- a/packages/stripe/src/Models/StripePaymentIntent.php
+++ b/packages/stripe/src/Models/StripePaymentIntent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lunar\Stripe\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Lunar\Base\BaseModel;
+use Lunar\Models\Cart;
+
+class StripePaymentIntent extends BaseModel
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected $guarded = [];
+
+    public function cart(): BelongsTo
+    {
+        return $this->belongsTo(Cart::class);
+    }
+}

--- a/packages/stripe/src/StripePaymentType.php
+++ b/packages/stripe/src/StripePaymentType.php
@@ -65,7 +65,7 @@ class StripePaymentType extends AbstractPayment
             return null;
         }
 
-        if (!$paymentIntentModel) {
+        if (! $paymentIntentModel) {
             $paymentIntentModel = StripePaymentIntent::create([
                 'intent_id' => $paymentIntentId,
                 'cart_id' => $this->cart?->id ?: $this->order->cart_id,

--- a/packages/stripe/src/StripePaymentType.php
+++ b/packages/stripe/src/StripePaymentType.php
@@ -55,9 +55,7 @@ class StripePaymentType extends AbstractPayment
     {
         $paymentIntentId = $this->data['payment_intent'];
 
-        $paymentIntentModel = StripePaymentIntent::first([
-            'intent_id' => $paymentIntentId,
-        ]);
+        $paymentIntentModel = StripePaymentIntent::where('intent_id', $paymentIntentId)->first();
 
         $this->order = $this->order ?: ($this->cart->draftOrder ?: $this->cart->completedOrder);
 

--- a/packages/stripe/src/StripePaymentsServiceProvider.php
+++ b/packages/stripe/src/StripePaymentsServiceProvider.php
@@ -6,10 +6,12 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use Lunar\Facades\Payments;
+use Lunar\Models\Cart;
 use Lunar\Stripe\Actions\ConstructWebhookEvent;
 use Lunar\Stripe\Components\PaymentForm;
 use Lunar\Stripe\Concerns\ConstructsWebhookEvent;
 use Lunar\Stripe\Managers\StripeManager;
+use Lunar\Stripe\Models\StripePaymentIntent;
 
 class StripePaymentsServiceProvider extends ServiceProvider
 {
@@ -23,6 +25,10 @@ class StripePaymentsServiceProvider extends ServiceProvider
         // Register our payment type.
         Payments::extend('stripe', function ($app) {
             return $app->make(StripePaymentType::class);
+        });
+
+        Cart::resolveRelationUsing('paymentIntents', function (Cart $cart) {
+            return $cart->hasMany(StripePaymentIntent::class);
         });
 
         $this->app->bind(ConstructsWebhookEvent::class, function ($app) {
@@ -41,6 +47,7 @@ class StripePaymentsServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'lunar');
         $this->loadRoutesFrom(__DIR__.'/../routes/webhooks.php');
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->mergeConfigFrom(__DIR__.'/../config/stripe.php', 'lunar.stripe');
 
         $this->publishes([

--- a/tests/stripe/Stripe/responses/payment_intent_created.json
+++ b/tests/stripe/Stripe/responses/payment_intent_created.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1234567890",
   "payment_method_options": {},
   "payment_method_types": [
     "card"

--- a/tests/stripe/Stripe/responses/payment_intent_fetched.json
+++ b/tests/stripe/Stripe/responses/payment_intent_fetched.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1234567890",
   "payment_method_options": {},
   "payment_method_types": [
     "card"

--- a/tests/stripe/Stripe/responses/payment_intent_paid.json
+++ b/tests/stripe/Stripe/responses/payment_intent_paid.json
@@ -116,7 +116,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1234567890",
   "payment_method_options": {},
   "payment_method_types": [
     "card"

--- a/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
+++ b/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use function Pest\Laravel\assertDatabaseHas;
+
+uses(\Lunar\Tests\Stripe\Unit\TestCase::class);
+
+it('can store payment intent address information', function () {
+    $cart = \Lunar\Tests\Stripe\Utils\CartBuilder::build();
+
+    $country = \Lunar\Models\Country::factory()->create([
+        'iso2' => 'GB',
+    ]);
+
+    $order = $cart->createOrder();
+
+    $paymentIntent = \Lunar\Stripe\Facades\Stripe::getClient()
+        ->paymentIntents
+        ->retrieve('PI_CAPTURE');
+
+    app(\Lunar\Stripe\Actions\StoreAddressInformation::class)->store($order, $paymentIntent);
+
+    assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
+        'first_name' => 'Buggs',
+        'last_name' => 'Bunny',
+        'city' => 'ACME Shipping Land',
+        'type' => 'shipping',
+        'country_id' => $country->id,
+        'line_one' => '123 ACME Shipping Lane',
+        'postcode' => 'AC2 2ME',
+        'state' => 'ACM3',
+        'contact_phone' => '123456',
+    ]);
+
+    assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
+        'first_name' => 'Elma',
+        'last_name' => 'Thudd',
+        'city' => 'ACME Land',
+        'type' => 'billing',
+        'country_id' => $country->id,
+        'line_one' => '123 ACME Lane',
+        'postcode' => 'AC1 1ME',
+        'state' => 'ACME',
+        'contact_email' => 'sales@acme.com',
+        'contact_phone' => '1234567',
+    ]);
+})->group('lunar.stripe.actions');

--- a/tests/stripe/Unit/Actions/UpdateOrderFromIntentTest.php
+++ b/tests/stripe/Unit/Actions/UpdateOrderFromIntentTest.php
@@ -13,7 +13,6 @@ it('creates pending transaction when status is requires_action', function () {
         ->retrieve('PI_REQUIRES_ACTION');
 
     $updatedOrder = \Lunar\Stripe\Actions\UpdateOrderFromIntent::execute($order, $paymentIntent);
-
     expect($updatedOrder->status)->toBe($order->status);
     expect($updatedOrder->placed_at)->toBeNull();
 })->group('lunar.stripe.actions');

--- a/tests/stripe/Unit/Http/Middleware/StripeWebookMiddlewareTest.php
+++ b/tests/stripe/Unit/Http/Middleware/StripeWebookMiddlewareTest.php
@@ -9,7 +9,7 @@ it('can handle valid event', function () {
             public function constructEvent(string $jsonPayload, string $signature, string $secret)
             {
                 return \Stripe\Event::constructFrom([
-                    'type' => 'payment_intent.succeeded'
+                    'type' => 'payment_intent.succeeded',
                 ]);
             }
         };

--- a/tests/stripe/Unit/Http/Middleware/StripeWebookMiddlewareTest.php
+++ b/tests/stripe/Unit/Http/Middleware/StripeWebookMiddlewareTest.php
@@ -8,7 +8,9 @@ it('can handle valid event', function () {
         {
             public function constructEvent(string $jsonPayload, string $signature, string $secret)
             {
-                return \Stripe\Event::constructFrom([]);
+                return \Stripe\Event::constructFrom([
+                    'type' => 'payment_intent.succeeded'
+                ]);
             }
         };
     });
@@ -19,5 +21,5 @@ it('can handle valid event', function () {
 
     $request = $middleware->handle($request, fn ($request) => $request);
 
-    expect($request->status())->toBe(200);
+    expect($request)->toBeInstanceOf(\Illuminate\Http\Request::class);
 });

--- a/tests/stripe/Unit/Managers/StripeManagerTest.php
+++ b/tests/stripe/Unit/Managers/StripeManagerTest.php
@@ -2,6 +2,7 @@
 
 use Lunar\Stripe\Facades\Stripe;
 use Lunar\Tests\Stripe\Utils\CartBuilder;
+
 use function Pest\Laravel\assertDatabaseHas;
 
 uses(\Lunar\Tests\Stripe\Unit\TestCase::class);

--- a/tests/stripe/Unit/Managers/StripeManagerTest.php
+++ b/tests/stripe/Unit/Managers/StripeManagerTest.php
@@ -2,13 +2,18 @@
 
 use Lunar\Stripe\Facades\Stripe;
 use Lunar\Tests\Stripe\Utils\CartBuilder;
+use function Pest\Laravel\assertDatabaseHas;
 
 uses(\Lunar\Tests\Stripe\Unit\TestCase::class);
 
 it('can create a payment intent', function () {
     $cart = CartBuilder::build();
 
-    Stripe::createIntent($cart->calculate());
+    $intent = Stripe::createIntent($cart->calculate(), []);
 
-    expect($cart->refresh()->meta['payment_intent'])->toBe('pi_1DqH152eZvKYlo2CFHYZuxkP');
+    assertDatabaseHas(\Lunar\Stripe\Models\StripePaymentIntent::class, [
+        'intent_id' => 'pi_1DqH152eZvKYlo2CFHYZuxkP',
+        'cart_id' => $cart->id,
+        'status' => $intent->status,
+    ]);
 });

--- a/tests/stripe/Unit/StripePaymentTypeTest.php
+++ b/tests/stripe/Unit/StripePaymentTypeTest.php
@@ -5,6 +5,7 @@ use Lunar\Models\Transaction;
 use Lunar\Stripe\Facades\Stripe;
 use Lunar\Stripe\StripePaymentType;
 use Lunar\Tests\Stripe\Utils\CartBuilder;
+
 use function Pest\Laravel\assertDatabaseHas;
 
 uses(\Lunar\Tests\Stripe\Unit\TestCase::class);
@@ -18,9 +19,9 @@ it('can capture an order', function () {
     ])->authorize();
 
     expect($response)->toBeInstanceOf(PaymentAuthorize::class)
-    ->and($response->success)->toBeTrue()
-    ->and($cart->refresh()->completedOrder->placed_at)->not()->toBeNull()
-    ->and($cart->paymentIntents->first()->intent_id)->toEqual('PI_CAPTURE');
+        ->and($response->success)->toBeTrue()
+        ->and($cart->refresh()->completedOrder->placed_at)->not()->toBeNull()
+        ->and($cart->paymentIntents->first()->intent_id)->toEqual('PI_CAPTURE');
 
     assertDatabaseHas((new Transaction)->getTable(), [
         'order_id' => $cart->refresh()->completedOrder->id,

--- a/tests/stripe/Unit/StripePaymentTypeTest.php
+++ b/tests/stripe/Unit/StripePaymentTypeTest.php
@@ -5,7 +5,6 @@ use Lunar\Models\Transaction;
 use Lunar\Stripe\Facades\Stripe;
 use Lunar\Stripe\StripePaymentType;
 use Lunar\Tests\Stripe\Utils\CartBuilder;
-
 use function Pest\Laravel\assertDatabaseHas;
 
 uses(\Lunar\Tests\Stripe\Unit\TestCase::class);
@@ -18,16 +17,16 @@ it('can capture an order', function () {
         'payment_intent' => 'PI_CAPTURE',
     ])->authorize();
 
-    expect($response)->toBeInstanceOf(PaymentAuthorize::class);
-    expect($response->success)->toBeTrue();
-    expect($cart->refresh()->completedOrder->placed_at)->not()->toBeNull();
-    expect($cart->meta['payment_intent'])->toEqual('PI_CAPTURE');
+    expect($response)->toBeInstanceOf(PaymentAuthorize::class)
+    ->and($response->success)->toBeTrue()
+    ->and($cart->refresh()->completedOrder->placed_at)->not()->toBeNull()
+    ->and($cart->paymentIntents->first()->intent_id)->toEqual('PI_CAPTURE');
 
     assertDatabaseHas((new Transaction)->getTable(), [
         'order_id' => $cart->refresh()->completedOrder->id,
         'type' => 'capture',
     ]);
-});
+})->group('this');
 
 it('can handle failed payments', function () {
     $cart = CartBuilder::build();


### PR DESCRIPTION
This PR looks to improve on how payment intents are stored and how to better prevent overlaps when manually placing orders via Stripe and also via the webhook.

## PaymentIntent storage and reference to carts/orders

Currently PaymentIntent information is stored in the Cart model's meta, which is then transferred to the order when created.

Whilst this works okay it causes for limitations and also means that if the carts meta is ever updated elsewhere, or the intent information is removed, then it will cause unrecoverable loss.

This PR looks to move away from the `payment_intent` key in the meta to a `StripePaymentIntent` model, this allows us more flexibility in how payment intents are handled and reacted on. A StripePaymentIntent will be associated to both a cart and an order.

The information we store is now:

- `intent_id` - This is the PaymentIntent ID which is provided by Stripe
- `status` - The PaymentIntent status
- `event_id` - If the PaymentIntent was placed via the webhook, this will be populated with the ID of that event
- `processing_at` - When a request to place the order is made, this is populated
- `processed_at` - Once the order is placed, this will be populated with the current timestamp

## Preventing overlap

Currently we delay sending the job to place the order to the queue by 20 seconds, this is less than ideal, now the payment type will check whether we are already processing this order and if so, not do anything further. This should prevent overlaps regardless of how they are triggered.