### PR TITLE
All cart items stock check should consider shippability

### DIFF
--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -60,7 +60,7 @@ class ShippingRateResolver
         $shippingMeta = $cart->shippingEstimateMeta;
 
         $this->allCartItemsAreInStock = ! $this->cart->lines->first(function ($line) {
-            return $line->purchasable->stock < $line->quantity;
+            return $line->purchasable->shippable && ($line->purchasable->stock < $line->quantity);
         });
 
         $this->customerGroups = collect([CustomerGroup::getDefault()]);


### PR DESCRIPTION
The `allCartItemsAreInStock` check in ShippingRateResolver needs to consider whether the items are shippable or not as well as the stock level.

This PR updates the logic to that.