### PR TITLE
Fix rounding issue when casting to int

### DIFF
--- a/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
+++ b/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
@@ -51,11 +51,12 @@ trait ManagesProductPricing
         unset($data['basePrices']);
         $variant->update($data);
 
+
         $prices->filter(
             fn ($price) => ! $price['id']
         )->each(fn ($price) => $variant->prices()->create([
             'currency_id' => $price['currency_id'],
-            'price' => (int) ($price['value'] * $price['factor']),
+            'price' => (int) round((float) ($price['value'] * $price['factor'])),
             'compare_price' => (int) ($price['compare_price'] * $price['factor']),
             'min_quantity' => 1,
             'customer_group_id' => null,
@@ -65,7 +66,7 @@ trait ManagesProductPricing
         $prices->filter(
             fn ($price) => $price['id']
         )->each(fn ($price) => Price::find($price['id'])->update([
-            'price' => (int) ($price['value'] * $price['factor']),
+            'price' => (int) round((float) ($price['value'] * $price['factor'])),
             'compare_price' => (int) ($price['compare_price'] * $price['factor']),
         ])
         );

--- a/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
+++ b/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
@@ -51,7 +51,6 @@ trait ManagesProductPricing
         unset($data['basePrices']);
         $variant->update($data);
 
-
         $prices->filter(
             fn ($price) => ! $price['id']
         )->each(fn ($price) => $variant->prices()->create([

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/ManageProductPricingTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/ManageProductPricingTest.php
@@ -109,4 +109,4 @@ it('can set product base prices correctly', function () {
         'price' => '232',
     ]);
 
-})->group('ting');
+});

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/ManageProductPricingTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/ManageProductPricingTest.php
@@ -105,7 +105,7 @@ it('can set product base prices correctly', function () {
         ],
     ])->call('save')->assertHasNoErrors();
 
-    \Pest\Laravel\assertDatabaseHas((new \Lunar\Models\Price())->getTable(), [
+    \Pest\Laravel\assertDatabaseHas((new \Lunar\Models\Price)->getTable(), [
         'price' => '232',
     ]);
 

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/ManageProductPricingTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/ManageProductPricingTest.php
@@ -74,3 +74,39 @@ it('will not show in navigation when multiple variants exist', function () {
             __('lunarpanel::relationmanagers.pricing.title')
         );
 });
+
+it('can set product base prices correctly', function () {
+    \Lunar\Models\Language::factory()->create([
+        'default' => true,
+    ]);
+
+    \Lunar\Models\Currency::factory()->create([
+        'default' => true,
+    ]);
+
+    $record = \Lunar\Models\Product::factory()->create();
+
+    $variant = \Lunar\Models\ProductVariant::factory()->create([
+        'product_id' => $record->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    \Livewire\Livewire::test(\Lunar\Admin\Filament\Resources\ProductResource\Pages\ManageProductPricing::class, [
+        'record' => $record->id,
+        'pageClass' => 'productPriceRelationManager',
+    ])->set('basePrices', [
+        [
+            'id' => null,
+            'currency_id' => \Lunar\Models\Currency::getDefault()->id,
+            'label' => 'GBP',
+            'value' => '2.32',
+            'factor' => '100',
+        ],
+    ])->call('save')->assertHasNoErrors();
+
+    \Pest\Laravel\assertDatabaseHas((new \Lunar\Models\Price())->getTable(), [
+        'price' => '232',
+    ]);
+
+})->group('ting');


### PR DESCRIPTION
There is a strange issue where somethings the rounding will be off with base prices. This was noticed when setting the price to `2.32` it would actually store as `231` in the database and come back as `2.31` when hydrated.

This PR rounds the decimal by the currency factor and casts to a float again before casting to an int to ensure prices are saved correctly.
