### PR TITLE
Don't force lowercase search term for `generate_search_term_expression`

### DIFF
--- a/packages/admin/src/helpers.php
+++ b/packages/admin/src/helpers.php
@@ -91,7 +91,7 @@ if (! function_exists('get_search_builder')) {
             /** @var Connection $databaseConnection */
             $databaseConnection = $query->getConnection();
 
-            $search = generate_search_term_expression($search, true, $databaseConnection);
+            $search = generate_search_term_expression($search, false, $databaseConnection);
 
             foreach (explode(' ', $search) as $searchWord) {
                 $query->where(function (Builder $query) use ($model, $searchWord) {


### PR DESCRIPTION
Currently when scout is disabled, the search term is being forced to lowercase, meaning when doing a `where` query in the database with `LIKE` it's not matching any results.

This PR stops this behaviour so products can be matched.

Fixes #2094  