### PR TITLE
Ensure discount subnavigation can be extended

### DIFF
--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -5,7 +5,6 @@ namespace Lunar\Admin\Filament\Resources;
 use Filament\Forms;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Form;
-use Filament\Pages\Page;
 use Filament\Pages\SubNavigationPosition;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;

--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -377,13 +377,13 @@ class DiscountResource extends BaseResource
         ];
     }
 
-    public static function getRecordSubNavigation(Page $page): array
+    public static function getDefaultSubNavigation(): array
     {
-        return $page->generateNavigationItems([
+        return [
             Pages\EditDiscount::class,
             Pages\ManageDiscountAvailability::class,
             Pages\ManageDiscountLimitations::class,
-        ]);
+        ];
     }
 
     protected static function getDefaultRelations(): array


### PR DESCRIPTION
This PR ensures discount sub navigation can be extended by using getDefaultSubNavigation() for its submenu.