### PR TITLE
Remove enforced unique validation on SKU

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductIdentifiers.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductIdentifiers.php
@@ -94,12 +94,7 @@ class ManageProductIdentifiers extends BaseEditRecord
 
         return $form->schema([
             Section::make()->schema([
-                ProductVariantResource::getSkuFormComponent()
-                    ->live()->unique(
-                        table: fn () => $variant->getTable(),
-                        ignorable: $variant,
-                        ignoreRecord: true,
-                    ),
+                ProductVariantResource::getSkuFormComponent()->live(),
                 ProductVariantResource::getGtinFormComponent(),
                 ProductVariantResource::getMpnFormComponent(),
                 ProductVariantResource::getEanFormComponent(),


### PR DESCRIPTION
This PR removes the enforced unique validation on SKU. 

Dev's can overwrite the SKU validation using `extendSkuValidation()` hook, but the line removed in this PR still forces unique validation even when you don't want it.