### PR TITLE
Fix validation on prices in Postgres

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
@@ -71,20 +71,7 @@ class CustomerGroupPricingRelationManager extends BaseRelationManager
                 Forms\Components\Group::make([
                     Forms\Components\TextInput::make('price')->formatStateUsing(
                         fn ($state) => $state?->decimal(rounding: false)
-                    )->numeric()->unique(
-                        modifyRuleUsing: function (Unique $rule, Forms\Get $get) {
-                            $owner = $this->getOwnerRecord();
-
-                            return $rule
-                                ->when(blank($get('customer_group_id')),
-                                    fn (Unique $rule) => $rule->whereNull('customer_group_id'),
-                                    fn (Unique $rule) => $rule->where('customer_group_id', $get('customer_group_id')))
-                                ->where('min_quantity', 1)
-                                ->where('currency_id', $get('currency_id'))
-                                ->where('priceable_type', $owner->getMorphClass())
-                                ->where('priceable_id', $owner->id);
-                        }
-                    )->helperText(
+                    )->numeric()->helperText(
                         __('lunarpanel::relationmanagers.pricing.form.price.helper_text')
                     )->required(),
                     Forms\Components\TextInput::make('compare_price')->formatStateUsing(

--- a/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
@@ -89,20 +89,7 @@ class PriceRelationManager extends BaseRelationManager
                 Forms\Components\Group::make([
                     Forms\Components\TextInput::make('price')->formatStateUsing(
                         fn ($state) => $state?->decimal(rounding: false)
-                    )->numeric()->unique(
-                        modifyRuleUsing: function (Unique $rule, Forms\Get $get) {
-                            $owner = $this->getOwnerRecord();
-
-                            return $rule
-                                ->when(blank($get('customer_group_id')),
-                                    fn (Unique $rule) => $rule->whereNull('customer_group_id'),
-                                    fn (Unique $rule) => $rule->where('customer_group_id', $get('customer_group_id')))
-                                ->where('min_quantity', $get('min_quantity'))
-                                ->where('currency_id', $get('currency_id'))
-                                ->where('priceable_type', $owner->getMorphClass())
-                                ->where('priceable_id', $owner->id);
-                        }
-                    )->helperText(
+                    )->numeric()->helperText(
                         __('lunarpanel::relationmanagers.pricing.form.price.helper_text')
                     )->required(),
                     Forms\Components\TextInput::make('compare_price')->formatStateUsing(

--- a/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
@@ -9,7 +9,6 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Validation\Rules\Unique;
 use Lunar\Admin\Events\ModelPricesUpdated;
 use Lunar\Facades\DB;
 use Lunar\Models\Currency;


### PR DESCRIPTION
Closes #1974 

The pricing unique validation wasn't working in any databases, and made Postgres return an error.

The unique validation isn't required for customer group pricing, and it's only really a helper for price breaks, nothing will break if someone decides to use the same price for two tiers and it might actually be useful in some scenarios.