### PR TITLE
Allow extending of page edit record forms

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
@@ -5,8 +5,8 @@ namespace Lunar\Admin\Filament\Resources\CustomerResource\RelationManagers;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Lunar\Admin\Filament\Resources\OrderResource;
-use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
+use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Models\Order;
 
 class OrdersRelationManager extends BaseRelationManager

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductInventory.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductInventory.php
@@ -92,7 +92,7 @@ class ManageProductInventory extends BaseEditRecord
         ];
     }
 
-    public function form(Form $form): Form
+    public function getDefaultForm(Form $form): Form
     {
         return (new ManageVariantInventory)->form($form)->statePath('');
     }

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantInventory.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantInventory.php
@@ -61,7 +61,7 @@ class ManageVariantInventory extends BaseEditRecord
         ];
     }
 
-    public function form(Form $form): Form
+    public function getDefaultForm(Form $form): Form
     {
         return $form->schema([
             Section::make()->schema([

--- a/packages/admin/src/Support/Pages/BaseCreateRecord.php
+++ b/packages/admin/src/Support/Pages/BaseCreateRecord.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 abstract class BaseCreateRecord extends CreateRecord
 {
     use Concerns\ExtendsFooterWidgets;
+    use Concerns\ExtendsForms;
     use Concerns\ExtendsFormActions;
     use Concerns\ExtendsHeaderActions;
     use Concerns\ExtendsHeaderWidgets;

--- a/packages/admin/src/Support/Pages/BaseCreateRecord.php
+++ b/packages/admin/src/Support/Pages/BaseCreateRecord.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 abstract class BaseCreateRecord extends CreateRecord
 {
     use Concerns\ExtendsFooterWidgets;
-    use Concerns\ExtendsForms;
     use Concerns\ExtendsFormActions;
+    use Concerns\ExtendsForms;
     use Concerns\ExtendsHeaderActions;
     use Concerns\ExtendsHeaderWidgets;
     use Concerns\ExtendsHeadings;

--- a/packages/admin/src/Support/Pages/BaseEditRecord.php
+++ b/packages/admin/src/Support/Pages/BaseEditRecord.php
@@ -9,6 +9,7 @@ abstract class BaseEditRecord extends EditRecord
 {
     use Concerns\ExtendsFooterWidgets;
     use Concerns\ExtendsFormActions;
+    use Concerns\ExtendsForms;
     use Concerns\ExtendsHeaderActions;
     use Concerns\ExtendsHeaderWidgets;
     use Concerns\ExtendsHeadings;

--- a/packages/admin/src/Support/Pages/Concerns/ExtendsForms.php
+++ b/packages/admin/src/Support/Pages/Concerns/ExtendsForms.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lunar\Admin\Support\Pages\Concerns;
+
+use Filament\Forms\Form;
+
+trait ExtendsForms
+{
+    public function form(Form $form): Form
+    {
+        return self::callLunarHook('extendForm', $this->getDefaultForm($form));
+    }
+
+    public function getDefaultForm(Form $form): Form
+    {
+        return $form;
+    }
+}


### PR DESCRIPTION
This PR adds the ability to extend base edit record pages.

Our use case is the ability to add to the inventory pages, which is why I've applied this to them.