### PR TITLE
Bump stripe-php to v16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "spatie/laravel-medialibrary": "^11.12.7",
         "spatie/laravel-permission": "^6.12",
         "spatie/php-structure-discoverer": "^2.3.1",
-        "stripe/stripe-php": "^14.4",
+        "stripe/stripe-php": "^16.0",
         "technikermathe/blade-lucide-icons": "^v3.0",
         "typesense/typesense-php": "^4.9"
     },

--- a/packages/stripe/composer.json
+++ b/packages/stripe/composer.json
@@ -13,7 +13,7 @@
   "require": {
       "php": "^8.2",
       "lunarphp/core": "self.version",
-      "stripe/stripe-php": "^14.4"
+      "stripe/stripe-php": "^16.0"
   },
   "autoload": {
       "psr-4": {

--- a/packages/stripe/src/MockClient.php
+++ b/packages/stripe/src/MockClient.php
@@ -22,7 +22,7 @@ class MockClient implements ClientInterface
         $this->url = 'https://checkout.stripe.com/pay/cs_test_'.Str::random(32);
     }
 
-    public function request($method, $absUrl, $headers, $params, $hasFile)
+    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1')
     {
         $id = array_slice(explode('/', $absUrl), -1)[0];
 

--- a/tests/stripe/Stripe/MockClient.php
+++ b/tests/stripe/Stripe/MockClient.php
@@ -22,7 +22,7 @@ class MockClient implements ClientInterface
         $this->url = 'https://checkout.stripe.com/pay/cs_test_'.Str::random(32);
     }
 
-    public function request($method, $absUrl, $headers, $params, $hasFile)
+    public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1')
     {
         $id = array_slice(explode('/', $absUrl), -1)[0];
 


### PR DESCRIPTION
Bumps the stripe-php version to `16` to be in line with Laravel Cashier as discussed in [#2154](https://github.com/lunarphp/lunar/discussions/2152)