### PR TITLE
fix: attribute_data property type in Product and ProductVariant models to use Illuminate\Support\Collection

### DIFF
--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -34,7 +34,7 @@ use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
  * @property ?int $brand_id
  * @property int $product_type_id
  * @property string $status
- * @property array $attribute_data
+ * @property ?\Illuminate\Support\Collection $attribute_data
  * @property ?\Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
  * @property ?\Illuminate\Support\Carbon $deleted_at

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -24,7 +24,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
  * @property int $id
  * @property int $product_id
  * @property int $tax_class_id
- * @property array $attribute_data
+ * @property ?\Illuminate\Support\Collection $attribute_data
  * @property ?string $tax_ref
  * @property int $unit_quantity
  * @property int $min_quantity


### PR DESCRIPTION
This PR fixes type hinting issues with the `attribute_data` property on the `Product` and `ProductVariant` models.