### PR TITLE
Fix access to Staff creation panel. Closes #1741

### DIFF
--- a/packages/admin/src/Models/Staff.php
+++ b/packages/admin/src/Models/Staff.php
@@ -131,7 +131,12 @@ class Staff extends Authenticatable
      */
     public function getGravatarAttribute()
     {
-        $hash = md5(strtolower(trim($this->attributes['email'])));
+        if (isset($this->attributes['email'])) {
+            $hash = md5(strtolower(trim($this->attributes['email'])));
+        }
+        else {
+            $hash = '';
+        }
 
         return "https://www.gravatar.com/avatar/$hash?d=mp";
     }


### PR DESCRIPTION
Fix to "gravatar" attribute in Staff model, required to avoid errors while accessing the Staff's creation panel.

Cfr. #1741