### PR TITLE
Fix docblock return types

### DIFF
--- a/packages/core/src/Pipelines/Cart/ApplyDiscounts.php
+++ b/packages/core/src/Pipelines/Cart/ApplyDiscounts.php
@@ -11,7 +11,7 @@ final class ApplyDiscounts
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return mixed
      */
     public function handle(Cart $cart, Closure $next)
     {

--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -14,7 +14,7 @@ final class ApplyShipping
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return mixed
      */
     public function handle(Cart $cart, Closure $next)
     {

--- a/packages/core/src/Pipelines/Cart/Calculate.php
+++ b/packages/core/src/Pipelines/Cart/Calculate.php
@@ -11,7 +11,7 @@ class Calculate
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return mixed
      */
     public function handle(Cart $cart, Closure $next)
     {

--- a/packages/core/src/Pipelines/Cart/CalculateLines.php
+++ b/packages/core/src/Pipelines/Cart/CalculateLines.php
@@ -12,7 +12,7 @@ class CalculateLines
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return mixed
      */
     public function handle(Cart $cart, Closure $next)
     {

--- a/packages/core/src/Pipelines/Cart/CalculateTax.php
+++ b/packages/core/src/Pipelines/Cart/CalculateTax.php
@@ -15,7 +15,7 @@ class CalculateTax
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return mixed
      */
     public function handle(Cart $cart, Closure $next)
     {

--- a/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
@@ -8,7 +8,7 @@ use Lunar\Models\Order;
 class CleanUpOrderLines
 {
     /**
-     * @return Closure
+     * @return mixed
      */
     public function handle(Order $order, Closure $next)
     {

--- a/packages/core/src/Pipelines/Order/Creation/CreateOrderAddresses.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateOrderAddresses.php
@@ -9,7 +9,7 @@ use Lunar\Models\OrderAddress;
 class CreateOrderAddresses
 {
     /**
-     * @return Closure
+     * @return mixed
      */
     public function handle(Order $order, Closure $next)
     {

--- a/packages/core/src/Pipelines/Order/Creation/CreateOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateOrderLines.php
@@ -9,7 +9,7 @@ use Lunar\Models\OrderLine;
 class CreateOrderLines
 {
     /**
-     * @return Closure
+     * @return mixed
      */
     public function handle(Order $order, Closure $next)
     {

--- a/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
+++ b/packages/core/src/Pipelines/Order/Creation/CreateShippingLine.php
@@ -10,7 +10,7 @@ use Lunar\Models\OrderLine;
 class CreateShippingLine
 {
     /**
-     * @return Closure
+     * @return mixed
      */
     public function handle(Order $order, Closure $next)
     {

--- a/packages/core/src/Pipelines/Order/Creation/FillOrderFromCart.php
+++ b/packages/core/src/Pipelines/Order/Creation/FillOrderFromCart.php
@@ -10,7 +10,7 @@ use Lunar\Models\Order;
 class FillOrderFromCart
 {
     /**
-     * @return Closure
+     * @return mixed
      */
     public function handle(Order $order, Closure $next)
     {

--- a/packages/core/src/Pipelines/Order/Creation/MapDiscountBreakdown.php
+++ b/packages/core/src/Pipelines/Order/Creation/MapDiscountBreakdown.php
@@ -8,7 +8,7 @@ use Lunar\Models\Order;
 class MapDiscountBreakdown
 {
     /**
-     * @return Closure
+     * @return mixed
      */
     public function handle(Order $order, Closure $next)
     {


### PR DESCRIPTION
This fixes the return type set the docblock of the handle method of several classes that are used within pipelines. Each actual return type will be the result of the callable.