### PR TITLE
Allow variant media page to be extended

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -74,7 +74,7 @@ class ManageVariantMedia extends BaseEditRecord
         return $record;
     }
 
-    public function form(Form $form): Form
+    public function getDefaultForm(Form $form): Form
     {
         return $form->schema([
             Section::make()->schema([

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -67,11 +67,13 @@ class ManageVariantMedia extends BaseEditRecord
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
+        $data = $this->callLunarHook('beforeUpdate', $data, $record);
+
         $record->images()->sync([
             $data['images'] => ['primary' => true],
         ]);
 
-        return $record;
+        return $this->callLunarHook('afterUpdate', $record, $data);
     }
 
     public function getDefaultForm(Form $form): Form


### PR DESCRIPTION
The variant media page currently can't be extended as it overrides the form() method, this PR enables it by using the correct getDefaultForm method.