### PR TITLE
Link to Laravel Herd in Starter Kit docs

### DIFF
--- a/docs/core/starter-kits.md
+++ b/docs/core/starter-kits.md
@@ -22,8 +22,7 @@ If you would prefer to install Lunar into your own Laravel application, please f
 ## Installation
 
 ::: tip
-We assume you have a suitable local development environment in which to run Lunar. We would highly suggest Laravel Herd 
-for this purpose.
+We assume you have a suitable local development environment in which to run Lunar. We would highly suggest [Laravel Herd](https://herd.laravel.com) for this purpose.
 :::
 
 ### Create a New Project


### PR DESCRIPTION
Adds a link to Laravel Herd in the tip on the starter kit page of the docs.