### PR TITLE
Update variant media page to allow multiple images

### DIFF
--- a/packages/admin/resources/lang/en/relationmanagers.php
+++ b/packages/admin/resources/lang/en/relationmanagers.php
@@ -95,6 +95,9 @@ return [
             'create' => [
                 'label' => 'Create Media',
             ],
+            'detach' => [
+                'label' => 'Detach',
+            ],
             'view' => [
                 'label' => 'View',
             ],

--- a/packages/admin/resources/lang/en/relationmanagers.php
+++ b/packages/admin/resources/lang/en/relationmanagers.php
@@ -89,6 +89,9 @@ return [
         'title' => 'Media',
         'title_plural' => 'Media',
         'actions' => [
+            'attach' => [
+                'label' => 'Attach Media',
+            ],
             'create' => [
                 'label' => 'Create Media',
             ],
@@ -121,6 +124,7 @@ return [
                 'label' => 'Primary',
             ],
         ],
+        'variant_description' => 'Attach product images to this variant',
     ],
     'urls' => [
         'title' => 'URL',

--- a/packages/admin/resources/lang/en/relationmanagers.php
+++ b/packages/admin/resources/lang/en/relationmanagers.php
@@ -127,6 +127,7 @@ return [
                 'label' => 'Primary',
             ],
         ],
+        'all_media_attached' => 'There are no product images available to attach',
         'variant_description' => 'Attach product images to this variant',
     ],
     'urls' => [

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -97,7 +97,7 @@ class ManageVariantMedia extends BaseManageRelatedRecords
                             ->required(),
 
                         Forms\Components\Toggle::make('primary')
-                            ->label(__('lunarpanel::relationmanagers.medias.table.primary.label'))
+                            ->label(__('lunarpanel::relationmanagers.medias.table.primary.label')),
                     ])
                     ->using(function (array $data): Model {
                         $record = $this->getOwnerRecord();

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -81,6 +81,7 @@ class ManageVariantMedia extends BaseManageRelatedRecords
             ->headerActions([
                 CreateAction::make('attach')
                     ->label(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
+                    ->modalHeading(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
                     ->form([
                         Forms\Components\Select::make('media_id')
                             ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -46,6 +46,18 @@ class ManageVariantMedia extends BaseManageRelatedRecords
         ];
     }
 
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ...ProductVariantResource::getBaseBreadcrumbs(
+                $this->getRecord()
+            ),
+            ProductVariantResource::getUrl('media', [
+                'record' => $this->getRecord(),
+            ]) => $this->getTitle(),
+        ];
+    }
+
     public function table(Table $table): Table
     {
         return $table
@@ -60,7 +72,7 @@ class ManageVariantMedia extends BaseManageRelatedRecords
             ->columns([
                 Tables\Columns\ImageColumn::make('image')
                     ->state(function (Media $record): string {
-                        return $record->hasGeneratedConversion('small') ? $record->getUrl('small') : '';
+                        return $record->hasGeneratedConversion('small') ? $record->getUrl('small') : $record->getUrl();
                     })
                     ->label(__('lunarpanel::relationmanagers.medias.table.image.label')),
                 Tables\Columns\TextColumn::make('file_name')
@@ -125,6 +137,13 @@ class ManageVariantMedia extends BaseManageRelatedRecords
                         ]);
 
                         return $record;
+                    }),
+            ])
+            ->actions([
+                Action::make('detach')
+                    ->label(__('lunarpanel::relationmanagers.medias.actions.detach.label'))
+                    ->action(function($record) {
+                        $this->getOwnerRecord()->images()->detach($record);
                     }),
             ])
             ->reorderRecordsTriggerAction(

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -2,22 +2,24 @@
 
 namespace Lunar\Admin\Filament\Resources\ProductVariantResource\Pages;
 
-use Awcodes\Shout\Components\Shout;
-use Filament\Actions\Action;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
+use Filament\Forms;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Tables;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Lunar\Admin\Filament\Resources\ProductResource;
+use Illuminate\Support\Arr;
 use Lunar\Admin\Filament\Resources\ProductVariantResource;
-use Lunar\Admin\Support\Forms\Components\MediaSelect;
-use Lunar\Admin\Support\Pages\BaseEditRecord;
-use Lunar\Models\ProductVariant;
+use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
-class ManageVariantMedia extends BaseEditRecord
+class ManageVariantMedia extends BaseManageRelatedRecords
 {
+    protected static string $relationship = 'images';
+
     protected static string $resource = ProductVariantResource::class;
 
     public function getTitle(): string|Htmlable
@@ -44,79 +46,91 @@ class ManageVariantMedia extends BaseEditRecord
         ];
     }
 
-    protected function getCancelFormAction(): Action
+    public function table(Table $table): Table
     {
-        return parent::getCancelFormAction()->url(function (Model $record) {
-            return ProductResource::getUrl('variants', [
-                'record' => $record->product,
-            ]);
-        });
-    }
-
-    public function getBreadcrumbs(): array
-    {
-        return [
-            ...ProductVariantResource::getBaseBreadcrumbs(
-                $this->getRecord()
-            ),
-            ProductVariantResource::getUrl('media', [
-                'record' => $this->getRecord(),
-            ]) => $this->getTitle(),
-        ];
-    }
-
-    protected function handleRecordUpdate(Model $record, array $data): Model
-    {
-        $record->images()->sync([
-            $data['images'] => ['primary' => true],
-        ]);
-
-        return $record;
-    }
-
-    public function form(Form $form): Form
-    {
-        return $form->schema([
-            Section::make()->schema([
-                Shout::make('no_selection')->content(
-                    __('lunarpanel::productvariant.pages.media.form.no_selection.label')
-                )->visible(
-                    fn (Get $get) => ! $get('images') && $this->getRecord()->product->media()->count()
-                ),
-                Shout::make('no_media_available')->content(
-                    __('lunarpanel::productvariant.pages.media.form.no_media_available.label')
-                )->visible(
-                    fn (Get $get) => ! $this->getRecord()->product->media()->count()
-                ),
-                MediaSelect::make('images')
-                    ->visible(
-                        fn () => $this->getRecord()->product->media()->count()
-                    )
-                    ->label(
-                        __('lunarpanel::productvariant.pages.media.form.images.label')
-                    )
-                    ->helperText(
-                        __('lunarpanel::productvariant.pages.media.form.images.helper_text')
-                    )
-                    ->afterStateHydrated(function (ProductVariant $record, MediaSelect $component) {
-                        $image = $record->images->first(function ($media) {
-                            return (bool) $media->pivot?->primary;
-                        });
-                        $component->state($image?->id);
+        return $table
+            ->heading(function () {
+                return __('lunarpanel::relationmanagers.medias.title');
+            })
+            ->description(function () {
+                return __('lunarpanel::relationmanagers.medias.variant_description');
+            })
+            ->recordTitleAttribute('name')
+            ->modifyQueryUsing(fn (Builder $query) => $query->orderBy('position'))
+            ->columns([
+                Tables\Columns\ImageColumn::make('image')
+                    ->state(function (Media $record): string {
+                        return $record->hasGeneratedConversion('small') ? $record->getUrl('small') : '';
                     })
-                    ->options(
-                        $this->getRecord()->product->media->mapWithKeys(
-                            fn ($media) => [
-                                $media->id => $media->getUrl('small'),
-                            ]
-                        )
-                    ),
-            ]),
-        ]);
-    }
+                    ->label(__('lunarpanel::relationmanagers.medias.table.image.label')),
+                Tables\Columns\TextColumn::make('file_name')
+                    ->limit(30)
+                    ->label(__('lunarpanel::relationmanagers.medias.table.file.label')),
+                Tables\Columns\TextColumn::make('custom_properties.name')
+                    ->label(__('lunarpanel::relationmanagers.medias.table.name.label')),
+                Tables\Columns\ToggleColumn::make('primary')
+                    ->label(__('lunarpanel::relationmanagers.medias.table.primary.label'))
+                    ->beforeStateUpdated(function ($record, $state) {
+                        if ($state === true) {
+                            $record = $this->getOwnerRecord();
 
-    public function getRelationManagers(): array
-    {
-        return [];
+                            $record->images->each(fn ($media) => $record->images()->updateExistingPivot($media->id, ['primary' => false]));
+                        }
+                    }),
+            ])
+            ->headerActions([
+                CreateAction::make('attach')
+                    ->label(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
+                    ->form([
+                        Forms\Components\Select::make('media_id')
+                            ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))
+                            ->options(function () {
+                                return $this->getRecord()
+                                    ->product
+                                    ->media
+                                    ->filter(fn ($media) => ! $this->getRecord()->images->pluck('id')->contains($media->id))
+                                    ->mapWithKeys(fn ($media) => [
+                                        $media->getKey() => Arr::get($media->data, 'custom_properties.name', $media->name),
+                                    ]);
+                            })
+                            ->required(),
+
+                        Forms\Components\Toggle::make('primary')
+                            ->label(__('lunarpanel::relationmanagers.medias.table.primary.label'))
+                    ])
+                    ->using(function (array $data): Model {
+                        $record = $this->getOwnerRecord();
+
+                        $isPrimary = $data['primary'] ?? false;
+                        $position = 0;
+
+                        if (! $isPrimary && $record->images->isEmpty()) {
+                            $isPrimary = true;
+                        }
+
+                        if ($record->images->isNotEmpty()) {
+                            $position = $record->images->pluck('pivot.position')->sort()->last() + 1;
+
+                            if ($isPrimary) {
+                                $record->images->each(fn ($media) => $record->images()->updateExistingPivot($media->id, ['primary' => false]));
+                            }
+                        }
+
+                        $record->images()->attach([
+                            $data['media_id'] => [
+                                'position' => $position,
+                                'primary' => $isPrimary,
+                            ],
+                        ]);
+
+                        return $record;
+                    }),
+            ])
+            ->reorderRecordsTriggerAction(
+                fn (Action $action, bool $isReordering) => $action
+                    ->button()
+                    ->label($isReordering ? 'Disable reordering' : 'Enable reordering'),
+            )
+            ->reorderable('position', true);
     }
 }

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -142,7 +142,7 @@ class ManageVariantMedia extends BaseManageRelatedRecords
             ->actions([
                 Action::make('detach')
                     ->label(__('lunarpanel::relationmanagers.medias.actions.detach.label'))
-                    ->action(function($record) {
+                    ->action(function ($record) {
                         $this->getOwnerRecord()->images()->detach($record);
                     }),
             ])

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -129,8 +129,7 @@ class ManageVariantMedia extends BaseManageRelatedRecords
             ])
             ->reorderRecordsTriggerAction(
                 fn (Action $action, bool $isReordering) => $action
-                    ->button()
-                    ->label($isReordering ? 'Disable reordering' : 'Enable reordering'),
+                    ->button(),
             )
             ->reorderable('position', true);
     }

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -2,7 +2,10 @@
 
 namespace Lunar\Admin\Filament\Resources\ProductVariantResource\Pages;
 
+use Awcodes\Shout\Components\Shout;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Get;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
 use Filament\Tables\Actions\Action;
@@ -95,21 +98,39 @@ class ManageVariantMedia extends BaseManageRelatedRecords
                     ->label(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
                     ->modalHeading(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
                     ->form([
-                        Forms\Components\Select::make('media_id')
-                            ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))
-                            ->options(function () {
-                                return $this->getRecord()
-                                    ->product
-                                    ->media
-                                    ->filter(fn ($media) => ! $this->getRecord()->images->pluck('id')->contains($media->id))
-                                    ->mapWithKeys(fn ($media) => [
-                                        $media->getKey() => Arr::get($media->data, 'custom_properties.name', $media->name),
-                                    ]);
-                            })
-                            ->required(),
+                        Section::make()->schema([
+                            Shout::make('no_selection')->content(
+                                __('lunarpanel::productvariant.pages.media.form.no_selection.label')
+                            )->visible(
+                                fn (Get $get) => ! $get('images') && $this->getRecord()->product->media()->count()
+                            ),
+                            Shout::make('no_media_available')->content(
+                                __('lunarpanel::productvariant.pages.media.form.no_media_available.label')
+                            )->visible(
+                                fn (Get $get) => ! $this->getRecord()->product->media()->count()
+                            ),
+                            Forms\Components\Select::make('media_id')
+                                ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))
+                                ->options(function () {
+                                    return $this->getRecord()
+                                        ->product
+                                        ->media
+                                        ->filter(fn ($media) => ! $this->getRecord()->images->pluck('id')->contains($media->id))
+                                        ->mapWithKeys(fn ($media) => [
+                                            $media->getKey() => Arr::get($media->data, 'custom_properties.name', $media->name),
+                                        ]);
+                                })
+                                ->visible(
+                                    fn () => $this->getRecord()->product->media()->count()
+                                )
+                                ->required(),
 
-                        Forms\Components\Toggle::make('primary')
-                            ->label(__('lunarpanel::relationmanagers.medias.table.primary.label')),
+                            Forms\Components\Toggle::make('primary')
+                                ->label(__('lunarpanel::relationmanagers.medias.table.primary.label'))
+                                ->visible(
+                                    fn () => $this->getRecord()->product->media()->count()
+                                ),
+                        ]),
                     ])
                     ->using(function (array $data): Model {
                         $record = $this->getOwnerRecord();

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -4,7 +4,6 @@ namespace Lunar\Admin\Filament\Resources\ProductVariantResource\Pages;
 
 use Awcodes\Shout\Components\Shout;
 use Filament\Forms;
-use Filament\Forms\Components\Section;
 use Filament\Forms\Get;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables;
@@ -98,39 +97,32 @@ class ManageVariantMedia extends BaseManageRelatedRecords
                     ->label(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
                     ->modalHeading(__('lunarpanel::relationmanagers.medias.actions.attach.label'))
                     ->form([
-                        Section::make()->schema([
-                            Shout::make('no_selection')->content(
-                                __('lunarpanel::productvariant.pages.media.form.no_selection.label')
-                            )->visible(
-                                fn (Get $get) => ! $get('images') && $this->getRecord()->product->media()->count()
-                            ),
-                            Shout::make('no_media_available')->content(
-                                __('lunarpanel::productvariant.pages.media.form.no_media_available.label')
-                            )->visible(
-                                fn (Get $get) => ! $this->getRecord()->product->media()->count()
-                            ),
-                            Forms\Components\Select::make('media_id')
-                                ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))
-                                ->options(function () {
-                                    return $this->getRecord()
-                                        ->product
-                                        ->media
-                                        ->filter(fn ($media) => ! $this->getRecord()->images->pluck('id')->contains($media->id))
-                                        ->mapWithKeys(fn ($media) => [
-                                            $media->getKey() => Arr::get($media->data, 'custom_properties.name', $media->name),
-                                        ]);
-                                })
-                                ->visible(
-                                    fn () => $this->getRecord()->product->media()->count()
-                                )
-                                ->required(),
+                        Shout::make('no_media_available')->content(
+                            __('lunarpanel::relationmanagers.medias.all_media_attached')
+                        )->visible(
+                            fn (Get $get) => ! $this->getRecord()->product->media()->count() >= $this->getRecord()->images()->count()
+                        ),
+                        Forms\Components\Select::make('media_id')
+                            ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))
+                            ->options(function () {
+                                return $this->getRecord()
+                                    ->product
+                                    ->media
+                                    ->filter(fn ($media) => ! $this->getRecord()->images->pluck('id')->contains($media->id))
+                                    ->mapWithKeys(fn ($media) => [
+                                        $media->getKey() => Arr::get($media->data, 'custom_properties.name', $media->name),
+                                    ]);
+                            })
+                            ->visible(
+                                fn () => $this->getRecord()->product->media()->count() > $this->getRecord()->images()->count()
+                            )
+                            ->required(),
 
-                            Forms\Components\Toggle::make('primary')
-                                ->label(__('lunarpanel::relationmanagers.medias.table.primary.label'))
-                                ->visible(
-                                    fn () => $this->getRecord()->product->media()->count()
-                                ),
-                        ]),
+                        Forms\Components\Toggle::make('primary')
+                            ->label(__('lunarpanel::relationmanagers.medias.table.primary.label'))
+                            ->visible(
+                                fn () => $this->getRecord()->product->media()->count() > $this->getRecord()->images()->count()
+                            ),
                     ])
                     ->using(function (array $data): Model {
                         $record = $this->getOwnerRecord();

--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantMedia.php
@@ -100,7 +100,7 @@ class ManageVariantMedia extends BaseManageRelatedRecords
                         Shout::make('no_media_available')->content(
                             __('lunarpanel::relationmanagers.medias.all_media_attached')
                         )->visible(
-                            fn (Get $get) => ! $this->getRecord()->product->media()->count() >= $this->getRecord()->images()->count()
+                            fn (Get $get) => $this->getRecord()->product->media()->count() <= $this->getRecord()->images()->count()
                         ),
                         Forms\Components\Select::make('media_id')
                             ->label(__('lunarpanel::relationmanagers.medias.table.file.label'))
@@ -113,8 +113,8 @@ class ManageVariantMedia extends BaseManageRelatedRecords
                                         $media->getKey() => Arr::get($media->data, 'custom_properties.name', $media->name),
                                     ]);
                             })
-                            ->visible(
-                                fn () => $this->getRecord()->product->media()->count() > $this->getRecord()->images()->count()
+                            ->disabled(
+                                fn () => $this->getRecord()->product->media()->count() <= $this->getRecord()->images()->count()
                             )
                             ->required(),
 


### PR DESCRIPTION
This PR updates the variant media screens to allow multiple images to be attached to the product, rather than just a primary image. This aligns with the behaviour before Lunar 1.x.

It now looks more like this:
![CleanShot 2025-02-07 at 07 45 02@2x](https://github.com/user-attachments/assets/638fa74b-3a37-418c-a3df-58e6a7f2163e)

As this is now a relation manager we've lost the shout boxes you had in place, if there's a way to still have those I think it would be useful. Let me know if I've missed how this could be done.
