### PR TITLE
Add Postgres support for query sorting

### DIFF
--- a/packages/admin/src/Support/Pages/BaseListRecords.php
+++ b/packages/admin/src/Support/Pages/BaseListRecords.php
@@ -45,7 +45,7 @@ abstract class BaseListRecords extends ListRecords
 
             $query->when(
                 ! $ids->isEmpty(),
-                fn ($query) => $query->orderByRaw("field(id, {$placeholders})", $ids->toArray()) // TODO: Only supports MySQL
+                fn ($query) => $query->orderBySequence($ids->toArray()) // TODO: Only supports MySQL
             );
         }
 

--- a/packages/admin/src/Support/Pages/BaseListRecords.php
+++ b/packages/admin/src/Support/Pages/BaseListRecords.php
@@ -45,7 +45,7 @@ abstract class BaseListRecords extends ListRecords
 
             $query->when(
                 ! $ids->isEmpty(),
-                fn ($query) => $query->orderBySequence($ids->toArray()) // TODO: Only supports MySQL
+                fn ($query) => $query->orderBySequence($ids->toArray())
             );
         }
 

--- a/packages/admin/src/Support/Resources/BaseResource.php
+++ b/packages/admin/src/Support/Resources/BaseResource.php
@@ -12,7 +12,6 @@ use Lunar\Admin\Support\Concerns;
 use Lunar\Base\Traits\Searchable;
 use Lunar\FieldTypes\TranslatedText;
 use Lunar\Models\Attribute;
-
 use function Filament\Support\generate_search_term_expression;
 
 class BaseResource extends Resource
@@ -76,7 +75,7 @@ class BaseResource extends Resource
 
             $query->when(
                 ! $ids->isEmpty(),
-                fn ($query) => $query->orderByRaw("field(id, {$placeholders})", $ids->toArray())
+                fn ($query) => $query->orderBySequence($ids->toArray())
             );
 
         } else {

--- a/packages/admin/src/Support/Resources/BaseResource.php
+++ b/packages/admin/src/Support/Resources/BaseResource.php
@@ -12,6 +12,7 @@ use Lunar\Admin\Support\Concerns;
 use Lunar\Base\Traits\Searchable;
 use Lunar\FieldTypes\TranslatedText;
 use Lunar\Models\Attribute;
+
 use function Filament\Support\generate_search_term_expression;
 
 class BaseResource extends Resource

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -44,7 +44,6 @@ use Lunar\Console\Commands\Orders\SyncNewCustomerOrders;
 use Lunar\Console\Commands\PruneCarts;
 use Lunar\Console\Commands\ScoutIndexerCommand;
 use Lunar\Console\InstallLunar;
-use Lunar\Core\Macro\Builder\OrderBySequence;
 use Lunar\Database\State\ConvertBackOrderPurchasability;
 use Lunar\Database\State\ConvertProductTypeAttributesToProducts;
 use Lunar\Database\State\ConvertTaxbreakdown;
@@ -324,6 +323,7 @@ class LunarServiceProvider extends ServiceProvider
 
             if ($driver === 'mysql') {
                 $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
                 return $this->orderByRaw("FIELD(id, {$placeholders})", $ids);
             }
 
@@ -332,7 +332,8 @@ class LunarServiceProvider extends ServiceProvider
                 foreach ($ids as $index => $id) {
                     $orderCases .= "WHEN id = $id THEN $index ";
                 }
-                return $this->orderByRaw("CASE $orderCases ELSE " . count($ids) . " END");
+
+                return $this->orderByRaw("CASE $orderCases ELSE ".count($ids).' END');
             }
 
             return $this;


### PR DESCRIPTION
This PR looks to add a new `orderBySequence` macro to the Eloquent Builder class which adds PostgreSQL support when needing to order records from the query builder based on an array of ID's in a certain order.