### PR TITLE
Put manage order shout entries in a group

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/ManageOrder.php
@@ -183,26 +183,29 @@ class ManageOrder extends BaseViewRecord
             ->schema([
                 Infolists\Components\Group::make()
                     ->schema([
-                        ShoutEntry::make('requires_capture')
-                            ->type('danger')
-                            ->content(__('lunarpanel::order.infolist.alert.requires_capture'))
-                            ->visible(fn () => $this->requiresCapture),
-                        ShoutEntry::make('requires_capture')
-                            ->state(fn () => $this->paymentStatus)
-                            ->icon(fn ($state) => match ($state) {
-                                'refunded' => FilamentIcon::resolve('lunar::exclamation-circle'),
-                                default => null
-                            })
-                            ->color(fn (ShoutEntry $component, $state) => match ($state) {
-                                'partial-refund' => 'info',
-                                'refunded' => 'danger',
-                                default => null
-                            })->content(fn ($state) => match ($state) {
-                                'partial-refund' => __('lunarpanel::order.infolist.alert.partially_refunded'),
-                                'refunded' => __('lunarpanel::order.infolist.alert.refunded') ,
-                                default => null
-                            })
-                            ->visible(fn ($state) => in_array($state, ['partial-refund', 'refunded'])),
+                        Infolists\Components\Group::make()->key('shouts')->schema([
+                            ShoutEntry::make('requires_capture')
+                                ->type('danger')
+                                ->content(__('lunarpanel::order.infolist.alert.requires_capture'))
+                                ->visible(fn () => $this->requiresCapture),
+                            ShoutEntry::make('partially_refunded')
+                                ->state(fn () => $this->paymentStatus)
+                                ->key('partially_refunded_notice')
+                                ->icon(fn ($state) => match ($state) {
+                                    'refunded' => FilamentIcon::resolve('lunar::exclamation-circle'),
+                                    default => null
+                                })
+                                ->color(fn (ShoutEntry $component, $state) => match ($state) {
+                                    'partial-refund' => 'info',
+                                    'refunded' => 'danger',
+                                    default => null
+                                })->content(fn ($state) => match ($state) {
+                                    'partial-refund' => __('lunarpanel::order.infolist.alert.partially_refunded'),
+                                    'refunded' => __('lunarpanel::order.infolist.alert.refunded') ,
+                                    default => null
+                                })
+                                ->visible(fn ($state) => in_array($state, ['partial-refund', 'refunded'])),
+                        ]),
                         ...static::getInfolistSchema(),
                     ])
                     ->columnSpan(['lg' => 2]),


### PR DESCRIPTION
Currently when you perform a refund on an order there is a hydration issue and Livewire throws an error in the console. This seems to be due to the `ShoutEntry` infolist notices which can appear when an order is partially refunded. This PR groups them together in the view so that Livewire can keep track of where they should go and stop hydration issues.

Closes #2165 