### PR TITLE
remove shipping methods table's update from migration

### DIFF
--- a/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
+++ b/packages/core/database/migrations/2025_08_14_164000_switch_to_jsonb.php
@@ -76,9 +76,6 @@ return new class extends Migration
         'products' => [
             ['name' => 'attribute_data', 'nullable' => true],
         ],
-        'shipping_methods' => [
-            ['name' => 'data', 'nullable' => true],
-        ],
         'transactions' => [
             ['name' => 'meta', 'nullable' => true],
         ],


### PR DESCRIPTION
This migration is aimed at PostgreSQL databases. It targets columns that were previously of type `json` and changes them to `jsonb`. The line removed in the PR causes a problem because the table mentioned does not exist in Lunar. This causes new installations that use PostgreSQL to fail.

Relevant issue:
- https://github.com/lunarphp/lunar/issues/2276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated a database migration to exclude a shipping-related field from JSON/JSONB conversions.
  - Streamlines the migration process and reduces unnecessary data alterations during upgrades or rollbacks.
  - Improves operational stability for deployments involving historical data.
  - No changes to user experience or visible functionality; the application behaves as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->