### PR TITLE
Fix attribute data saving on resources

### DIFF
--- a/packages/admin/src/Filament/Resources/BrandResource.php
+++ b/packages/admin/src/Filament/Resources/BrandResource.php
@@ -91,7 +91,7 @@ class BrandResource extends BaseResource
 
     protected static function getAttributeDataFormComponent(): Component
     {
-        return Attributes::make()->statePath('attribute_data');
+        return Attributes::make();
     }
 
     public static function getDefaultTable(Table $table): Table

--- a/packages/admin/src/Filament/Resources/CollectionResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource.php
@@ -76,6 +76,7 @@ class CollectionResource extends BaseResource
     {
         return Attributes::make();
     }
+
     protected static function getMainFormComponents(): array
     {
         return [

--- a/packages/admin/src/Filament/Resources/CollectionResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource.php
@@ -74,9 +74,8 @@ class CollectionResource extends BaseResource
 
     protected static function getAttributeDataFormComponent(): Component
     {
-        return Attributes::make()->statePath('attribute_data');
+        return Attributes::make();
     }
-
     protected static function getMainFormComponents(): array
     {
         return [

--- a/packages/admin/src/Filament/Resources/CustomerGroupResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerGroupResource.php
@@ -80,7 +80,7 @@ class CustomerGroupResource extends BaseResource
 
     protected static function getAttributeDataFormComponent(): Component
     {
-        return Attributes::make()->statePath('attribute_data');
+        return Attributes::make();
     }
 
     public static function getDefaultTable(Table $table): Table

--- a/packages/admin/src/Filament/Resources/CustomerResource.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource.php
@@ -109,7 +109,7 @@ class CustomerResource extends BaseResource
 
     protected static function getAttributeDataFormComponent(): Component
     {
-        return \Lunar\Admin\Support\Forms\Components\Attributes::make()->statePath('attribute_data');
+        return \Lunar\Admin\Support\Forms\Components\Attributes::make();
     }
 
     protected static function getFirstNameFormComponent(): Component

--- a/tests/admin/Feature/Filament/Resources/BrandResource/Pages/EditBrandTest.php
+++ b/tests/admin/Feature/Filament/Resources/BrandResource/Pages/EditBrandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.brand');
+
+it('can save attributes', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Brand::factory()->create();
+
+    $group = \Lunar\Models\AttributeGroup::factory()->create([
+        'attributable_type' => 'brand',
+        'name' => [
+            'en' => 'Details',
+        ],
+        'handle' => 'details',
+        'position' => 1,
+    ]);
+
+    $attribute = \Lunar\Models\Attribute::factory()->create([
+        'attribute_type' => 'brand',
+        'attribute_group_id' => $group->id,
+        'position' => 1,
+        'name' => [
+            'en' => 'Name',
+        ],
+        'handle' => 'name',
+        'section' => 'main',
+        'required' => false,
+        'system' => false,
+        'searchable' => false,
+    ]);
+
+    \Illuminate\Support\Facades\DB::table('lunar_attributables')->insert([
+        'attribute_id' => $attribute->id,
+        'attributable_type' => 'brand',
+        'attributable_id' => $record->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\BrandResource\Pages\EditBrand::class, [
+        'record' => $record->getRouteKey(),
+        'pageClass' => 'brandEdit',
+    ])->fillForm([
+        'attribute_data' => [
+            'name' => new \Lunar\FieldTypes\Text('New Brand Name'),
+        ],
+    ])->call('save');
+
+    expect($record->refresh()->attr('name'))->toBe('New Brand Name');
+});

--- a/tests/admin/Feature/Filament/Resources/CollectionResources/Pages/EditCollectionTest.php
+++ b/tests/admin/Feature/Filament/Resources/CollectionResources/Pages/EditCollectionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.collection');
+
+it('can save attributes', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Collection::factory()->create();
+
+    $group = \Lunar\Models\AttributeGroup::factory()->create([
+        'attributable_type' => 'collection',
+        'name' => [
+            'en' => 'Collection Details',
+        ],
+        'handle' => 'collection_details',
+        'position' => 1,
+    ]);
+
+    $attribute = \Lunar\Models\Attribute::factory()->create([
+        'attribute_type' => 'collection',
+        'attribute_group_id' => $group->id,
+        'position' => 1,
+        'name' => [
+            'en' => 'Name',
+        ],
+        'handle' => 'name',
+        'section' => 'main',
+        'required' => false,
+        'system' => false,
+        'searchable' => false,
+    ]);
+
+    \Illuminate\Support\Facades\DB::table('lunar_attributables')->insert([
+        'attribute_id' => $attribute->id,
+        'attributable_type' => 'product_type',
+        'attributable_id' => $record->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\CollectionResource\Pages\EditCollection::class, [
+        'record' => $record->getRouteKey(),
+        'pageClass' => 'collectionEdit',
+    ])->fillForm([
+        'attribute_data' => [
+            'name' => new \Lunar\FieldTypes\Text('New Collection Name'),
+        ],
+    ])->call('save');
+
+    expect($record->refresh()->attr('name'))->toBe('New Collection Name');
+});

--- a/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/EditCustomerTest.php
+++ b/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/EditCustomerTest.php
@@ -47,3 +47,53 @@ it('can save customer data', function () {
         ->first_name->toBe($newData->first_name)
         ->last_name->toBe($newData->last_name);
 });
+
+it('can save attributes', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Customer::factory()->create();
+
+    $group = \Lunar\Models\AttributeGroup::factory()->create([
+        'attributable_type' => 'customer',
+        'name' => [
+            'en' => 'Details',
+        ],
+        'handle' => 'details',
+        'position' => 1,
+    ]);
+
+    $attribute = \Lunar\Models\Attribute::factory()->create([
+        'attribute_type' => 'customer',
+        'attribute_group_id' => $group->id,
+        'position' => 1,
+        'name' => [
+            'en' => 'Name',
+        ],
+        'handle' => 'name',
+        'section' => 'main',
+        'required' => false,
+        'system' => false,
+        'searchable' => false,
+    ]);
+
+    \Illuminate\Support\Facades\DB::table('lunar_attributables')->insert([
+        'attribute_id' => $attribute->id,
+        'attributable_type' => 'customer',
+        'attributable_id' => $record->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    \Livewire\Livewire::test(EditCustomer::class, [
+        'record' => $record->getRouteKey(),
+        'pageClass' => 'customerEdit',
+    ])->fillForm([
+        'attribute_data' => [
+            'name' => new \Lunar\FieldTypes\Text('New Customer Name'),
+        ],
+    ])->call('save');
+
+    expect($record->refresh()->attr('name'))->toBe('New Customer Name');
+});

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
@@ -62,3 +62,53 @@ it('can edit variant attributes', function () {
 
     expect($variant->refresh()->attr($attribute->handle))->toBe('Hello');
 });
+
+it('can save attributes', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Product::factory()->create();
+
+    $group = \Lunar\Models\AttributeGroup::factory()->create([
+        'attributable_type' => 'product',
+        'name' => [
+            'en' => 'Details',
+        ],
+        'handle' => 'details',
+        'position' => 1,
+    ]);
+
+    $attribute = \Lunar\Models\Attribute::factory()->create([
+        'attribute_type' => 'product',
+        'attribute_group_id' => $group->id,
+        'position' => 1,
+        'name' => [
+            'en' => 'Name',
+        ],
+        'handle' => 'name',
+        'section' => 'main',
+        'required' => false,
+        'system' => false,
+        'searchable' => false,
+    ]);
+
+    \Illuminate\Support\Facades\DB::table('lunar_attributables')->insert([
+        'attribute_id' => $attribute->id,
+        'attributable_type' => 'brand',
+        'attributable_id' => $record->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\ProductResource\Pages\EditProduct::class, [
+        'record' => $record->getRouteKey(),
+        'pageClass' => 'productEdit',
+    ])->fillForm([
+        'attribute_data' => [
+            'name' => new \Lunar\FieldTypes\Text('New Product Name'),
+        ],
+    ])->call('save');
+
+    expect($record->refresh()->attr('name'))->toBe('New Product Name');
+});

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
@@ -68,7 +68,14 @@ it('can save attributes', function () {
         'default' => true,
     ]);
 
+    \Lunar\Models\TaxClass::factory()->create([
+        'default' => true,
+    ]);
+
     $record = \Lunar\Models\Product::factory()->create();
+    \Lunar\Models\ProductVariant::factory()->create([
+        'product_id' => $record->id,
+    ]);
 
     $group = \Lunar\Models\AttributeGroup::factory()->create([
         'attributable_type' => 'product',
@@ -95,8 +102,8 @@ it('can save attributes', function () {
 
     \Illuminate\Support\Facades\DB::table('lunar_attributables')->insert([
         'attribute_id' => $attribute->id,
-        'attributable_type' => 'brand',
-        'attributable_id' => $record->id,
+        'attributable_type' => 'product_type',
+        'attributable_id' => $record->productType->id,
     ]);
 
     $this->asStaff(admin: true);
@@ -108,7 +115,7 @@ it('can save attributes', function () {
         'attribute_data' => [
             'name' => new \Lunar\FieldTypes\Text('New Product Name'),
         ],
-    ])->call('save');
+    ])->call('save')->assertHasNoFormErrors();
 
     expect($record->refresh()->attr('name'))->toBe('New Product Name');
 });


### PR DESCRIPTION
PR #2054 which only updated the `ProductResource`. This PR adds the fix for other resources and introduces tests to ensure data is being saved as it should.