### PR TITLE
Allow brand limitation to search by name

### DIFF
--- a/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/BrandLimitationRelationManager.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/BrandLimitationRelationManager.php
@@ -47,7 +47,8 @@ class BrandLimitationRelationManager extends BaseRelationManager
                 })->preloadRecordSelect()
                     ->label(
                         __('lunarpanel::discount.relationmanagers.brands.actions.attach.label')
-                    ),
+                    )
+                ->recordSelectSearchColumns(['name']),
             ])->columns([
                 Tables\Columns\TextColumn::make('name')
                     ->label(

--- a/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/BrandLimitationRelationManager.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/RelationManagers/BrandLimitationRelationManager.php
@@ -48,7 +48,7 @@ class BrandLimitationRelationManager extends BaseRelationManager
                     ->label(
                         __('lunarpanel::discount.relationmanagers.brands.actions.attach.label')
                     )
-                ->recordSelectSearchColumns(['name']),
+                    ->recordSelectSearchColumns(['name']),
             ])->columns([
                 Tables\Columns\TextColumn::make('name')
                     ->label(


### PR DESCRIPTION
The brand limitation relation manager in discounts has a search field but it currently does nothing as there are no fields set to search over.

This PR ensures `->recordSelectSearchColumns(['name'])` is added to allow searching by name.