### PR TITLE
Fix: panel Attributes field exclude section/group with empty attributes

### DIFF
--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -64,7 +64,6 @@ class Attributes extends Forms\Components\Group
                     })
                     ->filter(fn ($group) => count($group['fields']));
 
-
                 $groupComponents = [];
 
                 foreach ($groups as $group) {

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -61,7 +61,9 @@ class Attributes extends Forms\Components\Group
                             'model' => $group,
                             'fields' => $attributes->groupBy('attribute_group_id')->get($group->id, []),
                         ];
-                    });
+                    })
+                    ->filter(fn ($group) => count($group['fields']));
+
 
                 $groupComponents = [];
 


### PR DESCRIPTION
**before**
![image](https://github.com/user-attachments/assets/26dcff52-f662-498e-aab9-541baee0d606)
