### PR TITLE
Preload base prices on Product Variant page

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -245,7 +245,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                     )]
             )->toArray();
 
-        $variants = $this->record->variants->load('values.option')->map(function ($variant) {
+        $variants = $this->record->variants->load(['basePrices.currency', 'basePrices.priceable', 'values.option'])->map(function ($variant) {
             return [
                 'id' => $variant->id,
                 'sku' => $variant->sku,


### PR DESCRIPTION
This PR preloads prices for each variant on the edit page, instead of lazy loading them when needed.

The example is for a product with ~600 variants.

#### Before

![explorer_B9rv3abs1i](https://github.com/user-attachments/assets/6faa1828-70ca-424f-a7cd-375fd519af14)

#### After

![explorer_LQw2S4Dhge](https://github.com/user-attachments/assets/9f100005-c15f-4024-b06b-4cf97e663643)