### PR TITLE
Handle soft deleted purchasable on order lines

### DIFF
--- a/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
+++ b/packages/admin/src/Filament/Resources/OrderResource/Pages/Components/OrderItemsTable.php
@@ -47,7 +47,7 @@ class OrderItemsTable extends TableComponent
                         Tables\Columns\Layout\Stack::make([
                             Tables\Columns\TextColumn::make('description')
                                 ->url(function (OrderLine $line) {
-                                    if ($line->purchasable_type == ProductVariant::morphName()) {
+                                    if ($line->purchasable && $line->purchasable_type == ProductVariant::morphName()) {
                                         return EditProduct::getUrl(['record' => $line->purchasable->product_id]);
                                     }
 


### PR DESCRIPTION
Currently when viewing an order in the panel a link is provided to the product, however if this product has been soft deleted then an exception is thrown due to trying to get the `product` to provide a link.

This is a small PR which will check for the existence of the `purchasable` relation before attempting to generate the link to ensure the page will still load in the event the product has been deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when viewing order item descriptions without an associated purchasable/product. The app now skips link generation when data is missing, avoiding crashes and broken links in the Order Items table. This improves stability, ensures pages load reliably, and delivers a smoother admin experience with consistent behavior even for incomplete or legacy order data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->