### PR TITLE
fix extended model morph map by checking parent class map

### DIFF
--- a/packages/core/src/Base/ModelManifest.php
+++ b/packages/core/src/Base/ModelManifest.php
@@ -143,7 +143,7 @@ class ModelManifest implements ModelManifestInterface
         return 'Lunar\\Models\\'.$shortName;
     }
 
-    public function isLunarModel(BaseModel $model): bool
+    public function isLunarModel(string|BaseModel $model): bool
     {
         $class = (new \ReflectionClass($model));
 

--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -3,6 +3,7 @@
 namespace Lunar\Base\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Lunar\Facades\ModelManifest;
 
@@ -44,6 +45,24 @@ trait HasModelExtending
         $contractClass = ModelManifest::guessContractClass(static::class);
 
         return ModelManifest::get($contractClass) ?? static::class;
+    }
+
+    public function getMorphClass(): string
+    {
+        $morphMap = Relation::morphMap();
+
+        if (! empty($morphMap)) {
+            if ($customModelMorphMap = array_search(static::modelClass(), $morphMap, true)) {
+                return $customModelMorphMap;
+            }
+
+            $parentClass = get_parent_class(static::class);
+            if (ModelManifest::isLunarModel($parentClass) && $lunarModelMorphMap = array_search($parentClass, $morphMap, true)) {
+                return $lunarModelMorphMap;
+            }
+        }
+
+        return parent::getMorphClass();
     }
 
     public static function isLunarInstance(): bool

--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -51,15 +51,14 @@ trait HasModelExtending
     {
         $morphMap = Relation::morphMap();
 
-        if (! empty($morphMap)) {
-            if ($customModelMorphMap = array_search(static::modelClass(), $morphMap, true)) {
-                return $customModelMorphMap;
-            }
+        if ($customModelMorphMap = array_search(static::modelClass(), $morphMap, true)) {
+            return $customModelMorphMap;
+        }
 
-            $parentClass = get_parent_class(static::class);
-            if (ModelManifest::isLunarModel($parentClass) && $lunarModelMorphMap = array_search($parentClass, $morphMap, true)) {
-                return $lunarModelMorphMap;
-            }
+        $parentClass = get_parent_class(static::class);
+
+        if (ModelManifest::isLunarModel($parentClass) && $lunarModelMorphMap = array_search($parentClass, $morphMap, true)) {
+            return $lunarModelMorphMap;
         }
 
         return parent::getMorphClass();

--- a/packages/core/src/Facades/ModelManifest.php
+++ b/packages/core/src/Facades/ModelManifest.php
@@ -16,7 +16,7 @@ use Lunar\Base\ModelManifestInterface;
  * @method static string|null get(string $interfaceClass)
  * @method static string guessContractClass(string $modelClass)
  * @method static string guessModelClass(string $modelContract)
- * @method static bool isLunarModel(BaseModel $model)
+ * @method static bool isLunarModel(string|BaseModel $model)
  * @method static string getTable(BaseModel $model)
  * @method static void morphMap()
  * @method static string getMorphMapKey(string $className)

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -45,3 +45,16 @@ test('can forward static method calls to extended model', function () {
     expect($newStaticMethod)->toBeInstanceOf(Collection::class);
     expect($newStaticMethod)->toHaveCount(3);
 });
+
+test('morph map is correct when models are extended', function () {
+    \Lunar\Facades\ModelManifest::replace(
+        \Lunar\Models\Contracts\Product::class,
+        \Lunar\Tests\Core\Stubs\Models\CustomProduct::class
+    );
+
+   expect((new \Lunar\Tests\Core\Stubs\Models\CustomProduct)->getMorphClass())
+       ->toBe('product')
+       ->and((new Product)->getMorphClass())
+       ->toBe('product');
+});
+


### PR DESCRIPTION
currently after model extension, when loading relationship it is unable to retrieve correct morph type

setup
```php
  public function boot(ShippingModifiers $shippingModifiers): void
{
    \Lunar\Facades\ModelManifest::replace(
        \Lunar\Models\Contracts\Product::class,
        \App\Models\Product::class,
    );
}
```

laravel will be looking for `App\Models\Product` in the morphMap array but it will not be able to resolve to `product` since Lunar registered 'product' => 'Lunar\Models\Product
https://github.com/lunarphp/lunar/blob/2b31dcabc4cc7f169051be63648836b75bf91d18/packages/core/src/Base/ModelManifest.php#L153-L176


earlier a workaround would be override the morphMap
```php
Relation::morphMap([
    'product' => \App\Models\Product::class,
]);
```

this fix resolve this by searching the morphMap array using the Lunar model's FQCN
it also checks if the extended model is already manually registered in morphMap by the user