### PR TITLE
Apply cart's customer group to discount manager

### DIFF
--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -122,6 +122,10 @@ class DiscountManager implements DiscountManagerInterface
             $this->channel($defaultChannel);
         }
 
+        if ($cart && $customerGroups = $cart->customer?->customerGroups) {
+            $this->customerGroup($customerGroups);
+        }
+
         if ($this->customerGroups->isEmpty() && $defaultGroup = CustomerGroup::getDefault()) {
             $this->customerGroup($defaultGroup);
         }


### PR DESCRIPTION
Currently in v0.8 customer groups associated to cart's customer are not applied in DiscountManager. 

This issue has been already fixed in v1.x, this PR aims to make it works even in v0.8.

Accepted PR targeting v1.x:
https://github.com/lunarphp/lunar/issues/2045