### PR TITLE
Sort BuyXGetY rewards by cheapest item price first

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -123,7 +123,7 @@ class BuyXGetY extends AbstractDiscountType
 
                 return false;
             });
-        })->sortBy(fn ($line) => $line->subTotal->value / $line->quantity);
+        })->sortBy('unitPrice.value');
 
         foreach ($rewardLines as $rewardLine) {
             if (! $remainingRewardQty) {

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -123,7 +123,7 @@ class BuyXGetY extends AbstractDiscountType
 
                 return false;
             });
-        })->sortBy('subTotal.value');
+        })->sortBy(fn ($line) => $line->subTotal->value / $line->quantity);
 
         foreach ($rewardLines as $rewardLine) {
             if (! $remainingRewardQty) {


### PR DESCRIPTION
At the moment BuyXGetY sorts rewards by cheapest line price first, but not all the line might be eligible so when you have multiple quantity in the line its not necessarily the cheapest item.

Instead it should be sorted by the cheapest items (lineSubTotal/quantity).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sorting logic for reward lines in Buy X Get Y discounts to prioritize items with lower unit prices, ensuring a more accurate application of discounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->