### PR TITLE
OrderFactory: make sure taxTotal is an integer.

### DIFF
--- a/packages/core/database/factories/OrderFactory.php
+++ b/packages/core/database/factories/OrderFactory.php
@@ -13,7 +13,7 @@ class OrderFactory extends BaseFactory
     public function definition(): array
     {
         $total = $this->faker->numberBetween(200, 25000);
-        $taxTotal = ($total - 100) * .2;
+        $taxTotal = intval(($total - 100) * .2);
 
         return [
             'channel_id' => Channel::factory(),


### PR DESCRIPTION
Using the OrderFactory to create orders:

```php
        Order::factory()->count(100)->create();
```

in a postgresql database causes an error:

> SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input
> syntax for type bigint: "15603.2"
>
> SQL: insert into "lunar_orders" ("channel_id", "new_customer",
> "user_id", "status", "reference", "sub_total", "discount_total",
> "shipping_total", "tax_breakdown", "tax_total", "total", "notes",
> "currency_code", "compare_currency_code", "exchange_rate", "meta",
> "updated_at", "created_at") values (2, 0, ?, awaiting-payment, HGMKWOMH,
> 15603.2, 0, 0, [], 3875.8, 19479, ?, GBP, GBP, 1, {"foo":"bar"},
> 2024-09-08 02:18:04, 2024-09-08 02:18:04) returning "id")

Calling intval() fixes this issue.

Please describe your Pull Request as best as possible, explaining what it provides and why it is of value, referencing any related Issues.

Try to include the following in your Pull Request, where applicable...

- Documentation updates
- Automated tests
