### PR TITLE
Add unit price incl tax to CartLine

### DIFF
--- a/docs/core/reference/carts.md
+++ b/docs/core/reference/carts.md
@@ -140,6 +140,7 @@ foreach ($cart->discountBreakdown as $discountBreakdown) {
 
 foreach ($cart->lines as $cartLine) {
     $cartLine->unitPrice; // The monetary value for a single item.
+    $cartLine->unitPriceInclTax; // The monetary value for a single item, including tax amount.
     $cartLine->total; // The total price value for the cart
     $cartLine->subTotal; // The sub total, excluding tax
     $cartLine->subTotalDiscounted; // The sub total, minus the discount amount.

--- a/packages/core/src/Actions/Carts/CalculateLineSubtotal.php
+++ b/packages/core/src/Actions/Carts/CalculateLineSubtotal.php
@@ -61,7 +61,6 @@ class CalculateLineSubtotal
             $cart->currency->decimal_places
         );
 
-
         $cartLine->subTotal = new Price($unitPrice * $cartLine->quantity, $cart->currency, $unitQuantity);
         $cartLine->unitPrice = new Price($unitPrice, $cart->currency, $unitQuantity);
         $cartLine->unitPriceInclTax = new Price($unitPriceInclTax, $cart->currency, $unitQuantity);

--- a/packages/core/src/Actions/Carts/CalculateLineSubtotal.php
+++ b/packages/core/src/Actions/Carts/CalculateLineSubtotal.php
@@ -25,6 +25,8 @@ class CalculateLineSubtotal
         $cart = $cartLine->cart;
         $unitQuantity = $purchasable->getUnitQuantity();
 
+        $priceInclTax = $cartLine->unitPriceInclTax;
+
         // we check if any cart line modifiers have already specified a unit price in their calculating() method
         if (! ($price = $cartLine->unitPrice) instanceof Price) {
             $priceResponse = Pricing::currency($cart->currency)
@@ -39,6 +41,12 @@ class CalculateLineSubtotal
                 $cart->currency,
                 $purchasable->getUnitQuantity()
             );
+
+            $priceInclTax = new Price(
+                $priceResponse->matched->priceIncTax()->value,
+                $cart->currency,
+                $purchasable->getUnitQuantity()
+            );
         }
 
         $unitPrice = (int) round(
@@ -47,8 +55,16 @@ class CalculateLineSubtotal
             $cart->currency->decimal_places
         );
 
+        $unitPriceInclTax = (int) round(
+            (($priceInclTax->decimal / $purchasable->getUnitQuantity())
+                * $cart->currency->factor),
+            $cart->currency->decimal_places
+        );
+
+
         $cartLine->subTotal = new Price($unitPrice * $cartLine->quantity, $cart->currency, $unitQuantity);
         $cartLine->unitPrice = new Price($unitPrice, $cart->currency, $unitQuantity);
+        $cartLine->unitPriceInclTax = new Price($unitPriceInclTax, $cart->currency, $unitQuantity);
 
         $pipeline = app(Pipeline::class)
             ->through(

--- a/packages/core/src/Models/CartLine.php
+++ b/packages/core/src/Models/CartLine.php
@@ -54,6 +54,11 @@ class CartLine extends BaseModel implements Contracts\CartLine
     public ?Price $unitPrice = null;
 
     /**
+     * The cart line unit price.
+     */
+    public ?Price $unitPriceInclTax = null;
+
+    /**
      * The cart line sub total.
      */
     public ?Price $subTotal = null;

--- a/packages/core/src/Pipelines/CartLine/GetUnitPrice.php
+++ b/packages/core/src/Pipelines/CartLine/GetUnitPrice.php
@@ -43,6 +43,12 @@ class GetUnitPrice
             $purchasable->getUnitQuantity()
         );
 
+        $cartLine->unitPriceInclTax = new Price(
+            $priceResponse->matched->priceIncTax()->value,
+            $cart->currency,
+            $purchasable->getUnitQuantity()
+        );
+
         return $next($cartLine);
     }
 }

--- a/tests/core/Unit/Actions/Carts/CalculateLineTest.php
+++ b/tests/core/Unit/Actions/Carts/CalculateLineTest.php
@@ -128,6 +128,9 @@ test('can calculate multi unit quantity line', function () {
     expect($line->unitPrice)->toBeInstanceOf(DataTypesPrice::class);
     expect($line->unitPrice->value)->toEqual(50);
 
+    expect($line->unitPriceInclTax)->toBeInstanceOf(DataTypesPrice::class);
+    expect($line->unitPriceInclTax->value)->toEqual(60);
+
     expect($line->subTotal)->toBeInstanceOf(DataTypesPrice::class);
     expect($line->subTotal->value)->toEqual(50);
 
@@ -193,6 +196,9 @@ test('can calculate large unit quantity line', function () {
     expect($line->unitPrice)->toBeInstanceOf(DataTypesPrice::class);
     expect($line->unitPrice->value)->toEqual(10);
 
+    expect($line->unitPriceInclTax)->toBeInstanceOf(DataTypesPrice::class);
+    expect($line->unitPriceInclTax->value)->toEqual(12);
+
     expect($line->subTotal)->toBeInstanceOf(DataTypesPrice::class);
     expect($line->subTotal->value)->toEqual(10);
 
@@ -257,6 +263,9 @@ test('can calculate multiple quantities', function () {
 
     expect($line->unitPrice)->toBeInstanceOf(DataTypesPrice::class);
     expect($line->unitPrice->value)->toEqual(100);
+
+    expect($line->unitPriceInclTax)->toBeInstanceOf(DataTypesPrice::class);
+    expect($line->unitPriceInclTax->value)->toEqual(120);
 
     expect($line->subTotal)->toBeInstanceOf(DataTypesPrice::class);
     expect($line->subTotal->value)->toEqual(1000);

--- a/tests/core/Unit/Models/CartTest.php
+++ b/tests/core/Unit/Models/CartTest.php
@@ -454,6 +454,7 @@ test('can calculate the cart', function () {
     expect($cart->lines[0]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6, false))->toEqual('$1.000000');
     expect($cart->lines[1]->unitPrice->value)->toEqual(158);
     expect($cart->lines[1]->unitPrice->unitDecimal(false))->toEqual(0.0158);
+    expect($cart->lines[1]->unitPriceInclTax->value)->toEqual(190);
     expect($cart->lines[1]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6))->toEqual('$0.0158');
     expect($cart->lines[1]->unitPrice->unitFormatted(null, NumberFormatter::CURRENCY, 6, false))->toEqual('$0.015800');
     expect($cart->subTotal->value)->toEqual(103);


### PR DESCRIPTION
This PR looks to add the unit price including tax amount to the CartLine

```php
public ?Price $unitPriceInclTax = null;
```