### PR TITLE
Allow using locales when creating or editing languages in the admin panel

### DIFF
--- a/packages/admin/src/Filament/Resources/LanguageResource.php
+++ b/packages/admin/src/Filament/Resources/LanguageResource.php
@@ -65,7 +65,7 @@ class LanguageResource extends BaseResource
             ->label(__('lunarpanel::language.form.code.label'))
             ->required()
             ->minLength(2)
-            ->maxLength(2);
+            ->maxLength(5);
     }
 
     protected static function getDefaultFormComponent(): Component


### PR DESCRIPTION
Allow entering a maximum of 5 characters for a language code instead of 2, so that a locale can be used. (eg en_GB or nl-BE).

There are multiple use cases for this:
- Words and spelling can differ between different versions of the same language.
- Multiple domain names may be used, and different descriptions can be useful to avoid a duplicate content SEO penalty.

I believe this is the only change necessary to support using locales. The database column already allows long language codes, and I don't see other places where this could create an issue.