### PR TITLE
Dont split name when storing Stripe address from Webhook

### DIFF
--- a/packages/stripe/src/Actions/StoreAddressInformation.php
+++ b/packages/stripe/src/Actions/StoreAddressInformation.php
@@ -26,8 +26,8 @@ class StoreAddressInformation
 
         if ($paymentIntent->shipping && $stripeShipping = $paymentIntent->shipping->address) {
             $country = Country::where('iso2', $stripeShipping->country)->first();
-            $shippingAddress->first_name = explode(' ', $paymentIntent->shipping->name)[0];
-            $shippingAddress->last_name = explode(' ', $paymentIntent->shipping->name)[1] ?? '';
+            $shippingAddress->first_name = $paymentIntent->shipping->name;
+            $shippingAddress->last_name = null;
             $shippingAddress->line_one = $stripeShipping->line1;
             $shippingAddress->line_two = $stripeShipping->line2;
             $shippingAddress->city = $stripeShipping->city;
@@ -40,8 +40,8 @@ class StoreAddressInformation
 
         if ($paymentMethod && $stripeBilling = $paymentMethod->billing_details?->address) {
             $country = Country::where('iso2', $stripeBilling->country)->first();
-            $billingAddress->first_name = explode(' ', $paymentMethod->billing_details->name)[0];
-            $billingAddress->last_name = explode(' ', $paymentMethod->billing_details->name)[1] ?? '';
+            $billingAddress->first_name = $paymentMethod->billing_details->name;
+            $billingAddress->last_name = null;
             $billingAddress->line_one = $stripeBilling->line1;
             $billingAddress->line_two = $stripeBilling->line2;
             $billingAddress->city = $stripeBilling->city;

--- a/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
+++ b/tests/stripe/Unit/Actions/StoreAddressInformationTest.php
@@ -20,8 +20,8 @@ it('can store payment intent address information', function () {
     app(\Lunar\Stripe\Actions\StoreAddressInformation::class)->store($order, $paymentIntent);
 
     assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
-        'first_name' => 'Buggs',
-        'last_name' => 'Bunny',
+        'first_name' => 'Buggs Bunny',
+        'last_name' => null,
         'city' => 'ACME Shipping Land',
         'type' => 'shipping',
         'country_id' => $country->id,
@@ -32,8 +32,8 @@ it('can store payment intent address information', function () {
     ]);
 
     assertDatabaseHas(\Lunar\Models\OrderAddress::class, [
-        'first_name' => 'Elma',
-        'last_name' => 'Thudd',
+        'first_name' => 'Elma Thudd',
+        'last_name' => null,
         'city' => 'ACME Land',
         'type' => 'billing',
         'country_id' => $country->id,


### PR DESCRIPTION
Currently when storing the address that comes back from Stripe, we are trying to split the name and populating the result in the first/last name columns. This creates issues when the name Stripe returns contains more than just the first and last name.

Therefore it would be more benefical to just simple store the name in the `first_name` column to prevent any loss of data since there shouldn't be any side effects of doing this.