### PR TITLE
Allow multiple extension to be registered for the same page/resource

### DIFF
--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -258,10 +258,28 @@ class LunarPanelManager
     public function extensions(array $extensions): self
     {
         foreach ($extensions as $class => $extension) {
-            $this->extensions[$class][] = new $extension;
+            if (! is_array($extension)) {
+                $extension = [$extension];
+            }
+
+            $extensions = collect($extension)->reject(
+                fn ($extension) => ! class_exists($extension)
+            )->map(
+                fn ($extension) => app($extension)
+            );
+
+            $this->extensions[$class] = [
+                ...$this->extensions[$class] ?? [],
+                ...$extensions->values()->toArray(),
+            ];
         }
 
         return $this;
+    }
+
+    public function getExtensions(): array
+    {
+        return $this->extensions;
     }
 
     /**

--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -262,15 +262,13 @@ class LunarPanelManager
                 $extension = [$extension];
             }
 
-            $extensions = collect($extension)->reject(
-                fn ($extension) => ! class_exists($extension)
-            )->map(
-                fn ($extension) => app($extension)
-            );
-
             $this->extensions[$class] = [
                 ...$this->extensions[$class] ?? [],
-                ...$extensions->values()->toArray(),
+                ...collect($extension)->reject(
+                    fn ($extension) => ! class_exists($extension)
+                )->map(
+                    fn ($extension) => app($extension)
+                )->values()->toArray(),
             ];
         }
 

--- a/tests/admin/Stubs/Filament/Extensions/ExtensionA.php
+++ b/tests/admin/Stubs/Filament/Extensions/ExtensionA.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lunar\Tests\Admin\Stubs\Filament\Extensions;
+
+use Lunar\Admin\Support\Extending\ViewPageExtension;
+
+class ExtensionA extends ViewPageExtension
+{
+    public function headerActions(array $actions): array
+    {
+        return [
+            ...$actions,
+        ];
+    }
+}

--- a/tests/admin/Stubs/Filament/Extensions/ExtensionB.php
+++ b/tests/admin/Stubs/Filament/Extensions/ExtensionB.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lunar\Tests\Admin\Stubs\Filament\Extensions;
+
+use Lunar\Admin\Support\Extending\ViewPageExtension;
+
+class ExtensionB extends ViewPageExtension
+{
+    public function headerActions(array $actions): array
+    {
+        return [
+            ...$actions,
+        ];
+    }
+}

--- a/tests/admin/Unit/LunarPanelManagerTest.php
+++ b/tests/admin/Unit/LunarPanelManagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Lunar\Admin\Filament\Resources\CustomerResource\Pages\ViewCustomer;
+use Lunar\Admin\Filament\Resources\ProductResource\Pages\EditProduct;
+use Lunar\Admin\Filament\Resources\ProductResource\Pages\ListProducts;
+use Lunar\Admin\Support\Facades\LunarPanel;
+use Lunar\Tests\Admin\Stubs\Filament\Extensions\ExtensionA;
+use Lunar\Tests\Admin\Stubs\Filament\Extensions\ExtensionB;
+
+uses(\Lunar\Tests\Admin\Unit\Filament\TestCase::class)
+    ->group('lunar.panel');
+
+it('can register multiple extensions at once', function () {
+
+    $panel = LunarPanel::extensions([
+        ViewCustomer::class => [ExtensionA::class, ExtensionB::class],
+        EditProduct::class => ExtensionA::class,
+        ListProducts::class => 'SomeClassThatDoesntExist',
+    ]);
+
+    expect($panel->getExtensions())->toHaveCount(3)
+        ->and($panel->getExtensions())->toHaveKey(ViewCustomer::class)
+        ->and($panel->getExtensions()[ViewCustomer::class])->toHaveCount(2)
+        ->and($panel->getExtensions()[ViewCustomer::class][0])->toBeInstanceOf(ExtensionA::class)
+        ->and($panel->getExtensions()[ViewCustomer::class][1])->toBeInstanceOf(ExtensionB::class)
+        ->and($panel->getExtensions()[EditProduct::class][0])->toBeInstanceOf(ExtensionA::class)
+        ->and($panel->getExtensions()[ListProducts::class])->toHaveCount(0);
+});


### PR DESCRIPTION
Currently when registering extensions in the panel, they are identified by the class to be extended as the array key, for example:

```php
LunarPanel::extensions([
  CustomerResource::class => ExtensionA::class,
]);
```

This means you cannot register muliple extensions at once and would need to call `extensions` multiple times:

```php
LunarPanel::extensions([
  CustomerResource::class => ExtensionA::class,
]);

LunarPanel::extensions([
  CustomerResource::class => ExtensionB::class,
]);
```

This PR looks to introduce changes so you can pass an array of extensions instead, meaning it can all be done in one call:

```php
LunarPanel::extensions([
  CustomerResource::class => [ExtensionA:class, ExtensionB::class],
]);
```

Other notable tweaks

- Added a check that the extension class exists before registering to minimise exceptions
- Use `app($extension)` instead of `new $extension` to initialise the extension class. 