### PR TITLE
Show vat number at order details

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "minicstudio/lunar",
+    "name": "lunarphp/lunar",
     "description": "Custom minic fork of Lunar package",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "lunarphp/lunar",
-    "description": "Lunar Monorepo",
+    "name": "minicstudio/lunar",
+    "description": "Custom minic fork of Lunar package",
     "license": "MIT",
     "authors": [
         {

--- a/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderAddresses.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Concerns/DisplaysOrderAddresses.php
@@ -138,6 +138,7 @@ trait DisplaysOrderAddresses
                         if ($address?->id ?? false) {
                             return collect([
                                 'company_name' => $address->company_name,
+                                'vat_number' => $address->meta?->vatNumber,
                                 'fullName' => $address->fullName,
                                 'line_one' => $address->line_one,
                                 'line_two' => $address->line_two,


### PR DESCRIPTION
This PR tends to resolve the following issue: [Issue nr #2070](https://github.com/lunarphp/lunar/issues/2070)

If the order was made by a legal person and the company's VAT number is available then show it at the order details billing address section.
