### PR TITLE
Make Admin Dashboard compatible with immutable Carbon Dates

### DIFF
--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/AverageOrderValueChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/AverageOrderValueChart.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Widgets\Dashboard\Orders;
 
+use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
 use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
 use Lunar\Facades\DB;
@@ -23,7 +24,7 @@ class AverageOrderValueChart extends ApexChartWidget
         return __('lunarpanel::widgets.dashboard.orders.average_order_value.heading');
     }
 
-    protected function getOrderQuery(?\DateTime $from = null, ?\DateTime $to = null)
+    protected function getOrderQuery(\DateTime|CarbonInterface|null $from = null, \DateTime|CarbonInterface|null $to = null)
     {
         return Order::whereNotNull('placed_at')
             ->with(['currency'])

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Widgets\Dashboard\Orders;
 
+use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
 use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
 use Lunar\Facades\DB;
@@ -22,7 +23,7 @@ class NewVsReturningCustomersChart extends ApexChartWidget
         return __('lunarpanel::widgets.dashboard.orders.new_returning_customers.heading');
     }
 
-    protected function getOrderQuery(?\DateTime $from = null, ?\DateTime $to = null)
+    protected function getOrderQuery(\DateTime|CarbonInterface|null $from = null, \DateTime|CarbonInterface|null $to = null)
     {
         return Order::whereNotNull('placed_at')
             ->whereBetween('placed_at', [

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderStatsOverview.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderStatsOverview.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Widgets\Dashboard\Orders;
 
+use Carbon\CarbonInterface;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -12,7 +13,7 @@ class OrderStatsOverview extends BaseWidget
 {
     protected static ?string $pollingInterval = '60s';
 
-    protected function getOrderQuery(?\DateTime $from = null, ?\DateTime $to = null)
+    protected function getOrderQuery(\DateTime|CarbonInterface|null $from = null, \DateTime|CarbonInterface|null $to = null)
     {
         return Order::whereNotNull('placed_at')
             ->whereBetween('placed_at', [

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderTotalsChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrderTotalsChart.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Widgets\Dashboard\Orders;
 
+use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
@@ -25,7 +26,7 @@ class OrderTotalsChart extends ApexChartWidget
         return __('lunarpanel::widgets.dashboard.orders.order_totals_chart.heading');
     }
 
-    protected function getOrderQuery(?\DateTime $from = null, ?\DateTime $to = null)
+    protected function getOrderQuery(\DateTime|CarbonInterface|null $from = null, \DateTime|CarbonInterface|null $to = null)
     {
         return Order::whereNotNull('placed_at')
             ->with(['currency'])

--- a/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrdersSalesChart.php
+++ b/packages/admin/src/Filament/Widgets/Dashboard/Orders/OrdersSalesChart.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Widgets\Dashboard\Orders;
 
+use Carbon\CarbonInterface;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
 use Lunar\Facades\DB;
@@ -24,7 +25,7 @@ class OrdersSalesChart extends ApexChartWidget
         return __('lunarpanel::widgets.dashboard.orders.order_sales_chart.heading');
     }
 
-    protected function getOrderQuery(?\DateTime $from = null, ?\DateTime $to = null)
+    protected function getOrderQuery(\DateTime|CarbonInterface|null $from = null, \DateTime|CarbonInterface|null $to = null)
     {
         return Order::whereNotNull('placed_at')
             ->with(['currency'])


### PR DESCRIPTION
If you want to use ImmutableDates in your Application with this line: 
```php
Illuminate\Support\Facades\Date::use(CarbonImmutable::class);
```

The Dashboard Widgets break because the signature of the `getOrderQuery` methods on the Widgets is to strict. 

The Error: 
```
Lunar\Admin\Filament\Widgets\Dashboard\Orders\NewVsReturningCustomersChart::getOrderQuery():
Argument #1 ($from) must be of type ?DateTime, Carbon\CarbonImmutable given, called in
 Packages/lunar/packages/lunar/packages/admin/src/Filament/Widgets/Dashboard/Orders/NewVsReturningCustomersChart.php on line 47
```

This PR changes the signature to accept also CarbonDates which solves the Problem. 

Old Signature: 
```php
protected function getOrderQuery(?\DateTime $from = null, ?\DateTime $to = null);
```

New Signature: 
```php
protected function getOrderQuery(\DateTime|CarbonInterface|null $from = null, \DateTime|CarbonInterface|null $to = null);
```


> [!WARNING]
>  This is a breaking change for people who extended one or more widgets and have overwritten the  `getOrderQuery` method. But the Impact is in a non critical part and the required work to upgrade is minimal. 
