### PR TITLE
feat: add translations for name label in create product option value

### DIFF
--- a/packages/admin/resources/lang/de/relationmanagers.php
+++ b/packages/admin/resources/lang/de/relationmanagers.php
@@ -212,4 +212,20 @@ return [
             ],
         ],
     ],
+    'values' => [
+        'title' => 'Werte',
+        'form' => [
+            'name' => [
+                'label' => 'Name',
+            ],
+        ],
+        'table' => [
+            'name' => [
+                'label' => 'Name',
+            ],
+            'position' => [
+                'label' => 'Position',
+            ],
+        ],
+    ],
 ];

--- a/packages/admin/resources/lang/en/relationmanagers.php
+++ b/packages/admin/resources/lang/en/relationmanagers.php
@@ -272,6 +272,11 @@ return [
     ],
     'values' => [
         'title' => 'Values',
+        'form' => [
+            'name' => [
+                'label' => 'Name',
+            ],
+        ],
         'table' => [
             'name' => [
                 'label' => 'Name',

--- a/packages/admin/resources/lang/es/relationmanagers.php
+++ b/packages/admin/resources/lang/es/relationmanagers.php
@@ -263,6 +263,11 @@ return [
     ],
     'values' => [
         'title' => 'Valores',
+        'form' => [
+            'name' => [
+                'label' => 'Nombre',
+            ],
+        ],
         'table' => [
             'name' => [
                 'label' => 'Nombre',

--- a/packages/admin/resources/lang/fr/relationmanagers.php
+++ b/packages/admin/resources/lang/fr/relationmanagers.php
@@ -263,6 +263,11 @@ return [
     ],
     'values' => [
         'title' => 'Valeurs',
+        'form' => [
+            'name' => [
+                'label' => 'Nom',
+            ],
+        ],
         'table' => [
             'name' => [
                 'label' => 'Nom',

--- a/packages/admin/resources/lang/nl/relationmanagers.php
+++ b/packages/admin/resources/lang/nl/relationmanagers.php
@@ -263,6 +263,11 @@ return [
     ],
     'values' => [
         'title' => 'Waarden',
+        'form' => [
+            'name' => [
+                'label' => 'Naam',
+            ],
+        ],
         'table' => [
             'name' => [
                 'label' => 'Naam',

--- a/packages/admin/resources/lang/pl/relationmanagers.php
+++ b/packages/admin/resources/lang/pl/relationmanagers.php
@@ -226,6 +226,11 @@ return [
     ],
     'values' => [
         'title' => 'Wartości',
+        'form' => [
+            'name' => [
+                'label' => 'Nazwa',
+            ],
+        ],
         'table' => [
             'name' => [
                 'label' => 'Nazwa',

--- a/packages/admin/resources/lang/vi/relationmanagers.php
+++ b/packages/admin/resources/lang/vi/relationmanagers.php
@@ -263,6 +263,11 @@ return [
     ],
     'values' => [
         'title' => 'Giá trị',
+        'form' => [
+            'name' => [
+                'label' => 'Tên',
+            ],
+        ],
         'table' => [
             'name' => [
                 'label' => 'Tên',


### PR DESCRIPTION
Added these translations while I investigated this issue: #2263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Values” section translations across multiple languages (de, en, es, fr, nl, pl, vi).
  * Introduced form label for the “Name” field in the Values section for all supported languages.
  * Enhanced German locale with a section title (“Werte”) and table column labels (“Name”, “Position”) for the Values list.
  * Improves multilingual consistency and clarity in the admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->