### PR TITLE
fix(core): respect table prefix config in search index

### DIFF
--- a/packages/core/src/Search/ScoutIndexer.php
+++ b/packages/core/src/Search/ScoutIndexer.php
@@ -12,7 +12,8 @@ class ScoutIndexer implements ScoutIndexerInterface
 {
     public function searchableAs(Model $model): string
     {
-        $name = str_replace('lunar_', '', $model->getTable());
+        $tablePrefix = config('lunar.database.table_prefix');
+        $name = str_replace($tablePrefix, '', $model->getTable());
 
         return config('scout.prefix').$name;
     }


### PR DESCRIPTION
It might not be crucial for things to work. But, from its appearance, it's supposed to strip the table prefix from the model's table. So, updated the code to make it behave as intended.