### PR TITLE
Cast Model ID to a string in ProductOptionIndexer.php

### DIFF
--- a/packages/core/src/Search/ProductOptionIndexer.php
+++ b/packages/core/src/Search/ProductOptionIndexer.php
@@ -29,7 +29,7 @@ class ProductOptionIndexer extends ScoutIndexer
 
     public function toSearchableArray(Model $model): array
     {
-        $data['id'] = $model->id;
+        $data['id'] = (string) $model->id;
 
         // Loop for add option name
         foreach ($model->name as $locale => $name) {


### PR DESCRIPTION
Cast the model's ID property to a string to match other indexers. 

This stops the Typesense scout driver throwing an error when indexing the record.
