### PR TITLE
Fix extended model resolving

### DIFF
--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -96,10 +96,11 @@ trait HasModelExtending
     /**
      * Returns the model alias registered in the model relation morph map.
      */
-    public static function morphName():string{
+    public static function morphName(): string
+    {
         return (new (static::modelClass()))->getMorphClass();
     }
-    
+
     public function getMorphClass(): string
     {
         $morphMap = Relation::morphMap();

--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -46,7 +46,7 @@ trait HasModelExtending
             $this->getAttributes(), $defaults
         );
 
-        return tap(new $newClass, function ($instance) use ($attributes) : Model {
+        return tap(new $newClass, function ($instance) use ($attributes): Model {
             $instance->setRawAttributes($attributes);
 
             $instance->setRelations($this->relations);

--- a/tests/core/Stubs/Models/CustomOrder.php
+++ b/tests/core/Stubs/Models/CustomOrder.php
@@ -2,6 +2,4 @@
 
 namespace Lunar\Tests\Core\Stubs\Models;
 
-class CustomOrder extends \Lunar\Models\Order
-{
-}
+class CustomOrder extends \Lunar\Models\Order {}

--- a/tests/core/Stubs/Models/CustomOrder.php
+++ b/tests/core/Stubs/Models/CustomOrder.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs\Models;
+
+class CustomOrder extends \Lunar\Models\Order
+{
+}

--- a/tests/core/Stubs/Models/Order.php
+++ b/tests/core/Stubs/Models/Order.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs\Models;
+
+class Order extends \Lunar\Models\Order
+{
+}

--- a/tests/core/Stubs/Models/Order.php
+++ b/tests/core/Stubs/Models/Order.php
@@ -2,6 +2,4 @@
 
 namespace Lunar\Tests\Core\Stubs\Models;
 
-class Order extends \Lunar\Models\Order
-{
-}
+class Order extends \Lunar\Models\Order {}

--- a/tests/core/Unit/Actions/Carts/CreateOrderTest.php
+++ b/tests/core/Unit/Actions/Carts/CreateOrderTest.php
@@ -236,7 +236,7 @@ test('can create order', function () {
     $order->save();
     $containsCurrency = str_contains($order->fresh()->getRawOriginal('tax_breakdown'), '"currency"');
     expect($containsCurrency)->toBeFalse();
-})->group('wah');
+});
 
 test('can create order with customer', function () {
     CustomerGroup::factory()->create([

--- a/tests/core/Unit/Actions/Carts/CreateOrderTest.php
+++ b/tests/core/Unit/Actions/Carts/CreateOrderTest.php
@@ -20,6 +20,7 @@ use Lunar\Models\Price;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRateAmount;
+use function Pest\Laravel\{assertDatabaseHas};
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -107,6 +108,10 @@ function can_update_draft_order()
 }
 
 test('can create order', function () {
+    \Lunar\Facades\ModelManifest::replace(
+        \Lunar\Models\Contracts\Order::class,
+        \Lunar\Tests\Core\Stubs\Models\CustomOrder::class
+    );
     CustomerGroup::factory()->create([
         'default' => true,
     ]);
@@ -223,15 +228,15 @@ test('can create order', function () {
         ->and($order->shippingAddress)->toBeInstanceOf(OrderAddress::class)
         ->and($order->billingAddress)->toBeInstanceOf(OrderAddress::class);
 
-    $this->assertDatabaseHas((new Order)->getTable(), $datacheck);
-    $this->assertDatabaseHas((new OrderLine)->getTable(), [
+    assertDatabaseHas((new Order)->getTable(), $datacheck);
+    assertDatabaseHas((new OrderLine)->getTable(), [
         'identifier' => $shippingOption->getIdentifier(),
     ]);
 
     $order->save();
     $containsCurrency = str_contains($order->fresh()->getRawOriginal('tax_breakdown'), '"currency"');
     expect($containsCurrency)->toBeFalse();
-});
+})->group('wah');
 
 test('can create order with customer', function () {
     CustomerGroup::factory()->create([

--- a/tests/core/Unit/Actions/Carts/CreateOrderTest.php
+++ b/tests/core/Unit/Actions/Carts/CreateOrderTest.php
@@ -20,6 +20,7 @@ use Lunar\Models\Price;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRateAmount;
+
 use function Pest\Laravel\{assertDatabaseHas};
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -39,9 +39,9 @@ test('can forward calls to extended model', function () {
 });
 
 test('extended model returns correct table name', function () {
-    expect((new \Lunar\Tests\Core\Stubs\Models\CustomOrder())->getTable())
+    expect((new \Lunar\Tests\Core\Stubs\Models\CustomOrder)->getTable())
         ->toBe(
-            (new \Lunar\Models\Order())->getTable()
+            (new \Lunar\Models\Order)->getTable()
         );
 });
 

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -38,6 +38,13 @@ test('can forward calls to extended model', function () {
     expect($sizeOption->sizes)->toHaveCount(1);
 });
 
+test('extended model returns correct table name', function () {
+    expect((new \Lunar\Tests\Core\Stubs\Models\CustomOrder())->getTable())
+        ->toBe(
+            (new \Lunar\Models\Order())->getTable()
+        );
+});
+
 test('can forward static method calls to extended model', function () {
     /** @see \Lunar\Tests\Core\Stubs\Models\ProductOption::getSizesStatic() */
     $newStaticMethod = ProductOption::getSizesStatic();


### PR DESCRIPTION
This PR looks to solve some anomalies that have been discovered with model extending.

## Problem A

When replacing a Lunar model, there are instances where the model provided by Lunar is still used for example, if you replace the model like so

```php
\Lunar\Facades\ModelManifest::replace(
    \Lunar\Models\Contracts\Order::class,
    \App\Models\Order::class
);
```

Later in the Lunar core, we are still referencing `Lunar\Models\Order::first()` or via relationships `$orderLine->order()`. We attempted to resolve these queries to their concrete replacements by overriding the `newModelQuery` method, however there were issues with castable attributes which caused them to be cast multiple times, resulting in errors.

### Solution

This has been rewritten so Lunar doesn't try to `fill` the extended instance of the model from the Lunar base class anymore and instead just populates the attributes as they are. Since this should just be a simple class swap it should no longer result in duplicate calls to attribute casters.

There are some additional checks to see if we are actually working with a model that hasn't been extended to ensure we are not getting into a situation where we try and rehydrate with the same class.

### Affected issues

This change should resolve #1942 #1930 

## Problem B

If your own custom model was named something other than it's counterpart, for example:

```php
\Lunar\Facades\ModelManifest::replace(
    \Lunar\Models\Contracts\Order::class,
    \App\Models\MyCustomOrder::class
);
```

This would result in the table name and subsequent foreign key naming to be incorrect i.e. `my_custom_order` and `my_custom_order_id`. This would mean developers would need to add their own methods to override this in order for the naming to resolve properly, which is a bit of a maintenance burden and easily missed when encountering errors.


### Solution

The `HasModelExtending` trait now provides its own `getTable` and `getForeignKey` methods which will check which class within Lunar we are extending and return the appropriate table name and foreign key.

## How this slipped through testing

Looks like there was an oversight and although there were tests for extending models, the tests themselves didn't use any extending when performing more complex tasks, like creating orders from carts.

This PR has now added some model extending to tests which were affected by the issues referenced above to hopefully keep this in check and make for a more "real world" test environment.