### PR TITLE
Adds the collection breadcrumb to the Product edit screen

### DIFF
--- a/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandCollections.php
+++ b/packages/admin/src/Filament/Resources/BrandResource/Pages/ManageBrandCollections.php
@@ -38,6 +38,7 @@ class ManageBrandCollections extends BaseManageRelatedRecords
     {
         return $table->columns([
             TranslatedTextColumn::make('attribute_data.name')
+                ->description(fn (Collection $record): string => $record->breadcrumb->implode(' > '))
                 ->attributeData()
                 ->limitedTooltip()
                 ->limit(50)

--- a/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/CollectionLimitationRelationManager.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/CollectionLimitationRelationManager.php
@@ -7,6 +7,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
+use Lunar\Models\Collection;
 
 class CollectionLimitationRelationManager extends BaseRelationManager
 {
@@ -48,6 +49,7 @@ class CollectionLimitationRelationManager extends BaseRelationManager
                     ->label(
                         __('lunarpanel::discount.relationmanagers.collections.table.name.label')
                     )
+                    ->description(fn (Collection $record): string => $record->breadcrumb->implode(' > '))
                     ->formatStateUsing(
                         fn (Model $record) => $record->attr('name')
                     ),

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductCollections.php
@@ -40,6 +40,7 @@ class ManageProductCollections extends BaseManageRelatedRecords
             ->reorderable('position')
             ->columns([
                 TranslatedTextColumn::make('attribute_data.name')
+                    ->description(fn (Collection $record): string => $record->breadcrumb->implode(' > '))
                     ->attributeData()
                     ->limitedTooltip()
                     ->limit(50)


### PR DESCRIPTION
<img width="943" alt="image" src="https://github.com/user-attachments/assets/08d53035-1916-425c-8819-66d31a7e9f54" />

Adds a breadcrumb underneath the collection name, if applicable.