### PR TITLE
Fix updating non shared product option values

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -309,7 +309,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
             }
 
             if ($optionModel->shared) {
-                return;
+                continue;
             }
 
             $this->configuredOptions[$optionIndex]['id'] = $optionModel->id;

--- a/packages/core/src/Facades/StorefrontSession.php
+++ b/packages/core/src/Facades/StorefrontSession.php
@@ -6,21 +6,22 @@ use Illuminate\Support\Facades\Facade;
 use Lunar\Base\StorefrontSessionInterface;
 
 /**
- * @method static void forget()
- * @method static void initCustomerGroups()
- * @method static void initChannel()
- * @method static \Lunar\Models\Contracts\Customer|null initCustomer()
- * @method static string getSessionKey()
- * @method static \Lunar\Managers\StorefrontSessionManager setChannel(\Lunar\Models\Contracts\Channel|string $channel)
- * @method static \Lunar\Managers\StorefrontSessionManager setCustomer(\Lunar\Models\Contracts\Customer $customer)
- * @method static \Lunar\Models\Contracts\Customer|null getCustomer()
+ * @method static \Lunar\Models\Contracts\Channel getChannel()
+ * @method static \Lunar\Managers\StorefrontSessionManager setChannel(\Lunar\Models\Contracts\Channel $channel)
+ * @method static \Illuminate\Support\Collection getCustomerGroups()
  * @method static \Lunar\Managers\StorefrontSessionManager setCustomerGroups(\Illuminate\Support\Collection $customerGroups)
  * @method static \Lunar\Managers\StorefrontSessionManager setCustomerGroup(\Lunar\Models\Contracts\CustomerGroup $customerGroup)
  * @method static \Lunar\Managers\StorefrontSessionManager resetCustomerGroups()
- * @method static \Lunar\Models\Contracts\Channel getChannel()
- * @method static \Illuminate\Support\Collection|null getCustomerGroups()
- * @method static \Lunar\Managers\StorefrontSessionManager setCurrency(\Lunar\Models\Contracts\Currency $currency)
  * @method static \Lunar\Models\Contracts\Currency getCurrency()
+ * @method static \Lunar\Managers\StorefrontSessionManager setCurrency(\Lunar\Models\Contracts\Currency $currency)
+ * @method static \Lunar\Models\Contracts\Customer|null getCustomer()
+ * @method static \Lunar\Managers\StorefrontSessionManager setCustomer(\Lunar\Models\Contracts\Customer $customer)
+ * @method static void initChannel()
+ * @method static void initCustomerGroups()
+ * @method static void initCurrency()
+ * @method static void initCustomer()
+ * @method static void forget()
+ * @method static string getSessionKey()
  *
  * @see \Lunar\Managers\StorefrontSessionManager
  */

--- a/packages/core/src/Facades/StorefrontSession.php
+++ b/packages/core/src/Facades/StorefrontSession.php
@@ -6,22 +6,21 @@ use Illuminate\Support\Facades\Facade;
 use Lunar\Base\StorefrontSessionInterface;
 
 /**
- * @method static \Lunar\Models\Contracts\Channel getChannel()
- * @method static \Lunar\Managers\StorefrontSessionManager setChannel(\Lunar\Models\Contracts\Channel $channel)
- * @method static \Illuminate\Support\Collection getCustomerGroups()
+ * @method static void forget()
+ * @method static void initCustomerGroups()
+ * @method static void initChannel()
+ * @method static \Lunar\Models\Contracts\Customer|null initCustomer()
+ * @method static string getSessionKey()
+ * @method static \Lunar\Managers\StorefrontSessionManager setChannel(\Lunar\Models\Contracts\Channel|string $channel)
+ * @method static \Lunar\Managers\StorefrontSessionManager setCustomer(\Lunar\Models\Contracts\Customer $customer)
+ * @method static \Lunar\Models\Contracts\Customer|null getCustomer()
  * @method static \Lunar\Managers\StorefrontSessionManager setCustomerGroups(\Illuminate\Support\Collection $customerGroups)
  * @method static \Lunar\Managers\StorefrontSessionManager setCustomerGroup(\Lunar\Models\Contracts\CustomerGroup $customerGroup)
  * @method static \Lunar\Managers\StorefrontSessionManager resetCustomerGroups()
- * @method static \Lunar\Models\Contracts\Currency getCurrency()
+ * @method static \Lunar\Models\Contracts\Channel getChannel()
+ * @method static \Illuminate\Support\Collection|null getCustomerGroups()
  * @method static \Lunar\Managers\StorefrontSessionManager setCurrency(\Lunar\Models\Contracts\Currency $currency)
- * @method static \Lunar\Models\Contracts\Customer|null getCustomer()
- * @method static \Lunar\Managers\StorefrontSessionManager setCustomer(\Lunar\Models\Contracts\Customer $customer)
- * @method static void initChannel()
- * @method static void initCustomerGroups()
- * @method static void initCurrency()
- * @method static void initCustomer()
- * @method static void forget()
- * @method static string getSessionKey()
+ * @method static \Lunar\Models\Contracts\Currency getCurrency()
  *
  * @see \Lunar\Managers\StorefrontSessionManager
  */


### PR DESCRIPTION
I stumbled upon an issue when updating product option values. Non-shared product option values were ignored during update. It was caused by an early return from foreach loop. I changed the `return` to `continue` to take other product options and their values into consideration when the `storeConfiguredOptions` method is being called.

This is just a simple **quick fix**. I will probably get back to refactoring the whole `ProductOptionsWidget` class soon. I find it to be a bit unintuitive. At first I thought, that the product options + values will get updated after I click the "Save Options" button, but it gets you back and you have to press "Save Variants" to persist the changes.