### PR TITLE
Ensure deleting attributes takes place on the right connection

### DIFF
--- a/packages/core/src/Models/Attribute.php
+++ b/packages/core/src/Models/Attribute.php
@@ -41,11 +41,12 @@ class Attribute extends BaseModel implements Contracts\Attribute
     protected static function booted(): void
     {
         static::deleting(function (self $attribute) {
-            DB::beginTransaction();
-            DB::table(
+            $connection = DB::connection();
+            $connection->beginTransaction();
+            $connection->table(
                 config('lunar.database.table_prefix').'attributables'
             )->where('attribute_id', '=', $attribute->id)->delete();
-            DB::commit();
+            $connection->commit();
         });
     }
 


### PR DESCRIPTION
This PR fixes a bug where attributables deleting would take place on the default database connection, not the one specified for lunar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of attribute deletion operations to ensure related data is consistently removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->