### PR TITLE
Add reorder to product collections

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
@@ -37,6 +37,7 @@ class ManageProductCollections extends BaseManageRelatedRecords
     {
         return $table
             ->recordTitleAttribute('name')
+            ->reorderable('position')
             ->columns([
                 TranslatedTextColumn::make('attribute_data.name')
                     ->attributeData()

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -117,7 +117,7 @@ class Product extends BaseModel implements Contracts\Product, SpatieHasMedia
         return $this->belongsToMany(
             \Lunar\Models\Collection::modelClass(),
             config('lunar.database.table_prefix').'collection_product'
-        )->withPivot(['position'])->withTimestamps();
+        )->withPivot(['position'])->orderByPivot('position')->withTimestamps();
     }
 
     public function associations(): HasMany


### PR DESCRIPTION
This PR allows collections associated to a product to be reordered and also updates the relationship to set this order by default.