### PR TITLE
Make discount table columns toggleable

### DIFF
--- a/packages/admin/resources/lang/en/discount.php
+++ b/packages/admin/resources/lang/en/discount.php
@@ -103,6 +103,12 @@ return [
         'ends_at' => [
             'label' => 'End Date',
         ],
+        'created_at' => [
+            'label' => 'Created At',
+        ],
+        'coupon' => [
+            'label' => 'Coupon',
+        ],
     ],
     'pages' => [
         'availability' => [

--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -209,7 +209,8 @@ class DiscountResource extends BaseResource
                 __('lunarpanel::discount.form.coupon.label')
             )->helperText(
                 __('lunarpanel::discount.form.coupon.helper_text')
-            );
+            )
+            ->unique(ignoreRecord: true);
     }
 
     protected static function getMaxUsesFormComponent(): Component
@@ -359,21 +360,34 @@ class DiscountResource extends BaseResource
                     \Lunar\Models\Discount::EXPIRED => 'danger',
                     \Lunar\Models\Discount::PENDING => 'gray',
                     \Lunar\Models\Discount::SCHEDULED => 'info',
-                }),
+                })
+                ->toggleable(),
             Tables\Columns\TextColumn::make('name')
                 ->label(__('lunarpanel::discount.table.name.label'))
-                ->searchable(),
+                ->searchable()
+                ->toggleable(),
             Tables\Columns\TextColumn::make('type')
                 ->formatStateUsing(function ($state) {
                     return (new $state)->getName();
                 })
-                ->label(__('lunarpanel::discount.table.type.label')),
+                ->label(__('lunarpanel::discount.table.type.label'))
+                ->toggleable(),
             Tables\Columns\TextColumn::make('starts_at')
                 ->label(__('lunarpanel::discount.table.starts_at.label'))
-                ->date(),
+                ->date()
+                ->toggleable(),
             Tables\Columns\TextColumn::make('ends_at')
                 ->label(__('lunarpanel::discount.table.ends_at.label'))
-                ->date(),
+                ->date()
+                ->toggleable(),
+            Tables\Columns\TextColumn::make('coupon')
+                ->label(__('lunarpanel::discount.table.name.coupon.label'))
+                ->searchable()
+                ->toggleable(isToggledHiddenByDefault: true),
+            Tables\Columns\TextColumn::make('created_at')
+                ->label(__('lunarpanel::discount.table.created_at.label'))
+                ->date()
+                ->toggleable(isToggledHiddenByDefault: true),
         ];
     }
 

--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -376,10 +376,12 @@ class DiscountResource extends BaseResource
             Tables\Columns\TextColumn::make('starts_at')
                 ->label(__('lunarpanel::discount.table.starts_at.label'))
                 ->date()
+                ->sortable()
                 ->toggleable(),
             Tables\Columns\TextColumn::make('ends_at')
                 ->label(__('lunarpanel::discount.table.ends_at.label'))
                 ->date()
+                ->sortable()
                 ->toggleable(),
             Tables\Columns\TextColumn::make('coupon')
                 ->label(__('lunarpanel::discount.table.name.coupon.label'))

--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -365,6 +365,7 @@ class DiscountResource extends BaseResource
             Tables\Columns\TextColumn::make('name')
                 ->label(__('lunarpanel::discount.table.name.label'))
                 ->searchable()
+                ->sortable()
                 ->toggleable(),
             Tables\Columns\TextColumn::make('type')
                 ->formatStateUsing(function ($state) {
@@ -383,10 +384,12 @@ class DiscountResource extends BaseResource
             Tables\Columns\TextColumn::make('coupon')
                 ->label(__('lunarpanel::discount.table.name.coupon.label'))
                 ->searchable()
+                ->sortable()
                 ->toggleable(isToggledHiddenByDefault: true),
             Tables\Columns\TextColumn::make('created_at')
                 ->label(__('lunarpanel::discount.table.created_at.label'))
                 ->date()
+                ->sortable()
                 ->toggleable(isToggledHiddenByDefault: true),
         ];
     }

--- a/packages/admin/src/Filament/Resources/DiscountResource.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource.php
@@ -384,7 +384,7 @@ class DiscountResource extends BaseResource
                 ->sortable()
                 ->toggleable(),
             Tables\Columns\TextColumn::make('coupon')
-                ->label(__('lunarpanel::discount.table.name.coupon.label'))
+                ->label(__('lunarpanel::discount.table.coupon.label'))
                 ->searchable()
                 ->sortable()
                 ->toggleable(isToggledHiddenByDefault: true),


### PR DESCRIPTION
This PR adds toggling to the discount table columns, and adding coupon and created at columns, hidden by default.

It makes the name, coupon and date fields sortable.

And it adds a unique validation on the coupon field, as currently you can add discount codes with the same coupon which throws an unhandled database error.