### PR TITLE
Update CollectionResource.php

### DIFF
--- a/packages/admin/src/Filament/Resources/CollectionResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource.php
@@ -47,7 +47,7 @@ class CollectionResource extends BaseResource
             ]) => $collection->group->name,
         ];
 
-        foreach ($collection->ancestors as $childCollection) {
+        foreach ($collection->children as $childCollection) {
             $crumbs[
             CollectionResource::getUrl('edit', [
                 'record' => $childCollection,


### PR DESCRIPTION
We have over 15,000 collections in the main catalog. The problem with **ancestors** is that it shows the linear collections that are on the same level. This makes the breadcrumb 15,000+ collection names. Using **CHILDREN** only shows the children of the collection that you clicked into. The page loads faster and the title bar with the breadcrumb is more readable.

Please describe your Pull Request as best as possible, explaining what it provides and why it is of value, referencing any related Issues.

Try to include the following in your Pull Request, where applicable...

- Documentation updates
- Automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated breadcrumb trail logic to display direct children of a collection instead of its ancestors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->