### PR TITLE
Fix cart merging - old cart should merge into new one

### DIFF
--- a/packages/core/src/Actions/Carts/AssociateUser.php
+++ b/packages/core/src/Actions/Carts/AssociateUser.php
@@ -18,7 +18,7 @@ class AssociateUser extends AbstractAction
         if ($policy == 'merge') {
             $userCart = Cart::whereUserId($user->getKey())->active()->unMerged()->latest()->first();
             if ($userCart) {
-                app(MergeCart::class)->execute($userCart, $cart);
+                app(MergeCart::class)->execute($cart, $userCart);
             }
         }
 


### PR DESCRIPTION
This PR fixes cart merging (`lunar.cart.auth_policy: merge`) to ensure that the current cart session is the one that has the line items applied to it, before this PR it was being applied to the old cart which didn't make sense.