### PR TITLE
doc: add remark for custom model definition

### DIFF
--- a/packages/core/config/media.php
+++ b/packages/core/config/media.php
@@ -4,26 +4,13 @@ use Lunar\Base\StandardMediaDefinitions;
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Media Definition
-    |--------------------------------------------------------------------------
-    |
-    | Specify which media definition should be used when generating media.
-    |
-    | note: if extended Lunar's model, you should update the key,
-    |       or default definition will be used
-    |
-    | example: App\Models\Product::class => CustomMediaDefinitions::class,
-    |
-    */
     'definitions' => [
-        Lunar\Models\Asset::class => StandardMediaDefinitions::class,
-        Lunar\Models\Brand::class => StandardMediaDefinitions::class,
-        Lunar\Models\Collection::class => StandardMediaDefinitions::class,
-        Lunar\Models\Product::class => StandardMediaDefinitions::class,
-        Lunar\Models\ProductOption::class => StandardMediaDefinitions::class,
-        Lunar\Models\ProductOptionValue::class => StandardMediaDefinitions::class,
+        'asset' => StandardMediaDefinitions::class,
+        'brand' => StandardMediaDefinitions::class,
+        'collection' => StandardMediaDefinitions::class,
+        'product' => StandardMediaDefinitions::class,
+        'product-option' => StandardMediaDefinitions::class,
+        'product-option-value' => StandardMediaDefinitions::class,
     ],
 
     'collection' => 'images',

--- a/packages/core/config/media.php
+++ b/packages/core/config/media.php
@@ -4,6 +4,19 @@ use Lunar\Base\StandardMediaDefinitions;
 
 return [
 
+    /*
+    |--------------------------------------------------------------------------
+    | Media Definition
+    |--------------------------------------------------------------------------
+    |
+    | Specify which media definition should be used when generating media.
+    |
+    | note: if extended Lunar's model, you should update the key,
+    |       or default definition will be used
+    |
+    | example: App\Models\Product::class => CustomMediaDefinitions::class,
+    |
+    */
     'definitions' => [
         Lunar\Models\Asset::class => StandardMediaDefinitions::class,
         Lunar\Models\Brand::class => StandardMediaDefinitions::class,

--- a/packages/core/src/Base/Traits/HasMedia.php
+++ b/packages/core/src/Base/Traits/HasMedia.php
@@ -63,6 +63,11 @@ trait HasMedia
     {
         $conversionClasses = config('lunar.media.definitions', []);
 
-        return $conversionClasses[static::class] ?? StandardMediaDefinitions::class;
+        $alias = \Illuminate\Support\Str::snake(class_basename(static::class));
+
+        return $conversionClasses[$alias]
+            ?? $conversionClasses[static::class] // fallback for published config
+            ?? $conversionClasses[get_parent_class(static::class)] // fallback use parent class
+            ?? StandardMediaDefinitions::class;
     }
 }

--- a/tests/core/Stubs/TestStandardMediaDefinitions.php
+++ b/tests/core/Stubs/TestStandardMediaDefinitions.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs;
+
+use Lunar\Base\StandardMediaDefinitions;
+
+class TestStandardMediaDefinitions extends StandardMediaDefinitions {}

--- a/tests/core/Unit/Traits/HasMediaTraitTest.php
+++ b/tests/core/Unit/Traits/HasMediaTraitTest.php
@@ -14,7 +14,7 @@ test('conversions are loaded', function () {
 
     expect($definitions)->toHaveCount(6);
 
-    expect($definitions[Product::class])->toEqual(StandardMediaDefinitions::class);
+    expect($definitions['product'])->toEqual(StandardMediaDefinitions::class);
 
     $file = UploadedFile::fake()->image('avatar.jpg');
 
@@ -32,7 +32,7 @@ test('conversions are loaded', function () {
 
 test('custom conversions are loaded', function () {
     Config::set('lunar.media.definitions', [
-        Product::class => TestStandardMediaDefinitions::class,
+        'product' => TestStandardMediaDefinitions::class,
     ]);
 
     $product = invade(new Product);
@@ -47,7 +47,7 @@ test('custom conversions are loaded for extended model', function () {
     );
 
     Config::set('lunar.media.definitions', [
-        Product::class => TestStandardMediaDefinitions::class,
+        'product' => TestStandardMediaDefinitions::class,
     ]);
 
     $product = invade(app(\Lunar\Models\Contracts\Product::class));

--- a/tests/core/Unit/Traits/HasMediaTraitTest.php
+++ b/tests/core/Unit/Traits/HasMediaTraitTest.php
@@ -2,8 +2,10 @@
 
 uses(\Lunar\Tests\Core\TestCase::class);
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Config;
 use Lunar\Base\StandardMediaDefinitions;
 use Lunar\Models\Product;
+use Lunar\Tests\Core\Stubs\TestStandardMediaDefinitions;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -26,6 +28,31 @@ test('conversions are loaded', function () {
     expect($image->hasGeneratedConversion('medium'))->toBeTrue();
     expect($image->hasGeneratedConversion('large'))->toBeTrue();
     expect($image->hasGeneratedConversion('zoom'))->toBeTrue();
+});
+
+test('custom conversions are loaded', function () {
+    Config::set('lunar.media.definitions', [
+        Product::class => TestStandardMediaDefinitions::class,
+    ]);
+
+    $product = invade(new Product);
+
+    expect($product->getDefinitionClass())->toEqual(TestStandardMediaDefinitions::class);
+});
+
+test('custom conversions are loaded for extended model', function () {
+    \Lunar\Facades\ModelManifest::replace(
+        \Lunar\Models\Contracts\Product::class,
+        \Lunar\Tests\Core\Stubs\Models\Product::class
+    );
+
+    Config::set('lunar.media.definitions', [
+        Product::class => TestStandardMediaDefinitions::class,
+    ]);
+
+    $product = invade(app(\Lunar\Models\Contracts\Product::class));
+
+    expect($product->getDefinitionClass())->toEqual(TestStandardMediaDefinitions::class);
 });
 
 test('images can have fallback url', function () {


### PR DESCRIPTION
when a Lunar model is extended/replaced, the media definition config should be updated. Or standard definition will be used

p/s: not sure should the media definition to change to string alias or internally auto resolve to lunar model fqcn