### PR TITLE
Update ManageVariantIdentifiers breadcrumb to match correct page #1

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantIdentifiers.php
+++ b/packages/admin/src/Filament/Resources/ProductVariantResource/Pages/ManageVariantIdentifiers.php
@@ -41,7 +41,7 @@ class ManageVariantIdentifiers extends BaseEditRecord
             ...ProductVariantResource::getBaseBreadcrumbs(
                 $this->getRecord()
             ),
-            ProductVariantResource::getUrl('inventory', [
+            ProductVariantResource::getUrl('identifiers', [
                 'record' => $this->getRecord(),
             ]) => $this->getTitle(),
         ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected breadcrumb navigation in the Product Variant admin area. When managing variant identifiers, the final breadcrumb now links to the Identifiers page instead of Inventory, aligning with the page context. This improves navigation accuracy and consistency across the admin interface, reducing confusion for users. No changes to data or functionality—only the breadcrumb destination was updated wherever this breadcrumb appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->