### PR TITLE
Use model manifest to query buy x get y conditions and rewards

### DIFF
--- a/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/ProductConditionRelationManager.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/ProductConditionRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
+use Lunar\Facades\ModelManifest;
 use Lunar\Models\Product;
 
 class ProductConditionRelationManager extends BaseRelationManager
@@ -38,7 +39,9 @@ class ProductConditionRelationManager extends BaseRelationManager
             ->paginated(false)
             ->modifyQueryUsing(
                 fn ($query) => $query->whereIn('type', ['condition'])
-                    ->wherePurchasableType(Product::class)
+                    ->wherePurchasableType(
+                        ModelManifest::getMorphMapKey(Product::class)
+                    )
                     ->whereHas('purchasable')
             )
             ->headerActions([

--- a/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/ProductRewardRelationManager.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/ProductRewardRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
+use Lunar\Facades\ModelManifest;
 use Lunar\Models\Product;
 
 class ProductRewardRelationManager extends BaseRelationManager
@@ -38,7 +39,9 @@ class ProductRewardRelationManager extends BaseRelationManager
             ->paginated(false)
             ->modifyQueryUsing(
                 fn ($query) => $query->whereIn('type', ['reward'])
-                    ->wherePurchasableType(Product::class)
+                    ->wherePurchasableType(
+                        ModelManifest::getMorphMapKey(Product::class)
+                    )
                     ->whereHas('purchasable')
             )
             ->headerActions([


### PR DESCRIPTION
This PR updates the filament discount queries for Buy x get y conditions and rewards to use the model manifest instead of the model FQCN.