### PR TITLE
Add purchasable_type to clean up signature

### DIFF
--- a/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
+++ b/packages/core/src/Pipelines/Order/Creation/CleanUpOrderLines.php
@@ -18,12 +18,13 @@ class CleanUpOrderLines
 
         // Build a set of "signatures" that uniquely identify each cart line
         $cartSignatures = $cart->lines->map(function ($line) {
-            return $this->signature($line->purchasable_id, (array) $line->meta, $line->quantity);
+            return $this->signature($line->purchasable_id, $line->purchasable_type, (array) $line->meta, $line->quantity);
         })->toArray();
 
         $order->productLines->each(function ($orderLine) use ($cartSignatures) {
             $sig = $this->signature(
                 $orderLine->purchasable_id,
+                $orderLine->purchasable_type,
                 (array) $orderLine->meta,
                 $orderLine->quantity,
             );
@@ -36,10 +37,11 @@ class CleanUpOrderLines
         return $next($order);
     }
 
-    private function signature(string $purchasableId, array $meta, int $qty): string
+    private function signature(string $purchasableId, string $purchasableType, array $meta, int $qty): string
     {
         return md5(json_encode([
             'id' => $purchasableId,
+            'type' => $purchasableType,
             'meta' => collect($meta)->sortKeys()->toArray(),
             'qty' => $qty,
         ]));


### PR DESCRIPTION
Adds `purchasable_type` to signature on the order lines cleanup action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved cart-to-order consistency by correctly distinguishing items with the same identifier but different types.
  - Prevents unintended merging or duplication of order lines during checkout.
  - Reduces edge cases where similar items were incorrectly combined, ensuring accurate line item handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->