### PR TITLE
ShippingRateResolver - cast strings to int for Carbon 3

### DIFF
--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -167,9 +167,9 @@ class ShippingRateResolver
 
                     [$h, $m, $s] = explode(':', $method->cutoff);
 
-                    return now()->set('hour', $h)
-                        ->set('minute', $m)
-                        ->set('second', $s)
+                    return now()->set('hour', (int) $h)
+                        ->set('minute', (int) $m)
+                        ->set('second', (int) $s)
                         ->isPast();
                 })
                 ->reject(function ($rate) {


### PR DESCRIPTION
Carbon 3 requires ints not strings on some methods - we stumbled onto an issue on a live site where the ShippingRateResolver was passing strings not ints.

This PR resolves that.