### PR TITLE
Handle non active payment intents

### DIFF
--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -32,7 +32,7 @@ class StripeManager
 
     public function getCartIntentId(Cart $cart): ?string
     {
-        return $cartModel->meta['payment_intent'] ?? $cart->paymentIntents->first()?->intent_id;
+        return $cartModel->meta['payment_intent'] ?? $cart->paymentIntents()->active()->first()?->intent_id;
     }
 
     public function fetchOrCreateIntent(Cart $cart, array $createOptions = []): PaymentIntent
@@ -165,6 +165,11 @@ class StripeManager
                 $intentId,
                 ['cancellation_reason' => $reason->value]
             );
+            $cart->paymentIntents()->where('intent_id', $intentId)->update([
+                'status' => PaymentIntent::STATUS_CANCELED,
+                'processing_at' => now(),
+                'processed_at' => now(),
+            ]);
         } catch (\Exception $e) {
 
         }

--- a/packages/stripe/src/Models/StripePaymentIntent.php
+++ b/packages/stripe/src/Models/StripePaymentIntent.php
@@ -2,9 +2,11 @@
 
 namespace Lunar\Stripe\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Models\Cart;
+use Stripe\PaymentIntent;
 
 class StripePaymentIntent extends BaseModel
 {
@@ -16,5 +18,10 @@ class StripePaymentIntent extends BaseModel
     public function cart(): BelongsTo
     {
         return $this->belongsTo(Cart::class, 'cart_id');
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNotIn('status', [PaymentIntent::STATUS_CANCELED, PaymentIntent::STATUS_SUCCEEDED]);
     }
 }


### PR DESCRIPTION
Currently when retrieving payment intents to use in Stripe, we aren't considering whether they have been canceled or are already succeeded. This PR looks to add an `active` scope to the cart payment intents relationship and also, when an intent is canceled, we now set the status on the relevant model. 