### PR TITLE
Manually map models on migration instead of loading via directory

### DIFF
--- a/packages/core/database/migrations/2024_03_15_100000_remap_polymorphic_relations.php
+++ b/packages/core/database/migrations/2024_03_15_100000_remap_polymorphic_relations.php
@@ -55,7 +55,7 @@ class RemapPolymorphicRelations extends Migration
                 $class => \Lunar\Facades\ModelManifest::getMorphMapKey($class),
             ]
         );
-        
+
         $tables = [
             'attributables' => ['attributable_type'],
             'attributes' => ['attribute_type'],

--- a/packages/core/database/migrations/2024_03_15_100000_remap_polymorphic_relations.php
+++ b/packages/core/database/migrations/2024_03_15_100000_remap_polymorphic_relations.php
@@ -1,25 +1,61 @@
 <?php
 
 use Illuminate\Support\Facades\Schema;
-use Lunar\Base\BaseModel;
 use Lunar\Base\Migration;
-use Spatie\StructureDiscoverer\Discover;
 
 class RemapPolymorphicRelations extends Migration
 {
     public function up()
     {
-        $modelClasses = collect(
-            Discover::in(__DIR__.'/../../src/Models')
-                ->classes()
-                ->extending(BaseModel::class)
-                ->get()
-        )->mapWithKeys(
+        $modelClasses = collect([
+            \Lunar\Models\CartLine::class,
+            \Lunar\Models\ProductOption::class,
+            \Lunar\Models\Asset::class,
+            \Lunar\Models\Brand::class,
+            \Lunar\Models\TaxZone::class,
+            \Lunar\Models\TaxZoneCountry::class,
+            \Lunar\Models\TaxZoneCustomerGroup::class,
+            \Lunar\Models\DiscountCollection::class,
+            \Lunar\Models\TaxClass::class,
+            \Lunar\Models\ProductOptionValue::class,
+            \Lunar\Models\Channel::class,
+            \Lunar\Models\AttributeGroup::class,
+            \Lunar\Models\Tag::class,
+            \Lunar\Models\Cart::class,
+            \Lunar\Models\Collection::class,
+            \Lunar\Models\Discount::class,
+            \Lunar\Models\TaxRate::class,
+            \Lunar\Models\Price::class,
+            \Lunar\Models\DiscountPurchasable::class,
+            \Lunar\Models\State::class,
+            \Lunar\Models\UserPermission::class,
+            \Lunar\Models\OrderAddress::class,
+            \Lunar\Models\Country::class,
+            \Lunar\Models\Address::class,
+            \Lunar\Models\Url::class,
+            \Lunar\Models\ProductVariant::class,
+            \Lunar\Models\TaxZonePostcode::class,
+            \Lunar\Models\ProductAssociation::class,
+            \Lunar\Models\TaxRateAmount::class,
+            \Lunar\Models\Attribute::class,
+            \Lunar\Models\Order::class,
+            \Lunar\Models\Customer::class,
+            \Lunar\Models\OrderLine::class,
+            \Lunar\Models\CartAddress::class,
+            \Lunar\Models\Language::class,
+            \Lunar\Models\TaxZoneState::class,
+            \Lunar\Models\Currency::class,
+            \Lunar\Models\Product::class,
+            \Lunar\Models\Transaction::class,
+            \Lunar\Models\ProductType::class,
+            \Lunar\Models\CollectionGroup::class,
+            \Lunar\Models\CustomerGroup::class,
+        ])->mapWithKeys(
             fn ($class) => [
                 $class => \Lunar\Facades\ModelManifest::getMorphMapKey($class),
             ]
         );
-
+        
         $tables = [
             'attributables' => ['attributable_type'],
             'attributes' => ['attribute_type'],


### PR DESCRIPTION
Currently if you publish the migrations they can fail due to trying to read a directory relative to the the vendor folder. This PR instead opts to manually map the models to prevent this issue completely.