### PR TITLE
Move to JSONB

### DIFF
--- a/docs/core/installation.md
+++ b/docs/core/installation.md
@@ -9,7 +9,7 @@ use and should exercise the same amount of caution as you would with any softwar
 
 - PHP >= 8.2
 - Laravel 11, 12
-- MySQL 8.0+ / PostgreSQL 9.2+
+- MySQL 8.0+ / PostgreSQL 9.4+
 - exif PHP extension (on most systems it will be installed by default)
 - intl PHP extension (on most systems it will be installed by default)
 - bcmath PHP extension (on most systems it will be installed by default)

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -152,6 +152,7 @@ return new class extends Migration
 
         // Get the Lunar table prefix from config
         $prefix = config('lunar.database.table_prefix', 'lunar_');
-        return $prefix . $table;
+
+        return $prefix.$table;
     }
 };

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -160,9 +160,7 @@ return new class extends Migration
             return $table;
         }
 
-        // Get the Lunar table prefix from config
-        $prefix = config('lunar.database.table_prefix', 'lunar_');
-
-        return $prefix.$table;
+        
+        return $this->prefix.$table;
     }
 };

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -1,9 +1,9 @@
-
 <?php
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -95,6 +95,11 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Only run for PostgreSQL - SQLite doesn't need jsonb conversion
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
         foreach ($this->columnsToUpdate as $table => $columns) {
             $fullTableName = $this->getTableName($table);
 
@@ -119,6 +124,11 @@ return new class extends Migration
      */
     public function down(): void
     {
+        // Only run for PostgreSQL
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
         foreach ($this->columnsToUpdate as $table => $columns) {
             $fullTableName = $this->getTableName($table);
 

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Lunar\Base\Migration;
 
 return new class extends Migration
 {
@@ -95,7 +95,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        // Only run for PostgreSQL - SQLite doesn't need jsonb conversion
+        // Only run for PostgreSQL - MySQL has no change and SQLite will error when trying to change
         if (DB::getDriverName() !== 'pgsql') {
             return;
         }

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -105,15 +105,9 @@ return new class extends Migration
 
             Schema::table($fullTableName, function (Blueprint $tableBlueprint) use ($columns) {
                 foreach ($columns as $column) {
-                    $columnBuilder = $tableBlueprint->jsonb($column['name']);
-
-                    if ($column['nullable']) {
-                        $columnBuilder->nullable();
-                    } else {
-                        $columnBuilder->nullable(false);
-                    }
-
-                    $columnBuilder->change();
+                    $tableBlueprint->jsonb($column['name'])
+                        ->nullable($column['nullable'])
+                        ->change();
                 }
             });
         }
@@ -134,15 +128,9 @@ return new class extends Migration
 
             Schema::table($fullTableName, function (Blueprint $tableBlueprint) use ($columns) {
                 foreach ($columns as $column) {
-                    $columnBuilder = $tableBlueprint->json($column['name']);
-
-                    if ($column['nullable']) {
-                        $columnBuilder->nullable();
-                    } else {
-                        $columnBuilder->nullable(false);
-                    }
-
-                    $columnBuilder->change();
+                    $tableBlueprint->json($column['name'])
+                        ->nullable($column['nullable'])
+                        ->change();
                 }
             });
         }
@@ -160,9 +148,6 @@ return new class extends Migration
             return $table;
         }
 
-        // Get the Lunar table prefix from config
-        $prefix = config('lunar.database.table_prefix', 'lunar_');
-
-        return $prefix.$table;
+        return $this->prefix.$table;
     }
 };

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table($this->prefix.'brands', function (Blueprint $table) {
+            $table->jsonb('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'collections', function (Blueprint $table) {
+            $table->jsonb('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'customers', function (Blueprint $table) {
+            $table->jsonb('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'customer_groups', function (Blueprint $table) {
+            $table->jsonb('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'products', function (Blueprint $table) {
+            $table->jsonb('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'product_variants', function (Blueprint $table) {
+            $table->jsonb('attribute_data')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table($this->prefix.'brands', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'collections', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'customers', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'customer_groups', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'products', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->change();
+        });
+
+        Schema::table($this->prefix.'product_variants', function (Blueprint $table) {
+            $table->json('attribute_data')->nullable()->change();
+        });
+    }
+};

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -141,13 +141,6 @@ return new class extends Migration
      */
     private function getTableName(string $table): string
     {
-        // Tables that don't use the lunar_ prefix
-        $nonLunarTables = ['activity_log', 'media'];
-
-        if (in_array($table, $nonLunarTables)) {
-            return $table;
-        }
-
-        return $this->prefix.$table;
+        return in_array($table, ['activity_log', 'media']) ? $table : $this->prefix.$table;
     }
 };

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -1,39 +1,117 @@
+
 <?php
 
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Lunar\Base\Migration;
 
 return new class extends Migration
 {
+    /**
+     * The list of tables and JSON columns to update.
+     */
+    private $columnsToUpdate = [
+        'activity_log' => [
+            ['name' => 'properties', 'nullable' => true],
+        ],
+        'addresses' => [
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'attribute_groups' => [
+            ['name' => 'name', 'nullable' => false],
+        ],
+        'attributes' => [
+            ['name' => 'configuration', 'nullable' => false],
+            ['name' => 'description', 'nullable' => true],
+            ['name' => 'name', 'nullable' => false],
+        ],
+        'brands' => [
+            ['name' => 'attribute_data', 'nullable' => true],
+        ],
+        'cart_addresses' => [
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'cart_lines' => [
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'carts' => [
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'collections' => [
+            ['name' => 'attribute_data', 'nullable' => true],
+        ],
+        'customer_groups' => [
+            ['name' => 'attribute_data', 'nullable' => true],
+        ],
+        'customers' => [
+            ['name' => 'attribute_data', 'nullable' => true],
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'discounts' => [
+            ['name' => 'data', 'nullable' => true],
+        ],
+        'order_addresses' => [
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'order_lines' => [
+            ['name' => 'meta', 'nullable' => true],
+            ['name' => 'tax_breakdown', 'nullable' => false],
+        ],
+        'orders' => [
+            ['name' => 'discount_breakdown', 'nullable' => true],
+            ['name' => 'meta', 'nullable' => true],
+            ['name' => 'shipping_breakdown', 'nullable' => true],
+            ['name' => 'tax_breakdown', 'nullable' => false],
+        ],
+        'product_option_values' => [
+            ['name' => 'name', 'nullable' => false],
+        ],
+        'product_options' => [
+            ['name' => 'label', 'nullable' => true],
+            ['name' => 'name', 'nullable' => false],
+        ],
+        'product_variants' => [
+            ['name' => 'attribute_data', 'nullable' => true],
+        ],
+        'products' => [
+            ['name' => 'attribute_data', 'nullable' => true],
+        ],
+        'shipping_methods' => [
+            ['name' => 'data', 'nullable' => true],
+        ],
+        'transactions' => [
+            ['name' => 'meta', 'nullable' => true],
+        ],
+        'media' => [
+            ['name' => 'custom_properties', 'nullable' => false],
+            ['name' => 'generated_conversions', 'nullable' => false],
+            ['name' => 'manipulations', 'nullable' => false],
+            ['name' => 'responsive_images', 'nullable' => false],
+        ],
+    ];
+
     /**
      * Run the migrations.
      */
     public function up(): void
     {
-        Schema::table($this->prefix.'brands', function (Blueprint $table) {
-            $table->jsonb('attribute_data')->nullable()->change();
-        });
+        foreach ($this->columnsToUpdate as $table => $columns) {
+            $fullTableName = $this->getTableName($table);
 
-        Schema::table($this->prefix.'collections', function (Blueprint $table) {
-            $table->jsonb('attribute_data')->nullable()->change();
-        });
+            Schema::table($fullTableName, function (Blueprint $tableBlueprint) use ($columns) {
+                foreach ($columns as $column) {
+                    $columnBuilder = $tableBlueprint->jsonb($column['name']);
 
-        Schema::table($this->prefix.'customers', function (Blueprint $table) {
-            $table->jsonb('attribute_data')->nullable()->change();
-        });
+                    if ($column['nullable']) {
+                        $columnBuilder->nullable();
+                    } else {
+                        $columnBuilder->nullable(false);
+                    }
 
-        Schema::table($this->prefix.'customer_groups', function (Blueprint $table) {
-            $table->jsonb('attribute_data')->nullable()->change();
-        });
-
-        Schema::table($this->prefix.'products', function (Blueprint $table) {
-            $table->jsonb('attribute_data')->nullable()->change();
-        });
-
-        Schema::table($this->prefix.'product_variants', function (Blueprint $table) {
-            $table->jsonb('attribute_data')->nullable()->change();
-        });
+                    $columnBuilder->change();
+                }
+            });
+        }
     }
 
     /**
@@ -41,28 +119,39 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table($this->prefix.'brands', function (Blueprint $table) {
-            $table->json('attribute_data')->nullable()->change();
-        });
+        foreach ($this->columnsToUpdate as $table => $columns) {
+            $fullTableName = $this->getTableName($table);
 
-        Schema::table($this->prefix.'collections', function (Blueprint $table) {
-            $table->json('attribute_data')->nullable()->change();
-        });
+            Schema::table($fullTableName, function (Blueprint $tableBlueprint) use ($columns) {
+                foreach ($columns as $column) {
+                    $columnBuilder = $tableBlueprint->json($column['name']);
 
-        Schema::table($this->prefix.'customers', function (Blueprint $table) {
-            $table->json('attribute_data')->nullable()->change();
-        });
+                    if ($column['nullable']) {
+                        $columnBuilder->nullable();
+                    } else {
+                        $columnBuilder->nullable(false);
+                    }
 
-        Schema::table($this->prefix.'customer_groups', function (Blueprint $table) {
-            $table->json('attribute_data')->nullable()->change();
-        });
+                    $columnBuilder->change();
+                }
+            });
+        }
+    }
 
-        Schema::table($this->prefix.'products', function (Blueprint $table) {
-            $table->json('attribute_data')->nullable()->change();
-        });
+    /**
+     * Get the full table name with appropriate prefix.
+     */
+    private function getTableName(string $table): string
+    {
+        // Tables that don't use the lunar_ prefix
+        $nonLunarTables = ['activity_log', 'media'];
 
-        Schema::table($this->prefix.'product_variants', function (Blueprint $table) {
-            $table->json('attribute_data')->nullable()->change();
-        });
+        if (in_array($table, $nonLunarTables)) {
+            return $table;
+        }
+
+        // Get the Lunar table prefix from config
+        $prefix = config('lunar.database.table_prefix', 'lunar_');
+        return $prefix . $table;
     }
 };

--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -160,7 +160,6 @@ return new class extends Migration
             return $table;
         }
 
-        
         return $this->prefix.$table;
     }
 };


### PR DESCRIPTION
Closes #2261 

We were using standard JSON fields and when it comes to Postgres this field type is very basic, not much more than a simple text field.

JSONB is a "proper" JSON field, is supported properly in Filament and should perform a lot better.

It's worth noting MySQL & Sqlite will continue to use the same JSON field type - so no change there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Converted many metadata and attribute fields to PostgreSQL JSONB for improved performance and consistency across activity logs, addresses, attributes, brands, carts, collections, customers, discounts, orders, products, shipping, transactions, and media.

- **Chores**
  - Added a PostgreSQL-only migration to perform the conversions and raised the PostgreSQL minimum requirement from 9.2+ to 9.4+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->