### PR TITLE
Add product link to order lines

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -13,9 +13,12 @@ use Filament\Tables\Table;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Livewire\Attributes\Computed;
+use Lunar\Admin\Filament\Resources\ProductResource\Pages\EditProduct;
 use Lunar\Admin\Livewire\Components\TableComponent;
 use Lunar\Admin\Support\Concerns\CallsHooks;
 use Lunar\Admin\Support\Tables\Components\KeyValue;
+use Lunar\Models\OrderLine;
+use Lunar\Models\ProductVariant;
 use Lunar\Models\Transaction;
 
 /**
@@ -43,6 +46,12 @@ class OrderItemsTable extends TableComponent
                     Tables\Columns\Layout\Split::make([
                         Tables\Columns\Layout\Stack::make([
                             Tables\Columns\TextColumn::make('description')
+                                ->url(function (OrderLine $line) {
+                                    if ($line->purchasable_type == ProductVariant::morphName()) {
+                                        return EditProduct::getUrl(['record' => $line->purchasable->product_id]);
+                                    }
+                                    return null;
+                                })
                                 ->weight(FontWeight::Bold),
                             Tables\Columns\TextColumn::make('identifier')
                                 ->color(Color::Gray),
@@ -108,6 +117,7 @@ class OrderItemsTable extends TableComponent
     {
         return $table
             ->query($this->record->lines()->getQuery()
+                ->with(['purchasable'])
                 ->wherein('type', ['physical', 'digital']))
             ->columns(static::getOrderLinesTableColumns())
             ->bulkActions([

--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -50,6 +50,7 @@ class OrderItemsTable extends TableComponent
                                     if ($line->purchasable_type == ProductVariant::morphName()) {
                                         return EditProduct::getUrl(['record' => $line->purchasable->product_id]);
                                     }
+
                                     return null;
                                 })
                                 ->weight(FontWeight::Bold),


### PR DESCRIPTION
It might be useful for store owners to be able to click through to a product when viewing order lines. There is a check to ensure we only try to link if the purchasable item is a variant, we may want to look to utlisie extensions in the future to accomodate different purchasables stores might have.