### PR TITLE
Do not dehydrate password_confirmation when editing a customer's user's password

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/UserRelationManager.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/RelationManagers/UserRelationManager.php
@@ -57,7 +57,8 @@ class UserRelationManager extends BaseRelationManager
                                 __('lunarpanel::user.form.password_confirmation.label')
                             )
                             ->password()
-                            ->minLength(8),
+                            ->minLength(8)
+                            ->dehydrated(false),
                     ])->columns(2),
 
                 ]),


### PR DESCRIPTION

The PR https://github.com/lunarphp/lunar/pull/1458 to edit the user's password does not dehydrate `password_confirmation` field, leading to a SQL error, exposing the password.

![Screenshot 2025-01-21 at 19 24 17](https://github.com/user-attachments/assets/617aa997-66fd-46fd-a4c6-9653d145c747)

