### PR TITLE
Minor typo on customer groups documentation

### DIFF
--- a/docs/core/reference/customers.md
+++ b/docs/core/reference/customers.md
@@ -162,7 +162,7 @@ class MyModel extends Model
 You will need to define the relationship for customer groups so that Lunar knows how to handle it.
 
 ```php
-public function customerGroup()
+public function customerGroups()
 {
     return $this->hasMany(\Lunar\Models\CustomerGroup::class)->withTimestamps()->withPivot([/* .. */]);
 }


### PR DESCRIPTION
- Documentation updates

I came across an error from copy / pasting to test out the scheduling feature and noticed that the doc's function was missing an 's'