### PR TITLE
Make Product name and SKU searchable

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
@@ -5,8 +5,8 @@ namespace Lunar\Admin\Filament\Resources\CustomerResource\RelationManagers;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Lunar\Admin\Filament\Resources\OrderResource;
-use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
+use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Models\Order;
 
 class OrdersRelationManager extends BaseRelationManager

--- a/packages/admin/src/Filament/Resources/ProductResource.php
+++ b/packages/admin/src/Filament/Resources/ProductResource.php
@@ -300,7 +300,8 @@ class ProductResource extends BaseResource
             ->attributeData()
             ->limitedTooltip()
             ->limit(50)
-            ->label(__('lunarpanel::product.table.name.label'));
+            ->label(__('lunarpanel::product.table.name.label'))
+            ->searchable();
     }
 
     public static function getSkuTableColumn(): Tables\Columns\Column
@@ -323,7 +324,8 @@ class ProductResource extends BaseResource
             })
             ->listWithLineBreaks()
             ->limitList(1)
-            ->toggleable();
+            ->toggleable()
+            ->searchable();
     }
 
     public static function getDefaultRelations(): array


### PR DESCRIPTION
If you use the database search driver (ie dont use scout) in the admin the product table is not searchable by SKU or by product name, which are the two ways you are most likely to search this table.

This PR updates that.