### PR TITLE
Add some additional database indexes

### DIFF
--- a/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
+++ b/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Base\Migration;
 

--- a/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
+++ b/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
@@ -12,8 +12,6 @@ return new class extends Migration
     private $columnsToUpdate = [
         'channelables' => [
             'enabled',
-            'channelable_type',
-            'channelable_id',
             'starts_at',
         ],
         'products' => [

--- a/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
+++ b/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
@@ -8,7 +8,7 @@ use Lunar\Base\Migration;
 return new class extends Migration
 {
     /**
-     * The list of tables and JSON columns to update.
+     * The list of tables and columns to index.
      */
     private $columnsToUpdate = [
         'channelables' => [
@@ -31,11 +31,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        // Only run for PostgreSQL - MySQL has no change and SQLite will error when trying to change
-        if (DB::getDriverName() !== 'pgsql') {
-            return;
-        }
-
         foreach ($this->columnsToUpdate as $table => $columns) {
             $fullTableName = $this->getTableName($table);
 

--- a/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
+++ b/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    /**
+     * The list of tables and JSON columns to update.
+     */
+    private $columnsToUpdate = [
+        'channelables' => [
+            'enabled',
+            'channelable_type',
+            'channelable_id',
+            'starts_at',
+            'ends_at',
+        ],
+        'products' => [
+            'deleted_at',
+        ],
+        'product_variants' => [
+            'deleted_at',
+        ],
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Only run for PostgreSQL - MySQL has no change and SQLite will error when trying to change
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        foreach ($this->columnsToUpdate as $table => $columns) {
+            $fullTableName = $this->getTableName($table);
+
+            Schema::table($fullTableName, function (Blueprint $tableBlueprint) use ($columns) {
+                foreach ($columns as $column) {
+                    $tableBlueprint->index($column);
+                }
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach ($this->columnsToUpdate as $table => $columns) {
+            $fullTableName = $this->getTableName($table);
+
+            Schema::table($fullTableName, function (Blueprint $tableBlueprint) use ($columns) {
+                foreach ($columns as $column) {
+                    $tableBlueprint->dropIndex([$column]);
+                }
+            });
+        }
+    }
+
+    /**
+     * Get the full table name with appropriate prefix.
+     */
+    private function getTableName(string $table): string
+    {
+        return in_array($table, ['activity_log', 'media']) ? $table : $this->prefix.$table;
+    }
+};

--- a/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
+++ b/packages/core/database/migrations/2025_10_29_084000_add_missing_indexes_to_tables.php
@@ -16,7 +16,6 @@ return new class extends Migration
             'channelable_type',
             'channelable_id',
             'starts_at',
-            'ends_at',
         ],
         'products' => [
             'deleted_at',


### PR DESCRIPTION
PR to add some additional database indexes to help with query speed, most notably we had a few missing on the `channelables` table and the `deleted_at` columns on products/variants.