### PR TITLE
Add ability to filter Customers by Customer Group

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource.php
@@ -190,6 +190,9 @@ class CustomerResource extends BaseResource
                 Tables\Columns\TextColumn::make('account_ref')
                     ->label(__('lunarpanel::customer.table.account_reference.label'))
                     ->sortable(),
+                Tables\Columns\TextColumn::make('customerGroups.name')
+                    ->label(__('lunarpanel::customergroup.label'))
+                    ->badge(),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('customer_group')

--- a/packages/admin/src/Filament/Resources/CustomerResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource.php
@@ -192,7 +192,11 @@ class CustomerResource extends BaseResource
                     ->sortable(),
             ])
             ->filters([
-                //
+                Tables\Filters\SelectFilter::make('customer_group')
+                    ->label(__('lunarpanel::customergroup.label'))
+                    ->relationship('customerGroups', 'name')
+                    ->searchable()
+                    ->preload(),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),

--- a/packages/admin/src/Filament/Resources/CustomerResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource.php
@@ -192,7 +192,17 @@ class CustomerResource extends BaseResource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('customerGroups.name')
                     ->label(__('lunarpanel::customergroup.label'))
-                    ->badge(),
+                    ->badge()
+                    ->limitList(1)
+                    ->tooltip(function (Tables\Columns\TextColumn $column, Model $record): ?string {
+                        if ($record->customerGroups->count() <= $column->getListLimit()) {
+                            return null;
+                        }
+
+                        return $record->customerGroups
+                            ->map(fn ($customerGroup) => $customerGroup->name)
+                            ->implode(', ');
+                    }),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('customer_group')

--- a/packages/admin/src/Filament/Resources/CustomerResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource.php
@@ -195,6 +195,7 @@ class CustomerResource extends BaseResource
                 Tables\Filters\SelectFilter::make('customer_group')
                     ->label(__('lunarpanel::customergroup.label'))
                     ->relationship('customerGroups', 'name')
+                    ->multiple()
                     ->searchable()
                     ->preload(),
             ])


### PR DESCRIPTION
Previously there was no way to view the customers associated to a specific customer group. This update introduces a filter to the customers listing screen so that you can filter by customer group.