### PR TITLE
Extending models breaks pipelines

### DIFF
--- a/packages/core/database/factories/CartFactory.php
+++ b/packages/core/database/factories/CartFactory.php
@@ -2,9 +2,9 @@
 
 namespace Lunar\Database\Factories;
 
-use Lunar\Models\Cart;
 use Lunar\Models\Channel;
 use Lunar\Models\Currency;
+use Lunar\Tests\Core\Stubs\Models\Cart;
 
 class CartFactory extends BaseFactory
 {

--- a/packages/core/database/factories/OrderFactory.php
+++ b/packages/core/database/factories/OrderFactory.php
@@ -4,7 +4,7 @@ namespace Lunar\Database\Factories;
 
 use Lunar\Base\ValueObjects\Cart\TaxBreakdown;
 use Lunar\Models\Channel;
-use Lunar\Models\Order;
+use Lunar\Tests\Core\Stubs\Models\Order;
 
 class OrderFactory extends BaseFactory
 {

--- a/tests/core/Stubs/Models/Cart.php
+++ b/tests/core/Stubs/Models/Cart.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs\Models;
+
+class Cart extends \Lunar\Models\Cart {}

--- a/tests/core/Stubs/Models/Order.php
+++ b/tests/core/Stubs/Models/Order.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs\Models;
+
+class Order extends \Lunar\Models\Order {}

--- a/tests/core/Unit/Actions/Carts/CreateOrderTest.php
+++ b/tests/core/Unit/Actions/Carts/CreateOrderTest.php
@@ -6,9 +6,12 @@ use Lunar\Actions\Carts\CreateOrder;
 use Lunar\DataTypes\Price as PriceDataType;
 use Lunar\DataTypes\ShippingOption;
 use Lunar\Exceptions\DisallowMultipleCartOrdersException;
+use Lunar\Facades\ModelManifest;
 use Lunar\Facades\ShippingManifest;
 use Lunar\Models\Cart;
 use Lunar\Models\CartAddress;
+use Lunar\Models\Contracts\Cart as CartContract;
+use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Models\Country;
 use Lunar\Models\Currency;
 use Lunar\Models\Customer;
@@ -20,8 +23,15 @@ use Lunar\Models\Price;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRateAmount;
+use Lunar\Tests\Core\Stubs\Models\Cart as CustomCart;
+use Lunar\Tests\Core\Stubs\Models\Order as CustomOrder;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    ModelManifest::replace(CartContract::class, CustomCart::class);
+    ModelManifest::replace(OrderContract::class, CustomOrder::class);
+});
 
 it('cant create order if already has complete and multiple disabled', function () {
     TaxClass::factory()->create([


### PR DESCRIPTION
This PR just aims to prove that in certain cases model extending breaks pipelines.

I just swapped `Cart` and `Order` models, let's call them `CustomCart` and `CustomOrder`.

**Problem:**
The problem appears to be double serialization of certain casted attributes, specifically `$shippingBreakdown` and `$taxBreakdown`, because at first the model is `Cart`, but when it goes through pipelines, it is resolved as `CustomCart` and this namespace corrupts attribute serialization, so when it tries to set eg. `$order->shipping_breakdown`, it tries to set a json encoded value instead of the `ShippingBreakdown` class.

Specifically this part of `ShippingBreakdown` / `TaxBreakdown` gets called when it should not.

```php
public function serialize($model, $key, $value, $attributes)
{
    return json_encode(
        $this->set($model, $key, $value, $attributes)
    );
}
```

**Possible solution:**
Resolve correct models in pipelines and probably everywhere possible like this:
```php
use Lunar\Models\Contracts\Cart as CartContract;
use Lunar\Models\Contracts\OrderLine as OrderLineContract;

final class CreateOrder extends AbstractAction
{
    /**
     * Execute the action.
     */
    public function execute(
        CartContract $cart,
        bool $allowMultipleOrders = false,
        ?int $orderIdToUpdate = null
    ): self {

    // ...
    
    // Instead of new OrderLine
    $orderLine = App::make(OrderLineContract::class);
```

I am ready to do the work with tests. I just need you to confirm, that this is the right solution in your opinion. I already tested this solution here: https://github.com/dystcz/lunar-api/pull/166 by swapping the necessary pipelines with updated container resolution.