### PR TITLE
fix: use logical and operator instead of binary

### DIFF
--- a/packages/core/src/Actions/Carts/GetExistingCartLine.php
+++ b/packages/core/src/Actions/Carts/GetExistingCartLine.php
@@ -31,7 +31,7 @@ class GetExistingCartLine extends AbstractAction
         return $lines->first(function ($line) use ($meta) {
             $diff = Arr::diff($line->meta, $meta);
 
-            return empty($diff->new) && empty($diff->edited) & empty($diff->removed);
+            return empty($diff->new) && empty($diff->edited) && empty($diff->removed);
         });
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where existing cart line items could be misidentified when no changes were present, leading to unintended merges or duplicates.
  * Cart lines are now matched only when there are truly no new, edited, or removed differences, improving the accuracy of item updates.
  * Results in more predictable cart behavior and smoother checkout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->