### PR TITLE
Add clarity for opt-out telemetry during upgrade

### DIFF
--- a/docs/core/upgrading.md
+++ b/docs/core/upgrading.md
@@ -35,7 +35,7 @@ If you are using Scout, you may need to update your `panel.php` config.
 This release introduces anonymous usage insights, which are sent via a deferred API call to Lunar. The reason for this addition
 is to allow us to have an idea of how Lunar is being used and at what capacity. We do not send or use any identifying information whatsoever.
 
-This is completely optional, however, it is turned on by default. To opt-out add the following to your service provider:
+This is completely optional, however, it is turned on by default. To opt-out add the following to your service provider's boot method:
 
 ```php
 \Lunar\Facades\Telemetry::optOut();


### PR DESCRIPTION
just to add some clarity to put the telemetry opt-out in `boot()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the upgrading guide to clarify opt-out steps, directing users to perform them in the service provider’s boot method rather than the general provider.
  * No changes to application behavior, APIs, or configuration are introduced by this update.
  * Aims to improve clarity for users following upgrade instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->