### PR TITLE
Add with trashed to orderline purchasable relation

### DIFF
--- a/packages/core/src/Models/OrderLine.php
+++ b/packages/core/src/Models/OrderLine.php
@@ -82,7 +82,7 @@ class OrderLine extends BaseModel implements Contracts\OrderLine
 
     public function purchasable(): MorphTo
     {
-        return $this->morphTo();
+        return $this->morphTo()->withTrashed();
     }
 
     public function currency(): HasOneThrough


### PR DESCRIPTION
Sometimes a purchasable might be soft deleted which causes errors in the panel when viewing an order. This PR looks to include the `withTrashed()` scope so that these orders can load. This shouldn't have any adverse effects on how orders work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Order lines now retain references to associated items even if those items have been archived or deleted. This ensures historical orders, invoices, and reports display complete information without missing products or errors.
  * Improves consistency across order detail pages, admin views, and data exports by preserving access to product details for past purchases, aiding auditing and customer support scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->