### PR TITLE
Add event for stripe webhook

### DIFF
--- a/packages/stripe/README.md
+++ b/packages/stripe/README.md
@@ -381,6 +381,22 @@ const submit = async () => {
 ```
 ---
 
+
+## Events
+
+Below are the events which are dispatched under specific situations within the addon.
+
+### `Lunar\Stripe\Events\Webhook\CartMissingForIntent`
+
+Dispatched when attempting to process a payment intent, but no matching Order or Cart model can be found.
+
+```php
+public function handle(\Lunar\Stripe\Events\Webhook\CartMissingForIntent $event)
+{
+    echo $event->paymentIntentId;
+}
+```
+
 ## Contributing
 
 Contributions are welcome, if you are thinking of adding a feature, please submit an issue first so we can determine whether it should be included.

--- a/packages/stripe/src/Events/Webhook/CartMissingForIntent.php
+++ b/packages/stripe/src/Events/Webhook/CartMissingForIntent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Lunar\Stripe\Events\Webhook;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CartMissingForIntent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public string $paymentIntentId,
+    ) {
+        //
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('stripe-webhooks'),
+        ];
+    }
+}

--- a/packages/stripe/src/Jobs/ProcessStripeWebhook.php
+++ b/packages/stripe/src/Jobs/ProcessStripeWebhook.php
@@ -7,10 +7,10 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Log;
 use Lunar\Facades\Payments;
 use Lunar\Models\Cart;
 use Lunar\Models\Order;
+use Lunar\Stripe\Events\Webhook\CartMissingForIntent;
 use Lunar\Stripe\Models\StripePaymentIntent;
 
 class ProcessStripeWebhook implements ShouldQueue
@@ -54,9 +54,7 @@ class ProcessStripeWebhook implements ShouldQueue
         }
 
         if (! $cart && ! $order) {
-            Log::error(
-                "Unable to find cart with intent {$this->paymentIntentId}"
-            );
+            CartMissingForIntent::dispatch($this->paymentIntentId);
 
             return;
         }

--- a/tests/stripe/Unit/Jobs/ProcessStripeWebbookTest.php
+++ b/tests/stripe/Unit/Jobs/ProcessStripeWebbookTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Lunar\Stripe\Jobs\ProcessStripeWebhook;
+
+uses(\Lunar\Tests\Stripe\Unit\TestCase::class)->group('lunar.stripe.jobs');
+
+it('will dispatch event if payment intent has no found cart or order', function () {
+    \Illuminate\Support\Facades\Event::fake();
+
+    ProcessStripeWebhook::dispatch('PI_FOOBAR', null);
+
+    \Illuminate\Support\Facades\Event::assertDispatched(
+        \Lunar\Stripe\Events\Webhook\CartMissingForIntent::class,
+    );
+});


### PR DESCRIPTION
Currently if an Order or Cart model cannot be found when processing an intent, we just log the error.  This approach doesn't give developers a chance to respond to the problem in their apps and therefore this change will dispatch an event so listeners are able to respond if needed.
