### PR TITLE
fix: show correct product thumbnail in product resource table

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource.php
+++ b/packages/admin/src/Filament/Resources/ProductResource.php
@@ -276,6 +276,7 @@ class ProductResource extends BaseResource
             SpatieMediaLibraryImageColumn::make('thumbnail')
                 ->collection(config('lunar.media.collection'))
                 ->conversion('small')
+                ->filterMediaUsing(fn ($media) => $media->where('custom_properties.primary', true)->count() ? $media->where('custom_properties.primary', true) : $media)
                 ->limit(1)
                 ->square()
                 ->label(''),


### PR DESCRIPTION
when using SpatieMediaLibraryImageColumn, specifying column name `thumbnail` doesn't use the `thumbnail relationship in the Product model, as this column only works with Spatie's `media` table

adding `filterMediaUsing` to filter the media collections to only show primary image, if no image then first image in the collection will be displayed