### PR TITLE
Add semicolon to example code

### DIFF
--- a/docs/core/extending/payments.md
+++ b/docs/core/extending/payments.md
@@ -71,7 +71,7 @@ class CustomPayment extends AbstractPayment
             paymentType: 'custom-type'
         );
         
-        PaymentAttemptEvent::dispatch($response)
+        PaymentAttemptEvent::dispatch($response);
 
         return $response;
     }


### PR DESCRIPTION
The example code has invalid syntax because it’s missing a semicolon.

- Documentation updates
https://docs.lunarphp.io/core/extending/payments.html