### PR TITLE
enhancement: use proper method name when setting a foreign-key relationship

### DIFF
--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -404,7 +404,7 @@ class LunarServiceProvider extends ServiceProvider
             $type = config('lunar.database.users_id_type', 'bigint');
 
             if ($type == 'uuid') {
-                $this->foreignUuId($field_name)
+                $this->foreignUuid($field_name)
                     ->nullable($nullable)
                     ->constrained(
                         (new $userModel)->getTable()


### PR DESCRIPTION
The code being replaced worked because PHP method names are case-insensitive for [historical reasons](https://stackoverflow.com/a/6302488), it's better to use [proper name](https://github.com/laravel/framework/blob/b8e2aa2527fb5601698e8021b3b205632ef2e4ba/src/Illuminate/Database/Schema/Blueprint.php#L1373) of the method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue affecting projects that use UUIDs for user IDs, which could cause database migrations to fail when creating user reference columns. Migrations now correctly handle UUID-based foreign keys, improving reliability during installation and upgrades. Projects using integer-based user IDs are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->