### PR TITLE
Tweak best sellers to 30 days

### DIFF
--- a/packages/admin/resources/lang/en/widgets.php
+++ b/packages/admin/resources/lang/en/widgets.php
@@ -83,7 +83,7 @@ return [
                 ],
             ],
             'popular_products' => [
-                'heading' => 'This months best sellers',
+                'heading' => 'Best Sellers (last 30 days)',
                 'description' => 'These figures are based on the number of times a product appears on an order, not the quantity ordered.',
             ],
             'latest_orders' => [

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductShipping.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductShipping.php
@@ -70,8 +70,8 @@ class ManageProductShipping extends BaseEditRecord
         $variant = $this->getVariant();
 
         $this->dimensions = [
-            ...$this->dimensions,
             ...$variant->only(array_keys($this->dimensions)),
+            ...$this->dimensions,
         ];
         $this->shippable = $variant->shippable;
     }

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductShipping.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductShipping.php
@@ -70,8 +70,8 @@ class ManageProductShipping extends BaseEditRecord
         $variant = $this->getVariant();
 
         $this->dimensions = [
-            ...$variant->only(array_keys($this->dimensions)),
             ...$this->dimensions,
+            ...$variant->only(array_keys($this->dimensions)),
         ];
         $this->shippable = $variant->shippable;
     }

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/PopularProductsTable.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/PopularProductsTable.php
@@ -34,7 +34,7 @@ class PopularProductsTable extends TableWidget
             ->query(function () {
                 return OrderLine::query()->whereHas('order', function ($relation) {
                     $relation->whereBetween('placed_at', [
-                        now()->subYear()->startOfMonth(),
+                        now()->subDays(30)->startOfDay(),
                         now()->endOfDay(),
                     ]);
                 })->select(


### PR DESCRIPTION
This PR looks to tweak the Best sellers widget on the dashboard to be a 30 day period instead of a year.