### PR TITLE
Fix exception when updating order line

### DIFF
--- a/packages/core/src/Observers/OrderLineObserver.php
+++ b/packages/core/src/Observers/OrderLineObserver.php
@@ -32,7 +32,7 @@ class OrderLineObserver
      */
     public function updating(OrderLine $orderLine)
     {
-        if (! in_array(Purchasable::class, class_implements($orderLine->purchasable_type, true))) {
+        if (! in_array(Purchasable::class, class_implements(Relation::getMorphedModel($orderLine->purchasable_type), true))) {
             throw new NonPurchasableItemException($orderLine->purchasable_type);
         }
     }

--- a/packages/core/src/Observers/OrderLineObserver.php
+++ b/packages/core/src/Observers/OrderLineObserver.php
@@ -32,7 +32,11 @@ class OrderLineObserver
      */
     public function updating(OrderLine $orderLine)
     {
-        if (! in_array(Purchasable::class, class_implements(Relation::getMorphedModel($orderLine->purchasable_type), true))) {
+        $purchasableModel = class_exists($orderLine->purchasable_type) ?
+            $orderLine->purchasable_type :
+            Relation::getMorphedModel($orderLine->purchasable_type);
+
+        if (! in_array(Purchasable::class, class_implements($purchasableModel, true))) {
             throw new NonPurchasableItemException($orderLine->purchasable_type);
         }
     }


### PR DESCRIPTION
After the Model Extending change, we have missing that the order line observer trigger an exception with the morph name.

``
class_implements(): Class product_variant does not exist and could not be loaded
``

