### PR TITLE
Deleting customers should detach groups, discounts and users

### DIFF
--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -64,6 +64,7 @@ use Lunar\Models\CartLine;
 use Lunar\Models\Channel;
 use Lunar\Models\Collection;
 use Lunar\Models\Currency;
+use Lunar\Models\Customer;
 use Lunar\Models\CustomerGroup;
 use Lunar\Models\Discount;
 use Lunar\Models\Language;
@@ -81,6 +82,7 @@ use Lunar\Observers\ChannelObserver;
 use Lunar\Observers\CollectionObserver;
 use Lunar\Observers\CurrencyObserver;
 use Lunar\Observers\CustomerGroupObserver;
+use Lunar\Observers\CustomerObserver;
 use Lunar\Observers\DiscountObserver;
 use Lunar\Observers\LanguageObserver;
 use Lunar\Observers\MediaObserver;
@@ -304,6 +306,7 @@ class LunarServiceProvider extends ServiceProvider
 
         Channel::observe(ChannelObserver::class);
         CustomerGroup::observe(CustomerGroupObserver::class);
+        Customer::observe(CustomerObserver::class);
         Discount::observe(DiscountObserver::class);
         Language::observe(LanguageObserver::class);
         Currency::observe(CurrencyObserver::class);

--- a/packages/core/src/Observers/CustomerObserver.php
+++ b/packages/core/src/Observers/CustomerObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lunar\Observers;
+
+use Lunar\Models\Customer;
+
+class CustomerObserver
+{
+    /**
+     * Handle the Discount "deleting" event.
+     *
+     * @return void
+     */
+    public function deleting(Customer $customer)
+    {
+        $customer->customerGroups()->detach();
+        $customer->discounts()->detach();
+        $customer->users()->detach();
+    }
+}


### PR DESCRIPTION
When deleting customers attached to customer groups an error is thrown due to the foreign key constraint.

We should ensure any relations are cleared when deleting them.