### PR TITLE
Fix/remove cart customer check exception

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -434,14 +434,6 @@ class Cart extends BaseModel implements Contracts\Cart
      */
     public function associate(LunarUser $user, string $policy = 'merge', bool $refresh = true): Cart
     {
-        if ($this->customer()->exists()) {
-            if (! $user->query()
-                ->whereHas('customers', fn ($query) => $query->where('customer_id', $this->customer->id))
-                ->exists()) {
-                throw new Exception('Invalid user');
-            }
-        }
-
         return app(
             config('lunar.cart.actions.associate_user', AssociateUser::class)
         )->execute($this, $user, $policy)


### PR DESCRIPTION
If anonymous customer creates a cart and then tries to login it it throws an exception and page crashes. From database perspective customer can have multiple users so this check should not be performed at all. 