### PR TITLE
Fix: Applying multiple discounts results in incorrect discountTotal

### DIFF
--- a/packages/core/src/DiscountTypes/AmountOff.php
+++ b/packages/core/src/DiscountTypes/AmountOff.php
@@ -235,6 +235,7 @@ class AmountOff extends AbstractDiscountType
         foreach ($lines as $line) {
             $subTotal = $line->subTotal->value;
             $subTotalDiscounted = $line->subTotalDiscounted?->value ?: 0;
+            $lineDiscount = $line->discountTotal?->value ?: 0;
 
             if ($subTotalDiscounted) {
                 $subTotal = $subTotalDiscounted;
@@ -244,14 +245,14 @@ class AmountOff extends AbstractDiscountType
 
             // If this line already has a greater discount value
             // don't add this one as they already have a better deal.
-            if ($line->discountTotal->value > $amount) {
+            if ($lineDiscount > $amount) {
                 continue;
             }
 
             $totalDiscount += $amount;
 
             $line->discountTotal = new Price(
-                $amount,
+                $lineDiscount + $amount,
                 $cart->currency,
                 1
             );

--- a/tests/core/Unit/DiscountTypes/AmountOffTest.php
+++ b/tests/core/Unit/DiscountTypes/AmountOffTest.php
@@ -786,13 +786,13 @@ test('fixed amount discount distributes across cart lines', function () {
 
 test('can apply percentage discount', function (
     string $coupon,
-    float $percentage,
-    int $discountTotalForOne,
-    int $taxTotalForOne,
-    int $totalForOne,
-    int $discountTotalForTwo,
-    int $taxTotalForTwo,
-    int $totalForTwo
+    float  $percentage,
+    int    $discountTotalForOne,
+    int    $taxTotalForOne,
+    int    $totalForOne,
+    int    $discountTotalForTwo,
+    int    $taxTotalForTwo,
+    int    $totalForTwo
 ) {
     $customerGroup = CustomerGroup::getDefault();
 
@@ -1823,4 +1823,85 @@ test('can handle malformed discount', function () {
     $cart = $cart->calculate();
 
     expect($cart->discountTotal->value)->toEqual(0);
+});
+
+test('can apply multiple discounts to the same line', function () {
+    $customerGroup = CustomerGroup::getDefault();
+
+    $channel = Channel::getDefault();
+
+    $currency = Currency::getDefault();
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 1000,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $discounts = Discount::factory()->createMany([
+        [
+            'type' => AmountOff::class,
+            'name' => '10% discount',
+            'data' => [
+                'percentage' => 10,
+                'fixed_value' => false,
+            ],
+        ],
+        [
+            'type' => AmountOff::class,
+            'name' => '20% discount',
+            'data' => [
+                'percentage' => 20,
+                'fixed_value' => false,
+            ],
+        ],
+    ]);
+
+    foreach ($discounts as $discount) {
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+    }
+
+    $cart = $cart->calculate();
+
+    /**
+     * Cart has two discounts.
+     * 1 x $10 / 10% off $9
+     * 1 x $9 / 20% off $7.20
+     * Cart total = $7.20 / 20% tax = $1.44 / Total = $8.64
+     */
+    expect($cart->discountBreakdown)->toHaveCount(2);
+    expect($cart->discountBreakdown->get(0)->price->value)->toEqual(100);
+    expect($cart->discountBreakdown->get(1)->price->value)->toEqual(180);
+    expect($cart->lines->first()->discountTotal->value)->toEqual(280);
+    expect($cart->subTotal->value)->toEqual(1000);
+    expect($cart->subTotalDiscounted->value)->toEqual(720);
+    expect($cart->discountTotal->value)->toEqual(280);
+    expect($cart->total->value)->toEqual(864);
 });

--- a/tests/core/Unit/DiscountTypes/AmountOffTest.php
+++ b/tests/core/Unit/DiscountTypes/AmountOffTest.php
@@ -786,13 +786,13 @@ test('fixed amount discount distributes across cart lines', function () {
 
 test('can apply percentage discount', function (
     string $coupon,
-    float  $percentage,
-    int    $discountTotalForOne,
-    int    $taxTotalForOne,
-    int    $totalForOne,
-    int    $discountTotalForTwo,
-    int    $taxTotalForTwo,
-    int    $totalForTwo
+    float $percentage,
+    int $discountTotalForOne,
+    int $taxTotalForOne,
+    int $totalForOne,
+    int $discountTotalForTwo,
+    int $taxTotalForTwo,
+    int $totalForTwo
 ) {
     $customerGroup = CustomerGroup::getDefault();
 


### PR DESCRIPTION
Fix: When multiple Discounts apply to the same CartLine, the subTotalDiscount and discountBreakdown contain both discounts, but the discountTotal of the Cart and CartLine only contained the value of the last Discount.

This inconsistency resulted in values not correctly adding up in the Admin Panel Order Detail and other places.

This commit fixed both the discountTotal of the Cart and the CartLine to match the Cart's discountBreakdown, subTotalDiscounted & total.