### PR TITLE
Fixed and added additional config for File Fieldtype

### DIFF
--- a/packages/admin/resources/lang/en/fieldtypes.php
+++ b/packages/admin/resources/lang/en/fieldtypes.php
@@ -53,5 +53,19 @@ return [
     ],
     'file' => [
         'label' => 'File',
+        'form' => [
+            'file_types' => [
+                'label' => 'Allowed File Types',
+            ],
+            'multiple' => [
+                'label' => 'Allow Multiple Files',
+            ],
+            'min_files' => [
+                'label' => 'Min. Files',
+            ],
+            'max_files' => [
+                'label' => 'Max. Files',
+            ],
+        ],
     ],
 ];

--- a/packages/admin/resources/lang/en/fieldtypes.php
+++ b/packages/admin/resources/lang/en/fieldtypes.php
@@ -56,6 +56,7 @@ return [
         'form' => [
             'file_types' => [
                 'label' => 'Allowed File Types',
+                'placeholder' => 'New MIME'
             ],
             'multiple' => [
                 'label' => 'Allow Multiple Files',

--- a/packages/admin/src/Support/FieldTypes/File.php
+++ b/packages/admin/src/Support/FieldTypes/File.php
@@ -45,22 +45,25 @@ class File extends BaseFieldType
     public static function getConfigurationFields(): array
     {
         return [
-            \Filament\Forms\Components\TagsInput::make('file_types')->label(
-                __('lunarpanel::fieldtypes.file.form.file_types.label')
-            )->suggestions([
-                'image/jpeg',
-                'image/png',
-                'image/gif',
-                'audio/mpeg',
-                'audio/aac',
-                'audio/wav',
-                'video/mp4',
-                'video/mpeg',
-                'application/msword',
-                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                'application/rtf',
-                'application/pdf'
-            ])->reorderable(),
+            \Filament\Forms\Components\TagsInput::make('file_types')
+                ->label(
+                    __('lunarpanel::fieldtypes.file.form.file_types.label')
+                )->suggestions([
+                    'image/jpeg',
+                    'image/png',
+                    'image/gif',
+                    'audio/mpeg',
+                    'audio/aac',
+                    'audio/wav',
+                    'video/mp4',
+                    'video/mpeg',
+                    'application/msword',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    'application/rtf',
+                    'application/pdf'
+                ])
+                ->placeholder(__('lunarpanel::fieldtypes.file.form.file_types.placeholder'))
+                ->reorderable(),
             \Filament\Forms\Components\Toggle::make('multiple')->label(
                 __('lunarpanel::fieldtypes.file.form.multiple.label')
             ),

--- a/packages/admin/src/Support/FieldTypes/File.php
+++ b/packages/admin/src/Support/FieldTypes/File.php
@@ -49,12 +49,15 @@ class File extends BaseFieldType
                 ->label(
                     __('lunarpanel::fieldtypes.file.form.file_types.label')
                 )->suggestions([
+                    'image/*',
                     'image/jpeg',
                     'image/png',
                     'image/gif',
+                    'audio/*',
                     'audio/mpeg',
                     'audio/aac',
                     'audio/wav',
+                    'video/*',
                     'video/mp4',
                     'video/mpeg',
                     'application/msword',

--- a/packages/admin/src/Support/FieldTypes/File.php
+++ b/packages/admin/src/Support/FieldTypes/File.php
@@ -13,9 +13,64 @@ class File extends BaseFieldType
 
     public static function getFilamentComponent(Attribute $attribute): Component
     {
-        return FileUpload::make($attribute->handle)
+        $file_types = $attribute->configuration->get('file_types');
+        $multiple = (bool) $attribute->configuration->get('multiple');
+        $min_files = $attribute->configuration->get('min_files');
+        $max_files = $attribute->configuration->get('max_files');
+
+        $input = FileUpload::make($attribute->handle)
             ->when(filled($attribute->validation_rules), fn (FileUpload $component) => $component->rules($attribute->validation_rules))
-            ->required((bool) $attribute->configuration->get('required'))
+            ->required((bool) $attribute->required)
             ->helperText($attribute->translate('description'));
+
+        if (!blank($file_types) && is_array($file_types)) {
+            $input->acceptedFileTypes($file_types);
+        }
+
+        if ($multiple) {
+            $input->multiple();
+        }
+
+        if ($min_files) {
+            $input->minFiles($min_files);
+        }
+
+        if ($max_files) {
+            $input->maxFiles($max_files);
+        }
+
+        return $input;
+    }
+
+    public static function getConfigurationFields(): array
+    {
+        return [
+            \Filament\Forms\Components\TagsInput::make('file_types')->label(
+                __('lunarpanel::fieldtypes.file.form.file_types.label')
+            )->suggestions([
+                'image/jpeg',
+                'image/png',
+                'image/gif',
+                'audio/mpeg',
+                'audio/aac',
+                'audio/wav',
+                'video/mp4',
+                'video/mpeg',
+                'application/msword',
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                'application/rtf',
+                'application/pdf'
+            ])->reorderable(),
+            \Filament\Forms\Components\Toggle::make('multiple')->label(
+                __('lunarpanel::fieldtypes.file.form.multiple.label')
+            ),
+            \Filament\Forms\Components\TextInput::make('min_files')
+                ->label(
+                    __('lunarpanel::fieldtypes.file.form.min_files.label')
+                )->nullable()->numeric(),
+            \Filament\Forms\Components\TextInput::make('max_files')->label(
+                __('lunarpanel::fieldtypes.file.form.max_files.label')
+            )->nullable()->numeric(),
+        ];
     }
 }

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -62,6 +62,12 @@ class AttributeData
                 return $state;
             })
             ->mutateDehydratedStateUsing(function ($state) use ($attribute) {
+                if ($attribute->type == FileFieldType::class) {
+                    $instance = new $attribute->type;
+                    $instance->setValue($state);
+                    return $instance;
+                }
+
                 if (
                     ! $state ||
                     (get_class($state) != $attribute->type)

--- a/packages/admin/src/Support/Synthesizers/FileSynth.php
+++ b/packages/admin/src/Support/Synthesizers/FileSynth.php
@@ -3,6 +3,7 @@
 namespace Lunar\Admin\Support\Synthesizers;
 
 use Lunar\FieldTypes\File;
+use Illuminate\Support\Arr;
 
 class FileSynth extends AbstractFieldSynth
 {
@@ -21,7 +22,7 @@ class FileSynth extends AbstractFieldSynth
 
         $instance->setValue($value);
 
-        return $instance;
+        return Arr::wrap($value);
     }
 
     public function get(&$target, $key)

--- a/packages/core/src/FieldTypes/File.php
+++ b/packages/core/src/FieldTypes/File.php
@@ -8,7 +8,7 @@ use Lunar\Base\FieldType;
 class File implements FieldType, JsonSerializable
 {
     /**
-     * @var array|null
+     * @var string|array|null
      */
     protected $value;
 
@@ -30,7 +30,7 @@ class File implements FieldType, JsonSerializable
     /**
      * Create a new instance of File field type.
      *
-     * @param  array|null  $value
+     * @param  string|array|null  $value
      */
     public function __construct($value = null)
     {
@@ -54,7 +54,7 @@ class File implements FieldType, JsonSerializable
     /**
      * Return the value of this field.
      *
-     * @return array|null
+     * @return string|array|null
      */
     public function getValue()
     {
@@ -64,7 +64,7 @@ class File implements FieldType, JsonSerializable
     /**
      * Set the value of this field.
      *
-     * @param  array|null  $value
+     * @param  string|array|null  $value
      */
     public function setValue($value)
     {
@@ -82,6 +82,7 @@ class File implements FieldType, JsonSerializable
     {
         return [
             'options' => [
+                'file_types' => 'array',
                 'multiple' => 'boolean',
                 'max_files' => 'numeric',
                 'min_files' => 'numeric'

--- a/packages/core/src/FieldTypes/File.php
+++ b/packages/core/src/FieldTypes/File.php
@@ -45,7 +45,7 @@ class File implements FieldType, JsonSerializable
     public function __toString()
     {
         if (is_array($this->getValue())) {
-            return implode(",", $this->getValue());
+            return implode(", ", $this->getValue());
         }
 
         return $this->getValue() ?? "";

--- a/packages/core/src/FieldTypes/File.php
+++ b/packages/core/src/FieldTypes/File.php
@@ -8,7 +8,7 @@ use Lunar\Base\FieldType;
 class File implements FieldType, JsonSerializable
 {
     /**
-     * @var string
+     * @var array|null
      */
     protected $value;
 
@@ -30,9 +30,9 @@ class File implements FieldType, JsonSerializable
     /**
      * Create a new instance of File field type.
      *
-     * @param  string  $value
+     * @param  array|null  $value
      */
-    public function __construct($value = '')
+    public function __construct($value = null)
     {
         $this->setValue($value);
     }
@@ -44,13 +44,17 @@ class File implements FieldType, JsonSerializable
      */
     public function __toString()
     {
-        return $this->getValue();
+        if (is_array($this->getValue())) {
+            return implode(",", $this->getValue());
+        }
+
+        return $this->getValue() ?? "";
     }
 
     /**
      * Return the value of this field.
      *
-     * @return string
+     * @return array|null
      */
     public function getValue()
     {
@@ -60,10 +64,14 @@ class File implements FieldType, JsonSerializable
     /**
      * Set the value of this field.
      *
-     * @param  string  $value
+     * @param  array|null  $value
      */
     public function setValue($value)
     {
+        if (blank($value)) {
+            $value = null;
+        }
+
         $this->value = $value;
     }
 
@@ -74,7 +82,9 @@ class File implements FieldType, JsonSerializable
     {
         return [
             'options' => [
+                'multiple' => 'boolean',
                 'max_files' => 'numeric',
+                'min_files' => 'numeric'
             ],
         ];
     }


### PR DESCRIPTION
This pull request fixes the File Attribute and its issue of receiving a `Livewire\Exceptions\CorruptComponentPayloadException` and not uploading the file. Additionally, this fieldtype can handle multiple files and configuration options were added: File Types, Multiple Files, Min Files, and Max Files.

Of importance is the change in the handling of the dehydrated state for the File Attribute in  [AttributeData](https://github.com/maurice-ellis/lunar/blob/3e19fc1a7f6a82ceef814e74c0cd71249b798e9c/packages/admin/src/Support/Forms/AttributeData.php#L65) that happens after the file upload.

Before dehydrating, files are uploaded by [BaseFileUpload](https://github.com/filamentphp/filament/blob/b083225530c336ae86cf288a276d139dd0057b82/packages/forms/src/Components/BaseFileUpload.php#L130) and a string or array is returned, which was not properly handled previouslly.

