### PR TITLE
Fix an issue where the AmountOff percentage is cast to an int, even t…

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/OrdersRelationManager.php
@@ -5,8 +5,8 @@ namespace Lunar\Admin\Filament\Resources\CustomerResource\RelationManagers;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Lunar\Admin\Filament\Resources\OrderResource;
-use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
+use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
 use Lunar\Models\Order;
 
 class OrdersRelationManager extends BaseRelationManager

--- a/packages/core/src/DiscountTypes/AmountOff.php
+++ b/packages/core/src/DiscountTypes/AmountOff.php
@@ -224,7 +224,7 @@ class AmountOff extends AbstractDiscountType
     /**
      * Apply the percentage to the cart line.
      */
-    private function applyPercentage(int $value, Cart $cart): Cart
+    private function applyPercentage(float $value, Cart $cart): Cart
     {
         $lines = $this->getEligibleLines($cart);
 

--- a/tests/core/Unit/DiscountTypes/AmountOffTest.php
+++ b/tests/core/Unit/DiscountTypes/AmountOffTest.php
@@ -794,7 +794,7 @@ test('can apply percentage discount', function () {
     $cart = Cart::factory()->create([
         'channel_id' => $channel->id,
         'currency_id' => $currency->id,
-        'coupon_code' => '10PERCENTOFF',
+        'coupon_code' => '10PT5PERCENTOFF',
     ]);
 
     $purchasable = ProductVariant::factory()->create();
@@ -816,9 +816,9 @@ test('can apply percentage discount', function () {
     $discount = Discount::factory()->create([
         'type' => AmountOff::class,
         'name' => 'Test Coupon',
-        'coupon' => '10PERCENTOFF',
+        'coupon' => '10PT5PERCENTOFF',
         'data' => [
-            'percentage' => 10,
+            'percentage' => 10.5,
             'fixed_value' => false,
         ],
     ]);
@@ -843,9 +843,9 @@ test('can apply percentage discount', function () {
 
     $cart = $cart->calculate();
 
-    expect($cart->discountTotal->value)->toEqual(100);
-    expect($cart->taxTotal->value)->toEqual(180);
-    expect($cart->total->value)->toEqual(1080);
+    expect($cart->discountTotal->value)->toEqual(105);
+    expect($cart->taxTotal->value)->toEqual(179);
+    expect($cart->total->value)->toEqual(1074);
 
     $cart->lines()->delete();
 
@@ -857,9 +857,9 @@ test('can apply percentage discount', function () {
 
     $cart = $cart->refresh()->calculate();
 
-    expect($cart->discountTotal->value)->toEqual(200);
-    expect($cart->taxTotal->value)->toEqual(360);
-    expect($cart->total->value)->toEqual(2160);
+    expect($cart->discountTotal->value)->toEqual(210);
+    expect($cart->taxTotal->value)->toEqual(358);
+    expect($cart->total->value)->toEqual(2148);
 });
 
 test('can only same discount to line once', function () {

--- a/tests/core/Unit/DiscountTypes/AmountOffTest.php
+++ b/tests/core/Unit/DiscountTypes/AmountOffTest.php
@@ -784,7 +784,16 @@ test('fixed amount discount distributes across cart lines', function () {
     expect($lastLine->discountTotal->value)->toEqual(333);
 });
 
-test('can apply percentage discount', function () {
+test('can apply percentage discount', function (
+    string $coupon,
+    float $percentage,
+    int $discountTotalForOne,
+    int $taxTotalForOne,
+    int $totalForOne,
+    int $discountTotalForTwo,
+    int $taxTotalForTwo,
+    int $totalForTwo
+) {
     $customerGroup = CustomerGroup::getDefault();
 
     $channel = Channel::getDefault();
@@ -794,7 +803,7 @@ test('can apply percentage discount', function () {
     $cart = Cart::factory()->create([
         'channel_id' => $channel->id,
         'currency_id' => $currency->id,
-        'coupon_code' => '10PT5PERCENTOFF',
+        'coupon_code' => $coupon,
     ]);
 
     $purchasable = ProductVariant::factory()->create();
@@ -816,9 +825,9 @@ test('can apply percentage discount', function () {
     $discount = Discount::factory()->create([
         'type' => AmountOff::class,
         'name' => 'Test Coupon',
-        'coupon' => '10PT5PERCENTOFF',
+        'coupon' => $coupon,
         'data' => [
-            'percentage' => 10.5,
+            'percentage' => $percentage,
             'fixed_value' => false,
         ],
     ]);
@@ -843,9 +852,9 @@ test('can apply percentage discount', function () {
 
     $cart = $cart->calculate();
 
-    expect($cart->discountTotal->value)->toEqual(105);
-    expect($cart->taxTotal->value)->toEqual(179);
-    expect($cart->total->value)->toEqual(1074);
+    expect($cart->discountTotal->value)->toEqual($discountTotalForOne);
+    expect($cart->taxTotal->value)->toEqual($taxTotalForOne);
+    expect($cart->total->value)->toEqual($totalForOne);
 
     $cart->lines()->delete();
 
@@ -857,10 +866,14 @@ test('can apply percentage discount', function () {
 
     $cart = $cart->refresh()->calculate();
 
-    expect($cart->discountTotal->value)->toEqual(210);
-    expect($cart->taxTotal->value)->toEqual(358);
-    expect($cart->total->value)->toEqual(2148);
-});
+    expect($cart->discountTotal->value)->toEqual($discountTotalForTwo);
+    expect($cart->taxTotal->value)->toEqual($taxTotalForTwo);
+    expect($cart->total->value)->toEqual($totalForTwo);
+})->with([
+    '10% Discount' => ['10PERCENTOFF', 10, 100, 180, 1080, 200, 360, 2160],
+    '10.25% Discount' => ['10PT25PERCENTOFF', 10.25, 103, 179, 1076, 205, 359, 2154],
+    '10.5% Discount' => ['10PT5PERCENTOFF', 10.5, 105, 179, 1074, 210, 358, 2148],
+]);
 
 test('can only same discount to line once', function () {
     $customerGroup = CustomerGroup::getDefault();


### PR DESCRIPTION
The admin panel allows you to enter a decimal value when creating an AmountOff Discount with a percentage discount. However, it gets cast to an int in the AmountOff class, which results in the percentage being rounded and the discount amount being slightly off.

You could argue that usually percentage discounts are given as whole numbers, but since the admin panel already supports decimal values, I think this should be changed.

Fixes #2003