### PR TITLE
Fix notification failures

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -4,6 +4,7 @@ namespace Lunar\Admin\Filament\Resources\OrderResource\Pages\Components;
 
 use Closure;
 use Filament\Forms;
+use Filament\Notifications\Notification;
 use Filament\Support\Colors\Color;
 use Filament\Support\Enums\FontWeight;
 use Filament\Tables;

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -170,7 +170,9 @@ class OrderItemsTable extends TableComponent
                 $response = $transaction->refund(bcmul($data['amount'], $this->record->currency->factor), $data['notes']);
 
                 if (! $response->success) {
-                    $action->failureNotification(fn () => $response->message);
+                    $action->failureNotification(
+                        fn () => Notification::make('refund_failure')->color('danger')->title($response->message)
+                    );
 
                     $action->failure();
 

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -508,7 +508,9 @@ class ManageOrder extends BaseViewRecord
                 $response = $transaction->capture(bcmul($data['amount'], $record->currency->factor));
 
                 if (! $response->success) {
-                    $action->failureNotification(fn () => $response->message);
+                    $action->failureNotification(
+                        fn () => Notification::make('capture_failure')->color('danger')->title($response->message)
+                    );
 
                     $action->failure();
 


### PR DESCRIPTION
In some places we are returning a `string` when an action fails, however we should be returning an instance of `Notification` this PR looks to fix that.