### PR TITLE
Fix InvalidArgument in shipping options DTO

### DIFF
--- a/packages/table-rate-shipping/src/DataTransferObjects/ShippingOptionLookup.php
+++ b/packages/table-rate-shipping/src/DataTransferObjects/ShippingOptionLookup.php
@@ -18,7 +18,7 @@ class ShippingOptionLookup
             $this->shippingRates->filter(
                 fn ($method) => get_class($method) != ShippingRate::class
             )->count(),
-            new InvalidArgument
+            InvalidArgument::class
         );
     }
 }

--- a/packages/table-rate-shipping/src/DataTransferObjects/ShippingOptionLookup.php
+++ b/packages/table-rate-shipping/src/DataTransferObjects/ShippingOptionLookup.php
@@ -2,8 +2,8 @@
 
 namespace Lunar\Shipping\DataTransferObjects;
 
-use InvalidArgumentException;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Lunar\Shipping\Models\ShippingRate;
 
 class ShippingOptionLookup

--- a/packages/table-rate-shipping/src/DataTransferObjects/ShippingOptionLookup.php
+++ b/packages/table-rate-shipping/src/DataTransferObjects/ShippingOptionLookup.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Shipping\DataTransferObjects;
 
-use Doctrine\Common\Cache\Psr6\InvalidArgument;
+use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use Lunar\Shipping\Models\ShippingRate;
 
@@ -18,7 +18,7 @@ class ShippingOptionLookup
             $this->shippingRates->filter(
                 fn ($method) => get_class($method) != ShippingRate::class
             )->count(),
-            InvalidArgument::class
+            InvalidArgumentException::class
         );
     }
 }


### PR DESCRIPTION
Not sure why we were using `Doctrine\Common\Cache\Psr6\InvalidArgument;`, I don't believe it's an exception that's supposed to be used externally to the package. It also no longer exists in the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal error handling to improve reliability when processing shipping options. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->