### PR TITLE
Swamp merge order on product shipping

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductShipping.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductShipping.php
@@ -70,8 +70,8 @@ class ManageProductShipping extends BaseEditRecord
         $variant = $this->getVariant();
 
         $this->dimensions = [
-            ...$variant->only(array_keys($this->dimensions)),
             ...$this->dimensions,
+            ...$variant->only(array_keys($this->dimensions)),
         ];
         $this->shippable = $variant->shippable;
     }


### PR DESCRIPTION
Swaps the merge order for dimensions due to the defaults overriding values saved agains the variant.
