### PR TITLE
Fix variant attribute validation since Filament 3.3.12

### DIFF
--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -62,7 +62,6 @@ class AttributeData
                 return $state;
             })
             ->mutateStateForValidationUsing(function ($state) {
-                // Convert FieldType objects to their actual values for validation
                 if ($state instanceof \Lunar\Base\FieldType) {
                     return $state->getValue();
                 }

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -61,6 +61,14 @@ class AttributeData
 
                 return $state;
             })
+            ->mutateStateForValidationUsing(function ($state) use ($attribute) {
+                // Convert FieldType objects to their actual values for validation
+                if ($state instanceof \Lunar\Base\FieldType) {
+                    return $state->getValue();
+                }
+
+                return $state;
+            })
             ->mutateDehydratedStateUsing(function ($state) use ($attribute) {
                 if ($attribute->type == FileFieldType::class) {
                     $instance = new $attribute->type;

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -61,7 +61,7 @@ class AttributeData
 
                 return $state;
             })
-            ->mutateStateForValidationUsing(function ($state) use ($attribute) {
+            ->mutateStateForValidationUsing(function ($state) {
                 // Convert FieldType objects to their actual values for validation
                 if ($state instanceof \Lunar\Base\FieldType) {
                     return $state->getValue();

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
@@ -37,6 +37,7 @@ it('can edit variant attributes', function () {
         ],
         'handle' => 'test-attribute',
         'section' => 'main',
+        'type' => \Lunar\FieldTypes\Toggle::class,
         'required' => false,
         'system' => false,
         'searchable' => false,
@@ -59,12 +60,12 @@ it('can edit variant attributes', function () {
 
     $component->fillForm([
         'variant' => [
-            $attribute->handle => new \Lunar\FieldTypes\Text('Hello'),
+            $attribute->handle => new \Lunar\FieldTypes\Toggle(true),
         ],
     ])->call('save')
         ->assertHasNoFormErrors();
 
-    expect($variant->refresh()->attr($attribute->handle))->toBe('Hello');
+    expect($variant->refresh()->attr($attribute->handle))->toBe(true);
 });
 
 it('can save attributes', function () {

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
@@ -5,7 +5,7 @@ use Livewire\Livewire;
 uses(\Lunar\Tests\Admin\Unit\Filament\TestCase::class)
     ->group('resource.product');
 
-it('can edit variant attributes', function () {
+it('can edit variant attributes', function ($attributeType, $attributeValue) {
     \Lunar\Models\CustomerGroup::factory()->create([
         'default' => true,
     ]);
@@ -37,7 +37,7 @@ it('can edit variant attributes', function () {
         ],
         'handle' => 'test-attribute',
         'section' => 'main',
-        'type' => \Lunar\FieldTypes\Toggle::class,
+        'type' => $attributeType,
         'required' => false,
         'system' => false,
         'searchable' => false,
@@ -60,13 +60,17 @@ it('can edit variant attributes', function () {
 
     $component->fillForm([
         'variant' => [
-            $attribute->handle => new \Lunar\FieldTypes\Toggle(true),
+            $attribute->handle => new $attributeType($attributeValue),
         ],
     ])->call('save')
         ->assertHasNoFormErrors();
 
-    expect($variant->refresh()->attr($attribute->handle))->toBe(true);
-});
+    expect($variant->refresh()->attr($attribute->handle))->toBe($attributeValue);
+})->with([
+    [\Lunar\FieldTypes\Text::class, 'Hello'],
+    [\Lunar\FieldTypes\Toggle::class, true],
+    [\Lunar\FieldTypes\Number::class, 100],
+]);
 
 it('can save attributes', function () {
     \Lunar\Models\Language::factory()->create([


### PR DESCRIPTION
## Description

This PR fixes a regression in variant attribute validation that occurred after Filament version 3.3.12, specifically related to [Filament PR #16081](https://github.com/filamentphp/filament/pull/16081/files).

## Issue

This PR fixes #2190  

## Changes

- **AttributeData.php**: Added  callback to convert FieldType objects to their actual values before validation
- **EditProductTest.php**: Updated test to use  field type with boolean values to properly test the fix

## Root Cause

Since Filament 3.3.12, the  callback wasn't being called consistently during form validation, causing FieldType objects to be passed directly to validation instead of their primitive values.

## Testing

Update the "can edit variant attributes" test in EditProductTest.php and change the type of the attribute to Toogle. This will make the test fail.

Add the changes from AttributeData.php and it will pass.