### PR TITLE
Fix vendor publish command for pdfs

### DIFF
--- a/docs/core/reference/orders.md
+++ b/docs/core/reference/orders.md
@@ -440,7 +440,7 @@ By default when you click "Download PDF" in the hub when viewing an order, you w
 download. You can publish the view that powers this to create your own PDF template.
 
 ```bash
-php artisan vendor:publish --tag=lunar.hub.views
+php artisan vendor:publish --tag=lunar.pdf
 ```
 
 This will create a view called `resources/vendor/lunarpanel/pdf/order.blade.php`, where you will be able to freely

--- a/docs/core/reference/orders.md
+++ b/docs/core/reference/orders.md
@@ -436,11 +436,11 @@ Here's an example of what the template could look like:
 
 ## Order Invoice PDF
 
-By default when you click "Download PDF" in the hub when viewing an order, you will get a basic PDF generated for you to
-download. You can publish the view that powers this to create your own PDF template.
+By default when you click "Download PDF" in the admin panel when viewing an order, you will get a basic PDF generated 
+for you to download. You can publish the view that powers this to create your own PDF template.
 
 ```bash
-php artisan vendor:publish --tag=lunar.pdf
+php artisan vendor:publish --tag=lunarpanel.pdf
 ```
 
 This will create a view called `resources/vendor/lunarpanel/pdf/order.blade.php`, where you will be able to freely

--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -74,6 +74,10 @@ class LunarPanelProvider extends ServiceProvider
             __DIR__.'/../resources/lang' => $this->app->langPath('vendor/lunarpanel'),
         ]);
 
+        $this->publishes([
+            __DIR__.'/../resources/views/pdf' => resource_path('views/vendor/lunar/pdf'),
+        ], 'lunar.pdf');
+
         collect($this->configFiles)->each(function ($config) {
             $this->mergeConfigFrom("{$this->root}/config/$config.php", "lunar.$config");
         });

--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -76,7 +76,7 @@ class LunarPanelProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../resources/views/pdf' => resource_path('views/vendor/lunarpanel/pdf'),
-        ], 'lunar.pdf');
+        ], 'lunarpanel.pdf');
 
         collect($this->configFiles)->each(function ($config) {
             $this->mergeConfigFrom("{$this->root}/config/$config.php", "lunar.$config");

--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -75,7 +75,7 @@ class LunarPanelProvider extends ServiceProvider
         ]);
 
         $this->publishes([
-            __DIR__.'/../resources/views/pdf' => resource_path('views/vendor/lunar/pdf'),
+            __DIR__.'/../resources/views/pdf' => resource_path('views/vendor/lunarpanel/pdf'),
         ], 'lunar.pdf');
 
         collect($this->configFiles)->each(function ($config) {


### PR DESCRIPTION
This will fix issue #2265 

I am not sure about the naming of the publish tag. 
I think lunar.pdf fits better as this will only target all pdfs currently (and in the future) in lunar. 

If accepted we need to edit the docs aswell. 


Docs: https://github.com/lunarphp/docs/pull/3