### PR TITLE
fix relation manager url generation

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
@@ -6,6 +6,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Lunar\Admin\Filament\Resources\OrderResource;
 use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
+use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
 use Lunar\Models\Order;
 
 class OrdersRelationManager extends BaseRelationManager
@@ -18,7 +19,7 @@ class OrdersRelationManager extends BaseRelationManager
             OrderResource::getTableColumns()
         )->actions([
             Tables\Actions\Action::make('viewOrder')
-                ->url(fn (Order $record): string => route('filament.lunar.resources.orders.order', $record)),
+                ->url(fn (Order $record): string => ManageOrder::getUrl(['record' => $record])),
         ]);
     }
 }


### PR DESCRIPTION
urls should not be hardcoded so changed it to a commonly used function. 

Current solution does not work for me as it conflicts with other used package codezero/laravel-localized-routes which prefixes all the routes with language. Though it's not a bit issue, but I think it's good to have a one way to generate urls in the code base. `ManageOrder::getUrl(['record' => $record])` is already used in many places.
