### PR TITLE
Allow Dashboard to be extended

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -170,6 +170,7 @@ export default defineConfig({
                         {text: 'Add-ons', link: '/admin/extending/addons'},
                         {text: 'Attributes', link: '/admin/extending/attributes'},
                         {text: 'Panel', link: '/admin/extending/panel'},
+                        {text: 'Dashboard', link: '/admin/extending/dashboard'},
                         {text: 'Pages', link: '/admin/extending/pages'},
                         {text: 'Resources', link: '/admin/extending/resources'},
                         {text: 'Relation Managers', link: '/admin/extending/relation-managers'},

--- a/docs/admin/extending/dashboard.md
+++ b/docs/admin/extending/dashboard.md
@@ -1,0 +1,64 @@
+# Extending The Dashboard
+
+You may customise the Lunar Dashboard when registering it in your app service provider.
+
+```php
+<?php
+
+namespace App\Filament\Extensions;
+
+use Lunar\Admin\Support\Extending\BaseExtension;
+
+class DashboardExtension extends BaseExtension
+{
+    /**
+    * Override or add to all widgets on the dashboard
+     */
+    public function getWidgets(array $widgets): array
+    {
+        return [
+            //...
+        ];
+    }
+    
+    /**
+    * Override or add to the overview widgets at the top of the dashboard
+     */
+    public function getOverviewWidgets(array $widgets): array
+    {
+        return [
+            //...
+        ];
+    }
+    
+    /**
+    * Override or add to the chart widgets
+     */
+    public function getChartWidgets(array $widgets): array
+    {
+        return [
+            //...
+        ];
+    }
+    
+    /**
+    * Override or add to the table widgets
+     */
+    public function getTableWidgets(array $widgets): array
+    {
+        return [
+            //...
+        ];
+    }
+}
+
+```
+
+```php
+public function boot()
+{
+    \Lunar\Admin\Support\Facades\LunarPanel::extensions([
+        \Lunar\Admin\Filament\Pages\Dashboard::class => App\Filament\Extensions\DashboardExtension::class,
+    ]);
+}
+```

--- a/docs/admin/extending/dashboard.md
+++ b/docs/admin/extending/dashboard.md
@@ -13,7 +13,7 @@ class DashboardExtension extends BaseExtension
 {
     /**
     * Override or add to all widgets on the dashboard
-     */
+    */
     public function getWidgets(array $widgets): array
     {
         return [
@@ -23,7 +23,7 @@ class DashboardExtension extends BaseExtension
     
     /**
     * Override or add to the overview widgets at the top of the dashboard
-     */
+    */
     public function getOverviewWidgets(array $widgets): array
     {
         return [
@@ -33,7 +33,7 @@ class DashboardExtension extends BaseExtension
     
     /**
     * Override or add to the chart widgets
-     */
+    */
     public function getChartWidgets(array $widgets): array
     {
         return [
@@ -43,7 +43,7 @@ class DashboardExtension extends BaseExtension
     
     /**
     * Override or add to the table widgets
-     */
+    */
     public function getTableWidgets(array $widgets): array
     {
         return [

--- a/packages/admin/src/Filament/Pages/Dashboard.php
+++ b/packages/admin/src/Filament/Pages/Dashboard.php
@@ -10,23 +10,52 @@ use Lunar\Admin\Filament\Widgets\Dashboard\Orders\OrdersSalesChart;
 use Lunar\Admin\Filament\Widgets\Dashboard\Orders\OrderStatsOverview;
 use Lunar\Admin\Filament\Widgets\Dashboard\Orders\OrderTotalsChart;
 use Lunar\Admin\Filament\Widgets\Dashboard\Orders\PopularProductsTable;
+use Lunar\Admin\Support\Concerns\CallsHooks;
 use Lunar\Admin\Support\Pages\BaseDashboard;
 
 class Dashboard extends BaseDashboard
 {
+    use CallsHooks;
+
     protected static ?int $navigationSort = 1;
 
     public function getWidgets(): array
     {
+        return self::callLunarHook('getWidgets', $this->getDefaultWidgets());
+    }
+
+    public function getDefaultWidgets(): array
+    {
         return [
+            ...$this->getDefaultOverviewWidgets(),
+            ...$this->getDefaultChartsWidgets(),
+            ...$this->getDefaultTableWidgets(),
+        ];
+    }
+
+    public function getDefaultOverviewWidgets(): array
+    {
+        return self::callLunarHook('getOverviewWidgets', [
             OrderStatsOverview::class,
+        ]);
+    }
+
+    public function getDefaultChartsWidgets(): array
+    {
+        return self::callLunarHook('getChartWidgets', [
             OrderTotalsChart::class,
             OrdersSalesChart::class,
             AverageOrderValueChart::class,
             NewVsReturningCustomersChart::class,
+        ]);
+    }
+
+    public function getDefaultTableWidgets(): array
+    {
+        return self::callLunarHook('getTableWidgets', [
             PopularProductsTable::class,
             LatestOrdersTable::class,
-        ];
+        ]);
     }
 
     public static function getNavigationIcon(): ?string


### PR DESCRIPTION
This PR looks to add extending functionality to the Dashboard page so that developers can add to the existing widgets on the Dashboard, or, completely override them and build a custom dashboard to their needs.