### PR TITLE
Store address information that comes from Stripe

### DIFF
--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,11 +18,11 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
-## 1.0.0-alpha.37
+## [Unreleased]
 
 #### Stripe Addon
 
-The Stripe addon will now attempt to update an orders billing and shipping address based on what has been stored against the Payment Intent. This is due to Stripe not always returning this information during their express checkout flows. This can be disabled by setting the `lunar.stripe.sync_addresses` config value to `false`.
+The Stripe addon will now attempt to update an order's billing and shipping address based on what has been stored against the Payment Intent. This is due to Stripe not always returning this information during their express checkout flows. This can be disabled by setting the `lunar.stripe.sync_addresses` config value to `false`.
 
 ## 1.0.0-alpha.34
 

--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -18,6 +18,12 @@ php artisan migrate
 
 Lunar currently provides bug fixes and security updates for only the latest minor release, e.g. `0.8`.
 
+## 1.0.0-alpha.37
+
+#### Stripe Addon
+
+The Stripe addon will now attempt to update an orders billing and shipping address based on what has been stored against the Payment Intent. This is due to Stripe not always returning this information during their express checkout flows. This can be disabled by setting the `lunar.stripe.sync_addresses` config value to `false`.
+
 ## 1.0.0-alpha.34
 
 ### Medium Impact

--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -92,10 +92,10 @@ Make sure you have the Stripe credentials set in `config/services.php`
 
 Below is a list of the available configuration options this package uses in `config/lunar/stripe.php`
 
-| Key | Default | Description |
-| --- | --- | --- |
-| `policy` | `automatic` | Determines the policy for taking payments and whether you wish to capture the payment manually later or take payment straight away. Available options `manual` or `automatic` |
-
+| Key              | Default      | Description                                                                                                                                                                   |
+|------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `policy`         | `automatic`  | Determines the policy for taking payments and whether you wish to capture the payment manually later or take payment straight away. Available options `manual` or `automatic` |
+| `sync_addresses` | `true`       | When enabled, the Stripe addon will attempt to sync the billing and shipping addresses which have been stored against the payment intent on Stripe.                           |
 ---
 
 ## Backend Usage

--- a/packages/stripe/config/stripe.php
+++ b/packages/stripe/config/stripe.php
@@ -27,6 +27,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Sync addresses
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the Stripe addon will attempt to sync the billing and shipping
+    | addresses which have been stored against the payment intent on Stripe.
+    | This is useful when you don't always get the full address during the
+    | checkout process, which can be the case when using express checkout.
+    |
+    */
+    'sync_addresses' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Status mapping
     |--------------------------------------------------------------------------
     |

--- a/packages/stripe/resources/responses/payment_intent_created.json
+++ b/packages/stripe/resources/responses/payment_intent_created.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -38,7 +38,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+    "shipping": {
+        "address": {
+            "city": "ACME Shipping Land",
+            "country": "GB",
+            "line1": "123 ACME Shipping Lane",
+            "line2": null,
+            "postal_code": "AC2 2ME",
+            "state": "ACM3"
+        },
+        "phone": "123456",
+        "name": "Buggs Bunny"
+    },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "requires_payment_method",

--- a/packages/stripe/resources/responses/payment_intent_fetched.json
+++ b/packages/stripe/resources/responses/payment_intent_fetched.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+    "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -38,7 +38,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+  "shipping": {
+      "address": {
+          "city": "ACME Shipping Land",
+          "country": "GB",
+          "line1": "123 ACME Shipping Lane",
+          "line2": null,
+          "postal_code": "AC2 2ME",
+          "state": "ACM3"
+      },
+      "phone": "123456",
+      "name": "Buggs Bunny"
+  },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "requires_payment_method",

--- a/packages/stripe/resources/responses/payment_intent_paid.json
+++ b/packages/stripe/resources/responses/payment_intent_paid.json
@@ -217,7 +217,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -227,7 +227,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+  "shipping": {
+      "address": {
+          "city": "ACME Shipping Land",
+          "country": "GB",
+          "line1": "123 ACME Shipping Lane",
+          "line2": null,
+          "postal_code": "AC2 2ME",
+          "state": "ACM3"
+      },
+      "phone": "123456",
+      "name": "Buggs Bunny"
+  },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "{status}",

--- a/packages/stripe/resources/responses/payment_intent_requires_payment_method.json
+++ b/packages/stripe/resources/responses/payment_intent_requires_payment_method.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
   "payment_method_options": {},
   "payment_method_types": [
     "card"
@@ -38,7 +38,18 @@
   "redaction": null,
   "review": null,
   "setup_future_usage": null,
-  "shipping": null,
+  "shipping": {
+      "address": {
+          "city": "ACME Shipping Land",
+          "country": "GB",
+          "line1": "123 ACME Shipping Lane",
+          "line2": null,
+          "postal_code": "AC2 2ME",
+          "state": "ACM3"
+      },
+      "phone": "123456",
+      "name": "Buggs Bunny"
+  },
   "statement_descriptor": null,
   "statement_descriptor_suffix": null,
   "status": "requires_payment_method",

--- a/packages/stripe/resources/responses/payment_method.json
+++ b/packages/stripe/resources/responses/payment_method.json
@@ -1,0 +1,47 @@
+{
+    "id": "pm_1MqLiJLkdIwHu7ixUEgbFdYF",
+    "object": "payment_method",
+    "billing_details": {
+        "address": {
+            "city": "ACME Land",
+            "country": "GB",
+            "line1": "123 ACME Lane",
+            "line2": null,
+            "postal_code": "AC1 1ME",
+            "state": "ACME"
+        },
+        "email": "sales@acme.com",
+        "name": "Elma Thudd",
+        "phone": "1234567"
+    },
+    "card": {
+        "brand": "visa",
+        "checks": {
+            "address_line1_check": null,
+            "address_postal_code_check": null,
+            "cvc_check": "unchecked"
+        },
+        "country": "US",
+        "exp_month": 8,
+        "exp_year": 2026,
+        "fingerprint": "mToisGZ01V71BCos",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+            "available": [
+                "visa"
+            ],
+            "preferred": null
+        },
+        "three_d_secure_usage": {
+            "supported": true
+        },
+        "wallet": null
+    },
+    "created": 1679945299,
+    "customer": null,
+    "livemode": false,
+    "metadata": {},
+    "type": "card"
+}

--- a/packages/stripe/src/Actions/StoreAddressInformation.php
+++ b/packages/stripe/src/Actions/StoreAddressInformation.php
@@ -33,7 +33,7 @@ class StoreAddressInformation
             $shippingAddress->city = $stripeShipping->city;
             $shippingAddress->state = $stripeShipping->state;
             $shippingAddress->postcode = $stripeShipping->postal_code;
-            $shippingAddress->country_id = $country->id;
+            $shippingAddress->country_id = $country?->id;
             $shippingAddress->contact_phone = $paymentIntent->shipping->phone;
             $shippingAddress->save();
         }
@@ -47,7 +47,7 @@ class StoreAddressInformation
             $billingAddress->city = $stripeBilling->city;
             $billingAddress->state = $stripeBilling->state;
             $billingAddress->postcode = $stripeBilling->postal_code;
-            $billingAddress->country_id = $country->id;
+            $billingAddress->country_id = $country?->id;
             $billingAddress->contact_phone = $paymentMethod->billing_details->phone;
             $billingAddress->contact_email = $paymentMethod->billing_details->email;
             $billingAddress->save();

--- a/packages/stripe/src/Actions/StoreAddressInformation.php
+++ b/packages/stripe/src/Actions/StoreAddressInformation.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lunar\Stripe\Actions;
+
+use Lunar\Models\Country;
+use Lunar\Models\Order;
+use Lunar\Models\OrderAddress;
+use Lunar\Stripe\Facades\Stripe;
+use Stripe\PaymentIntent;
+
+class StoreAddressInformation
+{
+    public function store(Order $order, PaymentIntent $paymentIntent)
+    {
+        $billingAddress = $order->billingAddress ?: new OrderAddress([
+            'order_id' => $order->id,
+            'type' => 'billing',
+        ]);
+
+        $shippingAddress = $order->shippingAddress ?: new OrderAddress([
+            'order_id' => $order->id,
+            'type' => 'shipping',
+        ]);
+
+        $paymentMethod = Stripe::getPaymentMethod($paymentIntent->payment_method);
+
+        if ($paymentIntent->shipping && $stripeShipping = $paymentIntent->shipping->address) {
+            $country = Country::where('iso2', $stripeShipping->country)->first();
+            $shippingAddress->first_name = explode(' ', $paymentIntent->shipping->name)[0];
+            $shippingAddress->last_name = explode(' ', $paymentIntent->shipping->name)[1] ?? '';
+            $shippingAddress->line_one = $stripeShipping->line1;
+            $shippingAddress->line_two = $stripeShipping->line2;
+            $shippingAddress->city = $stripeShipping->city;
+            $shippingAddress->state = $stripeShipping->state;
+            $shippingAddress->postcode = $stripeShipping->postal_code;
+            $shippingAddress->country_id = $country->id;
+            $shippingAddress->contact_phone = $paymentIntent->shipping->phone;
+            $shippingAddress->save();
+        }
+
+        if ($paymentMethod && $stripeBilling = $paymentMethod->billing_details?->address) {
+            $country = Country::where('iso2', $stripeBilling->country)->first();
+            $billingAddress->first_name = explode(' ', $paymentMethod->billing_details->name)[0];
+            $billingAddress->last_name = explode(' ', $paymentMethod->billing_details->name)[1] ?? '';
+            $billingAddress->line_one = $stripeBilling->line1;
+            $billingAddress->line_two = $stripeBilling->line2;
+            $billingAddress->city = $stripeBilling->city;
+            $billingAddress->state = $stripeBilling->state;
+            $billingAddress->postcode = $stripeBilling->postal_code;
+            $billingAddress->country_id = $country->id;
+            $billingAddress->contact_phone = $paymentMethod->billing_details->phone;
+            $billingAddress->contact_email = $paymentMethod->billing_details->email;
+            $billingAddress->save();
+        }
+    }
+}

--- a/packages/stripe/src/Actions/UpdateOrderFromIntent.php
+++ b/packages/stripe/src/Actions/UpdateOrderFromIntent.php
@@ -34,7 +34,7 @@ class UpdateOrderFromIntent
                 return $order;
             }
 
-            if (config('lunar.stripe.sync_addresses', true)) {
+            if (config('lunar.stripe.sync_addresses', true) && $paymentIntent->payment_method) {
                 (new StoreAddressInformation)->store($order, $paymentIntent);
             }
 

--- a/packages/stripe/src/Actions/UpdateOrderFromIntent.php
+++ b/packages/stripe/src/Actions/UpdateOrderFromIntent.php
@@ -34,6 +34,8 @@ class UpdateOrderFromIntent
                 return $order;
             }
 
+            (new StoreAddressInformation)->store($order, $paymentIntent);
+
             $order->update([
                 'status' => $statuses[$paymentIntent->status] ?? $paymentIntent->status,
                 'placed_at' => $order->placed_at ?: $placedAt,

--- a/packages/stripe/src/Actions/UpdateOrderFromIntent.php
+++ b/packages/stripe/src/Actions/UpdateOrderFromIntent.php
@@ -34,7 +34,9 @@ class UpdateOrderFromIntent
                 return $order;
             }
 
-            (new StoreAddressInformation)->store($order, $paymentIntent);
+            if (config('lunar.stripe.sync_addresses', true)) {
+                (new StoreAddressInformation)->store($order, $paymentIntent);
+            }
 
             $order->update([
                 'status' => $statuses[$paymentIntent->status] ?? $paymentIntent->status,

--- a/packages/stripe/src/MockClient.php
+++ b/packages/stripe/src/MockClient.php
@@ -111,6 +111,14 @@ class MockClient implements ClientInterface
             return [$this->rBody, $this->rcode, $this->rheaders];
         }
 
+        if ($method == 'get' && str_contains($absUrl, 'payment_methods')) {
+            $this->rBody = $this->getResponse('payment_method', [
+                'id' => $id,
+            ]);
+
+            return [$this->rBody, $this->rcode, $this->rheaders];
+        }
+
         return [$this->rBody, $this->rcode, $this->rheaders];
     }
 

--- a/tests/stripe/Stripe/responses/payment_intent_created.json
+++ b/tests/stripe/Stripe/responses/payment_intent_created.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1234567890",
   "payment_method_options": {},
   "payment_method_types": [
     "card"

--- a/tests/stripe/Stripe/responses/payment_intent_fetched.json
+++ b/tests/stripe/Stripe/responses/payment_intent_fetched.json
@@ -28,7 +28,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1234567890",
   "payment_method_options": {},
   "payment_method_types": [
     "card"

--- a/tests/stripe/Stripe/responses/payment_intent_paid.json
+++ b/tests/stripe/Stripe/responses/payment_intent_paid.json
@@ -116,7 +116,7 @@
   "metadata": {},
   "next_action": null,
   "on_behalf_of": null,
-  "payment_method": null,
+  "payment_method": "pm_1234567890",
   "payment_method_options": {},
   "payment_method_types": [
     "card"

--- a/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
+++ b/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use function Pest\Laravel\assertDatabaseHas;
+
+uses(\Lunar\Tests\Stripe\Unit\TestCase::class);
+
+it('can store payment intent address information', function () {
+    $cart = \Lunar\Tests\Stripe\Utils\CartBuilder::build();
+
+    $country = \Lunar\Models\Country::factory()->create([
+        'iso2' => 'GB',
+    ]);
+
+    $order = $cart->createOrder();
+
+    $paymentIntent = \Lunar\Stripe\Facades\Stripe::getClient()
+        ->paymentIntents
+        ->retrieve('PI_CAPTURE');
+
+    app(\Lunar\Stripe\Actions\StoreAddressInformation::class)->store($order, $paymentIntent);
+
+//    "address": {
+//        "city": "ACME Shipping Land",
+//          "country": "GB",
+//          "line1": "123 ACME Shipping Lane",
+//          "line2": null,
+//          "postal_code": "AC2 2ME",
+//          "state": "ACM3"
+//      },
+//      "email": "sales@acme.com",
+//      "name": "Buggs Bunny"
+//
+    assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
+        'first_name' => 'Buggs',
+        'last_name' => 'Bunny',
+        'city' => 'ACME Shipping Land',
+        'type' => 'shipping',
+        'country_id' => $country->id,
+        'line_one' => '123 ACME Shipping Lane',
+        'postcode' => 'AC2 2ME',
+        'state' => 'ACM3',
+        'contact_phone' => '123456'
+    ]);
+
+    assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
+        'first_name' => 'Elma',
+        'last_name' => 'Thudd',
+        'city' => 'ACME Land',
+        'type' => 'billing',
+        'country_id' => $country->id,
+        'line_one' => '123 ACME Lane',
+        'postcode' => 'AC1 1ME',
+        'state' => 'ACME',
+        'contact_email' => 'sales@acme.com',
+        'contact_phone' => '1234567'
+    ]);
+})->group('lunar.stripe.actions');

--- a/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
+++ b/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
@@ -19,17 +19,6 @@ it('can store payment intent address information', function () {
 
     app(\Lunar\Stripe\Actions\StoreAddressInformation::class)->store($order, $paymentIntent);
 
-    //    "address": {
-    //        "city": "ACME Shipping Land",
-    //          "country": "GB",
-    //          "line1": "123 ACME Shipping Lane",
-    //          "line2": null,
-    //          "postal_code": "AC2 2ME",
-    //          "state": "ACM3"
-    //      },
-    //      "email": "sales@acme.com",
-    //      "name": "Buggs Bunny"
-    //
     assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
         'first_name' => 'Buggs',
         'last_name' => 'Bunny',

--- a/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
+++ b/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
@@ -19,17 +19,17 @@ it('can store payment intent address information', function () {
 
     app(\Lunar\Stripe\Actions\StoreAddressInformation::class)->store($order, $paymentIntent);
 
-//    "address": {
-//        "city": "ACME Shipping Land",
-//          "country": "GB",
-//          "line1": "123 ACME Shipping Lane",
-//          "line2": null,
-//          "postal_code": "AC2 2ME",
-//          "state": "ACM3"
-//      },
-//      "email": "sales@acme.com",
-//      "name": "Buggs Bunny"
-//
+    //    "address": {
+    //        "city": "ACME Shipping Land",
+    //          "country": "GB",
+    //          "line1": "123 ACME Shipping Lane",
+    //          "line2": null,
+    //          "postal_code": "AC2 2ME",
+    //          "state": "ACM3"
+    //      },
+    //      "email": "sales@acme.com",
+    //      "name": "Buggs Bunny"
+    //
     assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
         'first_name' => 'Buggs',
         'last_name' => 'Bunny',
@@ -39,7 +39,7 @@ it('can store payment intent address information', function () {
         'line_one' => '123 ACME Shipping Lane',
         'postcode' => 'AC2 2ME',
         'state' => 'ACM3',
-        'contact_phone' => '123456'
+        'contact_phone' => '123456',
     ]);
 
     assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
@@ -52,6 +52,6 @@ it('can store payment intent address information', function () {
         'postcode' => 'AC1 1ME',
         'state' => 'ACME',
         'contact_email' => 'sales@acme.com',
-        'contact_phone' => '1234567'
+        'contact_phone' => '1234567',
     ]);
 })->group('lunar.stripe.actions');


### PR DESCRIPTION
When using Stripe frontend tools, such as Express checkout, we don't always get the complete address information sent back. This can cause a problem for Lunar as we're potentially storing a small subset of what is actually on the payment intent.

This PR looks to add a new action which updates the billing and shipping addresses on Lunar during placement, using the payment intent as the source of truth.

This is enabled/disabled via a new config option

```
// config/lunar/stripe.php

<?php

return [
    // ...
    'sync_addresses' => true,
];
```
