### PR TITLE
Fix Postgres issue on create customer page

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource.php
@@ -159,7 +159,13 @@ class CustomerResource extends BaseResource
     {
         return Forms\Components\CheckboxList::make('customerGroups')
             ->label(__('lunarpanel::customer.form.customer_groups.label'))
-            ->relationship(name: 'customerGroups', titleAttribute: 'name');
+            ->relationship(
+                name: 'customerGroups',
+                titleAttribute: 'name',
+                modifyQueryUsing: fn (Builder $query) => $query->distinct(
+                    ['id', 'name', 'handle', 'default']
+                )
+            );
     }
 
     protected static function getDefaultTable(Table $table): Table


### PR DESCRIPTION
There is an issue on the customer create page relating to the `CheckboxList` component which is linked to the `customerGroups` relationship. It appears that Filament uses `DISTINCT lunar_customer_groups.*` in the query and will throw a query exception due to a json field.

This PR overrides the query to explicitly select the columns, ignoring the `attribute_data` json column.