### PR TITLE
Add translation support for navigation label and breadcrumb in Taxes cluster

### DIFF
--- a/packages/admin/resources/lang/en/tax.php
+++ b/packages/admin/resources/lang/en/tax.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'label' => 'Tax',
+
+    'plural_label' => 'Taxes',
+
+];

--- a/packages/admin/src/Filament/Clusters/Taxes.php
+++ b/packages/admin/src/Filament/Clusters/Taxes.php
@@ -14,6 +14,16 @@ class Taxes extends Cluster
         return __('lunarpanel::global.sections.settings');
     }
 
+    public static function getNavigationLabel(): string
+    {
+        return  __('lunarpanel::tax.plural_label');
+    }
+
+    public static function getClusterBreadcrumb(): ?string
+    {
+        return  __('lunarpanel::tax.plural_label');
+    }
+
     public static function getNavigationIcon(): ?string
     {
         return FilamentIcon::resolve('lunar::tax');


### PR DESCRIPTION
This PR adds translation support for the Taxes cluster in the Lunar system.

The changes include:
Adding code that uses the existing translation file lunarpanel::tax.plural_label for navigation labels and breadcrumbs
The code uses the __() function to retrieve the translated string from the language file
These changes enable proper display of the module name, maintaining consistency with the rest of the translated system.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English localization for tax-related labels in the admin interface.
  * Improved navigation and breadcrumb display for the Taxes section using localized labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->