### PR TITLE
Refactor order reference generator

### DIFF
--- a/packages/core/src/Base/OrderReferenceGenerator.php
+++ b/packages/core/src/Base/OrderReferenceGenerator.php
@@ -16,25 +16,18 @@ class OrderReferenceGenerator implements OrderReferenceGeneratorInterface
 
         $month = $order->created_at->format('m');
 
+        $connection = DB::connection()->getDriverName();
+
+        $rawSelect = $connection != 'sqlite' ?
+            'MAX(CAST(SUBSTRING(reference from 9) as UNSIGNED))' :
+            'MAX(CAST(substr(reference, 9) as UNSIGNED))';
+
         $latest = Order::select(
-            DB::RAW('MAX(reference) as reference')
-        )->whereYear('created_at', '=', $year)
-            ->whereMonth('created_at', '=', $month)
-            ->where('id', '!=', $order->id)
-            ->first();
+            DB::RAW($rawSelect.' as reference')
+        )->whereYear('placed_at', '=', $year)
+            ->where('reference', 'LIKE', $year.'-'.$month.'-%')
+            ->where('id', '!=', $order->id)->first();
 
-        if (! $latest || ! $latest->reference) {
-            $increment = 1;
-        } else {
-            $segments = explode('-', $latest->reference);
-
-            if (count($segments) == 1) {
-                $increment = 1;
-            } else {
-                $increment = end($segments) + 1;
-            }
-        }
-
-        return $year.'-'.$month.'-'.str_pad($increment, 4, 0, STR_PAD_LEFT);
+        return $year.'-'.$month.'-'.str_pad($latest?->reference + 1, 4, 0, STR_PAD_LEFT);
     }
 }

--- a/packages/core/src/Base/OrderReferenceGenerator.php
+++ b/packages/core/src/Base/OrderReferenceGenerator.php
@@ -24,7 +24,7 @@ class OrderReferenceGenerator implements OrderReferenceGeneratorInterface
 
         $latest = Order::select(
             DB::RAW($rawSelect.' as reference')
-        )->whereYear('placed_at', '=', $year)
+        )->whereYear('created_at', '=', $year)
             ->where('reference', 'LIKE', $year.'-'.$month.'-%')
             ->where('id', '!=', $order->id)->first();
 

--- a/tests/core/Unit/Base/OrderReferenceGeneratorTest.php
+++ b/tests/core/Unit/Base/OrderReferenceGeneratorTest.php
@@ -56,3 +56,31 @@ function can_increment_order_reference_by_default()
 
     expect($result)->toEqual($order->created_at->format('Y-m').'-0002');
 }
+
+test('can generate high reference numbers', function () {
+    Order::factory()->create([
+        'reference' => '2024-04-5000000',
+        'placed_at' => now(),
+    ]);
+
+    Order::factory()->create([
+        'reference' => '2025-04-9999',
+        'placed_at' => now(),
+    ]);
+
+    Order::factory()->create([
+        'reference' => '2025-04-10000',
+        'placed_at' => now(),
+    ]);
+
+    $order = Order::factory()->create([
+        'reference' => null,
+        'placed_at' => now(),
+    ]);
+
+    expect($order->reference)->toBeNull();
+
+    $result = app(OrderReferenceGenerator::class)->generate($order);
+
+    expect($result)->toEqual($order->created_at->format('Y-m').'-10001');
+});

--- a/tests/core/Unit/Base/OrderReferenceGeneratorTest.php
+++ b/tests/core/Unit/Base/OrderReferenceGeneratorTest.php
@@ -63,13 +63,15 @@ test('can generate high reference numbers', function () {
         'placed_at' => now(),
     ]);
 
+    $year = now()->year;
+
     Order::factory()->create([
-        'reference' => '2025-04-9999',
+        'reference' => $year.'-04-9999',
         'placed_at' => now(),
     ]);
 
     Order::factory()->create([
-        'reference' => '2025-04-10000',
+        'reference' => $year.'-04-10000',
         'placed_at' => now(),
     ]);
 


### PR DESCRIPTION
Fixes #2164 by making some assumptions about the format and then casting to unsigned so the `MAX` function works as expected. This change also allows the generator code to be slim-lined.