### PR TITLE
Adds KeyValue to OrderItemsTable for lunar_order_lines meta data

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -96,6 +96,18 @@ class OrderItemsTable extends TableComponent
 
                             return $states;
                         }),
+
+                    KeyValue::make('meta_data')
+                        ->getStateUsing(function ($record) {
+
+                            $states = [];
+
+                            foreach($record->meta as $key => $value) {
+                                $states[$key] = $value;
+                            }
+
+                            return $states;;
+                        })
                 ]),
             ])
                 ->collapsed()

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -102,12 +102,14 @@ class OrderItemsTable extends TableComponent
 
                             $states = [];
 
-                            foreach($record->meta as $key => $value) {
-                                $states[$key] = $value;
+                            if ($record->meta) {
+                                foreach ($record->meta as $key => $value) {
+                                    $states[$key] = $value;
+                                }
                             }
 
-                            return $states;;
-                        })
+                            return $states;
+                        }),
                 ]),
             ])
                 ->collapsed()


### PR DESCRIPTION
If adding meta data to a line item there is currently no visibility on the backend for the order line item meta data.

For example, we run a custom printing shop and want to allow users to enter custom data for custom prints:

line_1: USDOT 1234567
line_2: GVW 12334566
...

We need a way to see this data after the order is placed without having to go into the db.
