### PR TITLE
Update logic to clean up order lines

### DIFF
--- a/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
@@ -3,6 +3,7 @@
 namespace Lunar\Pipelines\Order\Creation;
 
 use Closure;
+use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Models\Order;
 
@@ -16,12 +17,32 @@ class CleanUpOrderLines
         /** @var Order $order */
         $cart = $order->cart;
 
-        $purchasableIds = $cart->lines->pluck('purchasable_id');
+        // Build a set of "signatures" that uniquely identify each cart line
+        $cartSignatures = $cart->lines->map(function ($line) {
+            return $this->signature($line->purchasable_id, (array) $line->meta, $line->quantity);
+        })->toArray();
 
-        $order->productLines()
-            ->whereNotIn('purchasable_id', $purchasableIds)
-            ->delete();
+        $order->productLines->each(function ($orderLine) use ($cartSignatures) {
+            $sig = $this->signature(
+                $orderLine->purchasable_id,
+                (array) $orderLine->meta,
+                $orderLine->quantity,
+            );
+
+            if (! in_array($sig, $cartSignatures, true)) {
+                $orderLine->delete();
+            }
+        });
 
         return $next($order);
+    }
+
+    private function signature(string $purchasableId, array $meta, int $qty): string
+    {
+        return md5(json_encode([
+            'id' => $purchasableId,
+            'meta' => collect($meta)->sortKeys()->toArray(),
+            'qty' => $qty,
+        ]));
     }
 }

--- a/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
@@ -3,7 +3,6 @@
 namespace Lunar\Pipelines\Order\Creation;
 
 use Closure;
-use Illuminate\Database\Eloquent\Casts\ArrayObject;
 use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Models\Order;
 

--- a/tests/core/Unit/Pipelines/Order/Creation/CleanUpOrderLinesTest.php
+++ b/tests/core/Unit/Pipelines/Order/Creation/CleanUpOrderLinesTest.php
@@ -13,6 +13,7 @@ use Lunar\Models\OrderLine;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Pipelines\Order\Creation\CleanUpOrderLines;
+use function Pest\Laravel\{assertDatabaseHas, assertDatabaseMissing};
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -91,6 +92,124 @@ test('can run pipeline', function () {
         return $order;
     });
 
-    expect($order->productLines)->toHaveCount(1);
+    assertDatabaseHas((new OrderLine)->getTable(), [
+        'purchasable_id' => $purchasable->id,
+    ]);
+
+    assertDatabaseMissing((new OrderLine)->getTable(), [
+        'purchasable_id' => $purchasableB->id,
+    ]);
+
     expect($order->shippingLines->first()->identifier)->toEqual('BASDEL');
+});
+
+test('will remove lines with same purchasable ids when different', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    ShippingManifest::addOption(
+        new ShippingOption(
+            name: 'Basic Delivery',
+            description: 'Basic Delivery',
+            identifier: 'BASDEL',
+            price: new Price(500, $cart->currency, 1),
+            taxClass: TaxClass::factory()->create()
+        )
+    );
+
+    CartAddress::factory()->create([
+        'type' => 'shipping',
+        'shipping_option' => 'BASDEL',
+        'cart_id' => $cart->id,
+    ]);
+
+    $order = Order::factory()->create([
+        'cart_id' => $cart->id,
+    ]);
+
+    $purchasable = ProductVariant::factory()->create();
+    $purchasableB = ProductVariant::factory()->create();
+
+    \Lunar\Models\Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    \Lunar\Models\Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableB->getMorphClass(),
+        'priceable_id' => $purchasableB->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableB->getMorphClass(),
+        'purchasable_id' => $purchasableB->id,
+        'quantity' => 5,
+        'meta' => ['foo' => 'bar'],
+    ]);
+
+    OrderLine::factory()->create([
+        'order_id' => $order->id,
+        'purchasable_id' => $purchasable->id,
+        'purchasable_type' => $purchasable->getMorphClass(),
+    ]);
+
+
+    OrderLine::factory()->create([
+        'order_id' => $order->id,
+        'quantity' => 15,
+        'purchasable_id' => $purchasableB->id,
+        'purchasable_type' => $purchasableB->getMorphClass(),
+        'meta' => ['bar' => 'baz'],
+    ]);
+
+    OrderLine::factory()->create([
+        'order_id' => $order->id,
+        'quantity' => 5,
+        'purchasable_id' => $purchasableB->id,
+        'purchasable_type' => $purchasableB->getMorphClass(),
+        'meta' => ['foo' => 'bar'],
+    ]);
+
+
+    OrderLine::factory()->create([
+        'identifier' => 'BASDEL',
+        'purchasable_type' => ShippingOption::class,
+        'type' => 'shipping',
+        'order_id' => $order->id,
+    ]);
+
+    app(CleanUpOrderLines::class)->handle($order, function ($order) {
+        return $order;
+    });
+
+    assertDatabaseHas((new OrderLine)->getTable(), [
+        'purchasable_id' => $purchasable->id,
+    ]);
+
+    assertDatabaseHas((new OrderLine)->getTable(), [
+        'purchasable_id' => $purchasableB->id,
+        'quantity' => 5,
+        'meta' => json_encode(['foo' => 'bar']),
+    ]);
+
+    assertDatabaseMissing((new OrderLine)->getTable(), [
+        'purchasable_id' => $purchasableB->id,
+        'quantity' => 15,
+        'meta' => json_encode(['bar' => 'baz']),
+    ]);
 });

--- a/tests/core/Unit/Pipelines/Order/Creation/CleanUpOrderLinesTest.php
+++ b/tests/core/Unit/Pipelines/Order/Creation/CleanUpOrderLinesTest.php
@@ -95,10 +95,12 @@ test('can run pipeline', function () {
     });
 
     assertDatabaseHas((new OrderLine)->getTable(), [
+        'order_id' => $order->id,
         'purchasable_id' => $purchasable->id,
     ]);
 
     assertDatabaseMissing((new OrderLine)->getTable(), [
+        'order_id' => $order->id,
         'purchasable_id' => $purchasableB->id,
     ]);
 
@@ -198,16 +200,19 @@ test('will remove lines with same purchasable ids when different', function () {
     });
 
     assertDatabaseHas((new OrderLine)->getTable(), [
+        'order_id' => $order->id,
         'purchasable_id' => $purchasable->id,
     ]);
 
     assertDatabaseHas((new OrderLine)->getTable(), [
+        'order_id' => $order->id,
         'purchasable_id' => $purchasableB->id,
         'quantity' => 5,
         'meta' => json_encode(['foo' => 'bar']),
     ]);
 
     assertDatabaseMissing((new OrderLine)->getTable(), [
+        'order_id' => $order->id,
         'purchasable_id' => $purchasableB->id,
         'quantity' => 15,
         'meta' => json_encode(['bar' => 'baz']),

--- a/tests/core/Unit/Pipelines/Order/Creation/CleanUpOrderLinesTest.php
+++ b/tests/core/Unit/Pipelines/Order/Creation/CleanUpOrderLinesTest.php
@@ -13,7 +13,9 @@ use Lunar\Models\OrderLine;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Pipelines\Order\Creation\CleanUpOrderLines;
-use function Pest\Laravel\{assertDatabaseHas, assertDatabaseMissing};
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -168,7 +170,6 @@ test('will remove lines with same purchasable ids when different', function () {
         'purchasable_type' => $purchasable->getMorphClass(),
     ]);
 
-
     OrderLine::factory()->create([
         'order_id' => $order->id,
         'quantity' => 15,
@@ -184,7 +185,6 @@ test('will remove lines with same purchasable ids when different', function () {
         'purchasable_type' => $purchasableB->getMorphClass(),
         'meta' => ['foo' => 'bar'],
     ]);
-
 
     OrderLine::factory()->create([
         'identifier' => 'BASDEL',


### PR DESCRIPTION
This PR adds additional logic to the `CleanUpOrderLines` pipeline to catch any duplicate purchasable lines which may have slipped through the net due to differing quantities/meta values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Order line cleanup now uses per-line signatures to precisely compare against cart lines, removing only truly mismatched lines and preserving matching product and shipping lines.

* **Tests**
  * Added and expanded unit tests to validate persisted DB state (including same product with different metadata/prices) and replaced fragile in-memory checks with robust database assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->