### PR TITLE
Check if model uses Searchable class recursive

### DIFF
--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -23,7 +23,7 @@ if (! function_exists('sync_with_search')) {
             return;
         }
 
-        $isSearchable = in_array(Searchable::class, class_uses($model));
+        $isSearchable = in_array(Searchable::class, class_uses_recursive($model));
 
         if ($isSearchable) {
             $model->searchable();


### PR DESCRIPTION
Hi there,

So I was having issues with my models not being persisted in my search engine and after some trouble shooting I figured out that because I am extend models with my own classes als described here [https://docs.lunarphp.io/core/extending/models.html#replaceable-models](https://docs.lunarphp.io/core/extending/models.html#replaceable-models).

However when triggering a search from the admin `sync_with_search` only checks if the current model is using `Lunar\Base\Traits\Searchable` thus not calling `->searchable()`

By updating the code to `class_uses_recursive` the issue is solved and the model is once again persisted in the search engine.