### PR TITLE
Fix unsupported operand type on discounts

### DIFF
--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -64,7 +64,7 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
 
         $validCoupon = $cartCoupon ? ($cartCoupon === $conditionCoupon) : blank($conditionCoupon);
 
-        $minSpend = ($data['min_prices'][$cart->currency->code] ?? 0) / $cart->currency->factor;
+        $minSpend = (int) ($data['min_prices'][$cart->currency->code] ?? 0) / (int) $cart->currency->factor;
         $minSpend = (int) bcmul($minSpend, $cart->currency->factor);
 
         $lines = $this->getEligibleLines($cart);


### PR DESCRIPTION
We are seeing an unsupported operand type (string / string) on discounts.

![Screenshot 2024-10-08 at 15 13 14](https://github.com/user-attachments/assets/1b50b2b4-2199-4f65-829e-ddf4d31d27cf)

This PR fixes that.
