### PR TITLE
Adds attributes support for the Price Model

### DIFF
--- a/packages/core/database/migrations/2024_11_01_100000_add_attributes_to_prices_table.php
+++ b/packages/core/database/migrations/2024_11_01_100000_add_attributes_to_prices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table($this->prefix.'prices', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->after('min_quantity');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table($this->prefix.'prices', function ($table) {
+            $table->dropColumn('attribute_data');
+        });
+    }
+};

--- a/packages/core/src/Base/AttributeManifest.php
+++ b/packages/core/src/Base/AttributeManifest.php
@@ -9,9 +9,9 @@ use Lunar\Models\Brand;
 use Lunar\Models\Collection as ModelsCollection;
 use Lunar\Models\Customer;
 use Lunar\Models\CustomerGroup;
+use Lunar\Models\Price;
 use Lunar\Models\Product;
 use Lunar\Models\ProductVariant;
-use Lunar\Models\Price;
 
 class AttributeManifest
 {

--- a/packages/core/src/Base/AttributeManifest.php
+++ b/packages/core/src/Base/AttributeManifest.php
@@ -11,6 +11,7 @@ use Lunar\Models\Customer;
 use Lunar\Models\CustomerGroup;
 use Lunar\Models\Product;
 use Lunar\Models\ProductVariant;
+use Lunar\Models\Price;
 
 class AttributeManifest
 {
@@ -28,6 +29,7 @@ class AttributeManifest
         Customer::class,
         Brand::class,
         CustomerGroup::class,
+        Price::class,
         // Order::class,
     ];
 

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -5,9 +5,12 @@ namespace Lunar\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\Price as CastsPrice;
+use Lunar\Base\Casts\AsAttributeData;
 use Lunar\Base\Traits\HasMacros;
+use Lunar\Base\Traits\HasAttributes;
 use Lunar\Database\Factories\PriceFactory;
 use Spatie\LaravelBlink\BlinkFacade as Blink;
 
@@ -20,11 +23,13 @@ use Spatie\LaravelBlink\BlinkFacade as Blink;
  * @property \Lunar\DataTypes\Price $price
  * @property ?int $compare_price
  * @property int $min_quantity
+ * @property ?array $attribute_data
  * @property ?\Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
  */
 class Price extends BaseModel implements Contracts\Price
 {
+    use HasAttributes;
     use HasFactory;
     use HasMacros;
 
@@ -47,6 +52,7 @@ class Price extends BaseModel implements Contracts\Price
     protected $casts = [
         'price' => CastsPrice::class,
         'compare_price' => CastsPrice::class,
+        'attribute_data' => AsAttributeData::class,
     ];
 
     /**
@@ -102,6 +108,20 @@ class Price extends BaseModel implements Contracts\Price
         $priceIncTax->value = (int) round($priceIncTax->value * (1 + $this->getPriceableTaxRate()));
 
         return $priceIncTax;
+    }
+
+    /**
+     * Get the mapped attributes relation.
+     */
+    public function mappedAttributes(): MorphToMany
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return $this->morphToMany(
+            Attribute::class,
+            'attributable',
+            "{$prefix}attributables"
+        )->withTimestamps();
     }
 
     /**

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -7,10 +7,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Lunar\Base\BaseModel;
-use Lunar\Base\Casts\Price as CastsPrice;
 use Lunar\Base\Casts\AsAttributeData;
-use Lunar\Base\Traits\HasMacros;
+use Lunar\Base\Casts\Price as CastsPrice;
 use Lunar\Base\Traits\HasAttributes;
+use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\PriceFactory;
 use Spatie\LaravelBlink\BlinkFacade as Blink;
 


### PR DESCRIPTION
This PR adds attribute data to the `Price` model.

This will be useful for storing price related meta data for conditions such as title and description related to pricing. This is in relation to a discussion #2007 to allow adding titles and descriptions for Shipping rates and Rate breaks. 

Since the column on the database is nullable, it should not break or affect any existing UI. The attributes related to pricing can be added on a need basis as mentioned in the Use case on the discussion here: #2007 

A PR is in the works 