### PR TITLE
change CartSessionManager fetchOrCreate visibility

### DIFF
--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -127,7 +127,7 @@ class CartSessionManager implements CartSessionInterface
     /**
      * Fetches a cart and optionally creates one if it doesn't exist.
      */
-    private function fetchOrCreate(bool $create = false, bool $estimateShipping = false, bool $calculate = true): ?Cart
+    protected function fetchOrCreate(bool $create = false, bool $estimateShipping = false, bool $calculate = true): ?Cart
     {
         $cartId = $this->sessionManager->get(
             $this->getSessionKey()


### PR DESCRIPTION
we have a need to customize fetchOrCreate fetching existing cart logic
we cant override without copying other methods that calling fetchOrCreate as well

what we try to customize is
```php
        if (! $cartId && $user = $this->authManager->user()) {
            $cartId = $user->carts()->active()->first()?->id;
        }
```