### PR TITLE
Update Taxes.php

### DIFF
--- a/packages/admin/src/Filament/Clusters/Taxes.php
+++ b/packages/admin/src/Filament/Clusters/Taxes.php
@@ -9,6 +9,15 @@ class Taxes extends Cluster
 {
     protected static ?int $navigationSort = 5;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('lunarpanel::taxclass.label') ?? static::$navigationLabel ?? static::$title ?? str(class_basename(static::class))
+            ->beforeLast('Cluster')
+            ->kebab()
+            ->replace('-', ' ')
+            ->title();
+    }
+
     public static function getNavigationGroup(): ?string
     {
         return __('lunarpanel::global.sections.settings');


### PR DESCRIPTION
Made `getNavigationLabel` translatable and fallback to dynamic title generation

- Updated `getNavigationLabel` method to support translation via `__()` helper.
- Added fallback mechanism to dynamically generate the navigation label if no translation is available, using class name and formatting it to a readable title.
