### PR TITLE
Allow shipping tables pages to be extended

### DIFF
--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingExclusionListResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingExclusionListResource.php
@@ -106,7 +106,7 @@ class ShippingExclusionListResource extends BaseResource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListShippingExclusionLists::route('/'),

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -188,7 +188,7 @@ class ShippingMethodResource extends BaseResource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListShippingMethod::route('/'),

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource.php
@@ -291,7 +291,7 @@ class ShippingZoneResource extends BaseResource
         ];
     }
 
-    public static function getPages(): array
+    public static function getDefaultPages(): array
     {
         return [
             'index' => Pages\ListShippingZones::route('/'),


### PR DESCRIPTION
The shipping tables resources should use getDefaultPages() not getPages() so that they can be extended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated method names for improved clarity in shipping resource management. No changes to existing functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->