### PR TITLE
Fix variant switcher when overriding ProductVariant model

### DIFF
--- a/packages/admin/src/Filament/Widgets/Products/VariantSwitcherTable.php
+++ b/packages/admin/src/Filament/Widgets/Products/VariantSwitcherTable.php
@@ -88,9 +88,9 @@ class VariantSwitcherTable extends TableWidget
 
     protected function getTableRecordUrlUsing(): ?Closure
     {
-        return function (ProductVariant $variant) {
+        return function (Model $record) {
             return ProductVariantResource::getUrl('edit', [
-                'record' => $variant,
+                'record' => $record,
             ]);
         };
     }


### PR DESCRIPTION
Hi there!

In our application we extend the ProductVariant model like so
```
ModelManifest::replace(
    \Lunar\Models\Contracts\ProductVariant::class,
   App\Models\ProductVariant::class,
);

```

When trying to switch using the button on the top right when editing a variant:

![Screenshot 2025-01-31 at 10 54 39](https://github.com/user-attachments/assets/ba7a9785-0e58-4192-8c24-8e4160567964)

The following error is generated.

![Screenshot 2025-01-31 at 10 52 19](https://github.com/user-attachments/assets/7bf73712-bbaf-4dd2-8792-222921c518a3)

After some digging I found that in the closure there was a hard reference to the original model, this caused the evaluation in [getRecordUrl](https://github.com/filamentphp/filament/blob/3.x/packages/tables/src/Table/Concerns/HasRecordUrl.php#L29) to not fill the variable properly. Switching to `record` makes it work even when extending