### PR TITLE
Corrected Heading of Weight Units in Products##product-dimensions Reference

### DIFF
--- a/docs/core/reference/products.md
+++ b/docs/core/reference/products.md
@@ -254,7 +254,7 @@ by default:
 - ft
 - in
 
-**Width**
+**Weight**
 
 - kg
 - g


### PR DESCRIPTION
Previously, Docs had heading of ``Width`` for units of weight measurement.
Corrected the heading to ``Weight``
