### PR TITLE
Make discount name searchable

### DIFF
--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -361,7 +361,8 @@ class DiscountResource extends BaseResource
                     \Lunar\Models\Discount::SCHEDULED => 'info',
                 }),
             Tables\Columns\TextColumn::make('name')
-                ->label(__('lunarpanel::discount.table.name.label')),
+                ->label(__('lunarpanel::discount.table.name.label'))
+                ->searchable(),
             Tables\Columns\TextColumn::make('type')
                 ->formatStateUsing(function ($state) {
                     return (new $state)->getName();


### PR DESCRIPTION
Currently the discount listing in the admin panel is unsearchable as there is no indexer set up and none of the fields are searchable so the database has nothing to do.

This PR adds searchable to the name field.