### PR TITLE
Ensure products are reindexed after sort

### DIFF
--- a/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionProducts.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource/Pages/ManageCollectionProducts.php
@@ -55,6 +55,15 @@ class ManageCollectionProducts extends BaseManageRelatedRecords
         ]);
     }
 
+    public function reorderTable(array $order): void
+    {
+        parent::reorderTable($order);
+
+        foreach (Product::whereIn('id', $order)->get() as $product) {
+            $product->searchable();
+        }
+    }
+
     public function table(Table $table): Table
     {
         return $table->columns([


### PR DESCRIPTION
Currently when you reorder products within a collection, they are not being reindexed by Scout. This PR will tap into the reorder action to ensure they are sync'ed with the search provider.
