### PR TITLE
Force cart calculation when calling `estimateShipping`

### DIFF
--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -149,7 +149,6 @@ class CartSessionManager implements CartSessionInterface
         }
 
         $this->cart = $cart;
-
         if ($calculate) {
             $this->cart->calculate();
         }
@@ -175,6 +174,7 @@ class CartSessionManager implements CartSessionInterface
             $this->getShippingEstimateMeta(),
             setOverride: true
         );
+        $this->cart->calculate(force: true);
     }
 
     /**


### PR DESCRIPTION
When estimating the shipping, the cart isn't being forced to calculate which results in the cart not properly applying the estimated shipping when going through the pipelines.