### PR TITLE
Support selection of the highest tax rate in the basket for shipping

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
@@ -5,8 +5,8 @@ namespace Lunar\Admin\Filament\Resources\CustomerResource\RelationManagers;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Lunar\Admin\Filament\Resources\OrderResource;
-use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
+use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Models\Order;
 
 class OrdersRelationManager extends BaseRelationManager

--- a/packages/table-rate-shipping/config/shipping-tables.php
+++ b/packages/table-rate-shipping/config/shipping-tables.php
@@ -2,4 +2,11 @@
 
 return [
     'enabled' => env('LUNAR_SHIPPING_TABLES_ENABLED', true),
+
+    /*
+     * What method should we use for a shipping rate tax calculation?
+     * Options are 'default' for the system-wide default tax rate,
+     * or 'highest' to select the highest tax rate in the cart
+     */
+    'shipping_rate_tax_calculation' => 'default',
 ];

--- a/packages/table-rate-shipping/src/Models/ShippingRate.php
+++ b/packages/table-rate-shipping/src/Models/ShippingRate.php
@@ -10,6 +10,7 @@ use Lunar\Base\BaseModel;
 use Lunar\Base\Purchasable;
 use Lunar\Base\Traits\HasPrices;
 use Lunar\DataTypes\ShippingOption;
+use Lunar\Facades\Taxes;
 use Lunar\Models\Cart;
 use Lunar\Models\TaxClass;
 use Lunar\Shipping\Database\Factories\ShippingRateFactory;
@@ -27,6 +28,8 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
      * @var array
      */
     protected $guarded = [];
+
+    private ?TaxClass $resolvedTaxClass;
 
     protected static function booted()
     {
@@ -73,7 +76,7 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
      */
     public function getTaxClass(): TaxClass
     {
-        return TaxClass::getDefault();
+        return $this->resolvedTaxClass ?? TaxClass::getDefault();
     }
 
     public function getTaxReference(): ?string
@@ -139,6 +142,10 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
      */
     public function getShippingOption(Cart $cart): ?ShippingOption
     {
+        if (config('lunar.shipping-tables.shipping_rate_tax_calculation') == 'highest') {
+            $this->resolvedTaxClass = $this->resolveHighestTaxRateInCart($cart);
+        }
+
         return $this->shippingMethod->driver()->resolve(
             new ShippingOptionRequest(
                 shippingRate: $this,
@@ -155,5 +162,24 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
     public function getTotalInventory(): int
     {
         return 1;
+    }
+
+    private function resolveHighestTaxRateInCart(Cart $cart): ?TaxClass
+    {
+        $highestRate = false;
+        $highestTaxClass = null;
+
+        foreach ($cart->lines as $cartLine) {
+            if ($cartLine->purchasable->taxClass) {
+                foreach ($cartLine->purchasable->taxClass->taxRateAmounts as $amount) {
+                    if ($highestRate === false || $amount->percentage > $highestRate) {
+                        $highestRate = $amount->percentage;
+                        $highestTaxClass = $cartLine->purchasable->taxClass;
+                    }
+                }
+            }
+        }
+
+        return $highestTaxClass;
     }
 }

--- a/packages/table-rate-shipping/src/Models/ShippingRate.php
+++ b/packages/table-rate-shipping/src/Models/ShippingRate.php
@@ -10,7 +10,6 @@ use Lunar\Base\BaseModel;
 use Lunar\Base\Purchasable;
 use Lunar\Base\Traits\HasPrices;
 use Lunar\DataTypes\ShippingOption;
-use Lunar\Facades\Taxes;
 use Lunar\Models\Cart;
 use Lunar\Models\TaxClass;
 use Lunar\Shipping\Database\Factories\ShippingRateFactory;

--- a/tests/shipping/Unit/Resolvers/ShippingOptionResolverTest.php
+++ b/tests/shipping/Unit/Resolvers/ShippingOptionResolverTest.php
@@ -5,7 +5,10 @@ uses(\Lunar\Tests\Shipping\TestCase::class);
 use Lunar\Models\CartAddress;
 use Lunar\Models\Country;
 use Lunar\Models\Currency;
+use Lunar\Models\Price;
+use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
+use Lunar\Models\TaxRateAmount;
 use Lunar\Shipping\DataTransferObjects\ShippingOptionLookup;
 use Lunar\Shipping\Facades\Shipping;
 use Lunar\Shipping\Models\ShippingMethod;
@@ -93,4 +96,119 @@ test('can fetch shipping options', function () {
     );
 
     $this->assertcount(1, $options);
+});
+
+test('sets tax rate to the highest basket rate', function () {
+    config()->set('lunar.shipping-tables.shipping_rate_tax_calculation', 'highest');
+
+    $currency = Currency::factory()->create([
+        'default' => true,
+    ]);
+
+    $country = Country::factory()->create();
+
+    TaxClass::factory()->create([
+        'default' => true,
+        'name' => 'default',
+    ]);
+
+    $higherRate = TaxClass::factory()->create([
+        'default' => false,
+        'name' => 'higher'
+    ]);
+
+    $taxAmount = TaxRateAmount::factory()->create();
+    $taxAmount->percentage = 90;
+
+    $higherRate->taxRateAmounts()->save($taxAmount);
+
+    $customerGroup = \Lunar\Models\CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $shippingZone = ShippingZone::factory()->create([
+        'type' => 'countries',
+    ]);
+
+    $shippingZone->countries()->attach($country);
+
+    $shippingMethod = ShippingMethod::factory()->create([
+        'driver' => 'ship-by',
+        'data' => [
+            'minimum_spend' => [
+                "{$currency->code}" => 200,
+            ],
+        ],
+    ]);
+
+    $shippingMethod->customerGroups()->sync([
+        $customerGroup->id => ['enabled' => true, 'visible' => true, 'starts_at' => now(), 'ends_at' => null],
+    ]);
+
+    $shippingRate = \Lunar\Shipping\Models\ShippingRate::factory()
+        ->create([
+            'shipping_method_id' => $shippingMethod->id,
+            'shipping_zone_id' => $shippingZone->id,
+        ]);
+
+    $shippingRate->prices()->createMany([
+        [
+            'price' => 600,
+            'min_quantity' => 1,
+            'currency_id' => $currency->id,
+        ],
+        [
+            'price' => 500,
+            'min_quantity' => 700,
+            'currency_id' => $currency->id,
+        ],
+        [
+            'price' => 0,
+            'min_quantity' => 800,
+            'currency_id' => $currency->id,
+        ],
+    ]);
+
+    $cart = $this->createCart($currency, 500);
+
+    $purchasable = ProductVariant::factory()->create();
+    $purchasable->stock = 50;
+    $purchasable->tax_class_id = $higherRate->id;
+    $purchasable->save();
+
+    Price::factory()->create([
+        'price' => 300,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->shippingAddress()->create(
+        CartAddress::factory()->make([
+            'country_id' => $country->id,
+            'state' => null,
+        ])->toArray()
+    );
+
+    $shippingRates = Shipping::shippingRates(
+        $cart->refresh()->calculate()
+    )->get();
+
+    $options = Shipping::shippingOptions()->cart(
+        $cart->refresh()->calculate()
+    )->get(
+        new ShippingOptionLookup(
+            shippingRates: $shippingRates
+        )
+    );
+
+    $this->assertcount(1, $options);
+    $this->assertSame($options->first()->option->taxClass->id, $higherRate->id);
 });

--- a/tests/shipping/Unit/Resolvers/ShippingOptionResolverTest.php
+++ b/tests/shipping/Unit/Resolvers/ShippingOptionResolverTest.php
@@ -114,7 +114,7 @@ test('sets tax rate to the highest basket rate', function () {
 
     $higherRate = TaxClass::factory()->create([
         'default' => false,
-        'name' => 'higher'
+        'name' => 'higher',
     ]);
 
     $taxAmount = TaxRateAmount::factory()->create();


### PR DESCRIPTION
Currently the shipping tables add-on only supports returning the default tax class/rate.

However countries can have different requirements for how tax should be calculated on shipping depending on what is in the basket, for example in the UK shipping should take the most expensive tax rate in the basket.

This PR updates the add-on with a new config option (`lunar.shipping-tables.shipping_rate_tax_calculation`) which currently has two options: `default` for selecting the default rate, or `highest` for selecting the highest rate in the basket.