### PR TITLE
Add description for setting minimum-stability to be set to dev for local development

### DIFF
--- a/docs/core/local-development.md
+++ b/docs/core/local-development.md
@@ -45,6 +45,11 @@ Update your `composer.json` file similar to the following.
     }
 ````
 
+Ensure minimum stability is set for development
+```json
+    "minimum-stability": "dev",
+````
+
 Run `composer update` from your Laravel application's root directory and fingers crossed you're all up and running,. 
 
 ```sh


### PR DESCRIPTION
## Description

Updates documentation for the `local-development.md` to include `minimum-stability`  should be set to `dev` in `composer.json`.

- Error displayed when not setting `minimum-stability`  option to `dev` 
```sh
Root composer.json requires lunarphp/lunar , it is satisfiable by lunarphp/lunar[0.1.1, ..., 0.8.1] from composer repo (https://repo.packagist.org/) but lunarphp/lunar[1.x-dev] from path repo (packages/) has higher repository priority. The packages from the higher priority repository do not match your minimum-stability and are therefore not installable. That repository is canonical so the lower priority repo's packages are not installable. See https://getcomposer.org/repoprio for details and assistance.
````


