### PR TITLE
Fix: fixes exception thrown on option "all"

### DIFF
--- a/packages/admin/src/Support/Pages/Concerns/ExtendsTablePagination.php
+++ b/packages/admin/src/Support/Pages/Concerns/ExtendsTablePagination.php
@@ -10,7 +10,7 @@ trait ExtendsTablePagination
 {
     protected function getDefaultPaginationQuery(Builder $query): Paginator|CursorPaginator
     {
-        return $query->paginate($this->getTableRecordsPerPage());
+        return parent::paginateTableQuery($query);
     }
 
     protected function paginateTableQuery(Builder $query): Paginator|CursorPaginator

--- a/tests/admin/Feature/Support/Extending/ExtendsTablePaginationTest.php
+++ b/tests/admin/Feature/Support/Extending/ExtendsTablePaginationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Livewire\Livewire;
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('extending.list');
+
+it('can list all records', function () {
+    $this->asStaff();
+
+    $customers = \Lunar\Models\Customer::factory(30)->create();
+
+    Livewire::test(\Lunar\Admin\Filament\Resources\CustomerResource\Pages\ListCustomers::class)
+        ->set('tableRecordsPerPage', 'all')
+        ->assertCountTableRecords(30)
+        ->assertCanSeeTableRecords($customers);
+});


### PR DESCRIPTION
This PR fixes the exception on List pages if the pagination option is set to "all".

Related issue #2058
