### PR TITLE
Update Cart.php

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -506,7 +506,7 @@ class Cart extends BaseModel implements Contracts\Cart
 
     public function getShippingOption(): ?ShippingOption
     {
-        return ShippingManifest::getShippingOption($this->refresh());
+        return ShippingManifest::getShippingOption($this->load('shippingAddress'));
     }
 
     public function isShippable(): bool

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -506,7 +506,7 @@ class Cart extends BaseModel implements Contracts\Cart
 
     public function getShippingOption(): ?ShippingOption
     {
-        return ShippingManifest::getShippingOption($this->calculate());
+        return ShippingManifest::getShippingOption($this->refresh());
     }
 
     public function isShippable(): bool


### PR DESCRIPTION
currently I'm facing an issue where we use `$cart->getShippingOption()` in a cart calculate pipeline and its causing infinite loop

for what this method concern, it should just need `refresh()` or `load('shippingAddress')` to get latest shipping address and shipping option
