### PR TITLE
Added the ability to pass the channel to the StorefrontSessionManager

### DIFF
--- a/packages/core/src/Managers/StorefrontSessionManager.php
+++ b/packages/core/src/Managers/StorefrontSessionManager.php
@@ -36,16 +36,17 @@ class StorefrontSessionManager implements StorefrontSessionInterface
 
     /**
      * Initialise the manager
-     *
-     * @param protected SessionManager
      */
     public function __construct(
         protected SessionManager $sessionManager,
-        protected AuthManager $authManager
+        protected AuthManager $authManager,
+        ?\Lunar\Models\Contracts\Channel $channel = null
     ) {
         if (! $this->customerGroups) {
             $this->customerGroups = collect();
         }
+
+        $this->channel = $channel;
 
         $this->initChannel();
         $this->initCustomerGroups();


### PR DESCRIPTION
Currently, when the StorefrontSessionManager is initialised, there is no way of setting the defaults.

In my use case, I'm determining the channel based on the URL structure and market that is defined (separate to Lunar).

So in my middleware, I want to initialise the storefront with the channel but there isn't actually a way to do this. This adds the option to supply a channel