### PR TITLE
Fix updating single variant attributes from the product form

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource.php
+++ b/packages/admin/src/Filament/Resources/ProductResource.php
@@ -32,8 +32,8 @@ use Lunar\Admin\Support\Tables\Columns\TranslatedTextColumn;
 use Lunar\FieldTypes\Text;
 use Lunar\FieldTypes\TranslatedText;
 use Lunar\Models\Attribute;
-use Lunar\Models\Contracts\Product;
 use Lunar\Models\Currency;
+use Lunar\Models\ProductFilamentProxy;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\Tag;
 
@@ -41,7 +41,7 @@ class ProductResource extends BaseResource
 {
     protected static ?string $permission = 'catalog:manage-products';
 
-    protected static ?string $model = Product::class;
+    protected static ?string $model = ProductFilamentProxy::class;
 
     protected static ?string $recordTitleAttribute = 'recordTitle';
 
@@ -125,14 +125,10 @@ class ProductResource extends BaseResource
                 static::getAttributeDataFormComponent(),
                 Attributes::make()->using(
                     ProductVariant::class
-                )->afterStateHydrated(function ($state, ?Model $record, $component) {
-                    $variant = $record->variants->first();
-                    if ($variant) {
-                        $component->state($variant->attribute_data);
-                    }
-                })->visible(
+                )->visible(
                     fn (?Model $record) => $record && $record->variants()->count() == 1
-                )->statePath('variant_attributes'),
+                )
+                ->statePath('variant_attributes'),
             ])
             ->columns(1);
     }

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/EditProduct.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/EditProduct.php
@@ -2,13 +2,14 @@
 
 namespace Lunar\Admin\Filament\Resources\ProductResource\Pages;
 
-use Filament\Actions;
 use Filament\Forms;
-use Filament\Support\Facades\FilamentIcon;
+use Filament\Actions;
+use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Support\Facades\FilamentIcon;
+use Lunar\Admin\Support\Pages\BaseEditRecord;
 use Lunar\Admin\Filament\Resources\ProductResource;
 use Lunar\Admin\Support\Actions\Products\ForceDeleteProductAction;
-use Lunar\Admin\Support\Pages\BaseEditRecord;
 
 class EditProduct extends BaseEditRecord
 {
@@ -68,7 +69,7 @@ class EditProduct extends BaseEditRecord
     {
         $data = $this->callLunarHook('beforeUpdate', $data, $record);
 
-        $variantData = $data['variant_attributes'] ?? null;
+        $variantData = Arr::pull($data, 'variant_attributes', null);
 
         if ($variantData) {
             $variant = $record->variants()->first();

--- a/packages/core/src/Models/ProductFilamentProxy.php
+++ b/packages/core/src/Models/ProductFilamentProxy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Lunar\Models;
+
+use Illuminate\Support\Collection;
+
+class ProductFilamentProxy extends Product
+{
+    protected $appends = [
+        'variant_attributes',
+    ];
+
+    public function getVariantAttributesAttribute(): Collection
+    {
+        return $this->variants->first()->attribute_data;
+    }
+}


### PR DESCRIPTION
Fixes #1996

This is based on https://github.com/lunarphp/lunar/pull/2054

In the current implementation, the variant attributes are not properly hydrated in the ProductResource. 
This change creates a ProductFilamentProxy that extends the Product model and adds the variant attributes to the product using an accessor and the `$appends` property.

I created a new ProductFilamentProxy class to make this change as non-breaking as possible. It is probably not the best solution but it works and can then be refactored.