### PR TITLE
fix: typo in blade variable name

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/EditOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/EditOrder.php
@@ -44,7 +44,7 @@ class EditOrder extends BaseEditRecord
 
                     return response()->streamDownload(function () {
                         echo Pdf::loadView('lunarpanel::pdf.order', [
-                            'order' => $this->record,
+                            'record' => $this->record,
                         ])->stream();
                     }, name: "Order-{$this->record->reference}.pdf");
                 }),


### PR DESCRIPTION
The pdf/order.blade.php file expects the variable that holds the order data to be named 'record'.
'order' should be the old variable name (before 1.x)
