### PR TITLE
Fix event firing for extended models

### DIFF
--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -138,4 +138,23 @@ trait HasModelExtending
             $instance->registerObserver($class);
         }
     }
+
+    /**
+     * Fire the given event for the model.
+     */
+    protected function fireModelEvent($event, $halt = true): mixed
+    {
+        // Fire the actual models events
+        $result = parent::fireModelEvent($event, $halt);
+
+        $lunarClass = str_replace('Contracts\\', '', ModelManifest::guessContractClass(static::class));
+
+        if ($lunarClass == static::class) {
+            return $result;
+        }
+
+        return static::$dispatcher->{($halt ? 'until' : 'dispatch')}(
+            "eloquent.{$event}: ".$lunarClass, $this
+        );
+    }
 }

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -68,6 +68,7 @@ use Lunar\Models\CustomerGroup;
 use Lunar\Models\Language;
 use Lunar\Models\Order;
 use Lunar\Models\OrderLine;
+use Lunar\Models\Product;
 use Lunar\Models\ProductOption;
 use Lunar\Models\ProductOptionValue;
 use Lunar\Models\ProductVariant;
@@ -83,6 +84,7 @@ use Lunar\Observers\LanguageObserver;
 use Lunar\Observers\MediaObserver;
 use Lunar\Observers\OrderLineObserver;
 use Lunar\Observers\OrderObserver;
+use Lunar\Observers\ProductObserver;
 use Lunar\Observers\ProductOptionObserver;
 use Lunar\Observers\ProductOptionValueObserver;
 use Lunar\Observers\ProductVariantObserver;
@@ -296,6 +298,8 @@ class LunarServiceProvider extends ServiceProvider
      */
     protected function registerObservers(): void
     {
+        Product::observe(ProductObserver::class);
+
         Channel::observe(ChannelObserver::class);
         CustomerGroup::observe(CustomerGroupObserver::class);
         Language::observe(LanguageObserver::class);

--- a/packages/core/src/Observers/ProductObserver.php
+++ b/packages/core/src/Observers/ProductObserver.php
@@ -8,8 +8,6 @@ class ProductObserver
 {
     /**
      * Handle the ProductVariant "deleted" event.
-     *
-     * @return void
      */
     public function deleting(Product $product): void
     {

--- a/packages/core/src/Observers/ProductObserver.php
+++ b/packages/core/src/Observers/ProductObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lunar\Observers;
+
+use Lunar\Models\Product;
+
+class ProductObserver
+{
+    /**
+     * Handle the ProductVariant "deleted" event.
+     *
+     * @return void
+     */
+    public function deleting(Product $product): void
+    {
+        $product->variants()->delete();
+    }
+
+    public function restored(Product $product): void
+    {
+        $product->variants()->restore();
+    }
+}

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -77,7 +77,7 @@ test('core model events are triggered with extended models', function () {
     $product->delete();
 
     \Illuminate\Support\Facades\Event::assertDispatched(
-        'eloquent.deleted: ' . Product::class
+        'eloquent.deleted: '.Product::class
     );
 
     \Lunar\Facades\ModelManifest::replace(
@@ -90,6 +90,6 @@ test('core model events are triggered with extended models', function () {
     $product->delete();
 
     \Illuminate\Support\Facades\Event::assertDispatched(
-        'eloquent.deleted: ' . Product::class
+        'eloquent.deleted: '.Product::class
     );
 });

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -68,3 +68,28 @@ test('morph map is correct when models are extended', function () {
         ->and(Product::morphName())
         ->toBe('product');
 });
+
+test('core model events are triggered with extended models', function () {
+    \Illuminate\Support\Facades\Event::fake();
+
+    $product = \Lunar\Tests\Core\Stubs\Models\Product::factory()->create();
+
+    $product->delete();
+
+    \Illuminate\Support\Facades\Event::assertDispatched(
+        'eloquent.deleted: ' . Product::class
+    );
+
+    \Lunar\Facades\ModelManifest::replace(
+        \Lunar\Models\Contracts\Product::class,
+        \Lunar\Tests\Core\Stubs\Models\CustomProduct::class
+    );
+
+    $product = \Lunar\Tests\Core\Stubs\Models\CustomProduct::factory()->create();
+
+    $product->delete();
+
+    \Illuminate\Support\Facades\Event::assertDispatched(
+        'eloquent.deleted: ' . Product::class
+    );
+});


### PR DESCRIPTION
Currently when models are extended, any observers which are registered by Lunar are not taking into account by model events as the signature changes.

For example Lunar registers listeners to : `eloquent:updating: Lunar\Models\Product` however if you had your own custom model, the signature will be `eloquent:updating: App\Models\Product` which means the observers aren't dispatched.

This PR looks to override the default `fireModelEvent` method and add in an extra check to see if we're dealing with an extended model and, if so, dispatch any events for the `Lunar\Models\Product` counterpart.