### PR TITLE
Fix default color and icon for state in CustomerGroupRelationManager

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -81,15 +81,8 @@ class CustomerGroupRelationManager extends BaseRelationManager
             return Tables\Columns\IconColumn::make($column)->label(
                 __("lunarpanel::relationmanagers.customer_groups.table.{$column}.label")
             )
-                ->color(fn (string $state): string => match ($state) {
-                    '1' => 'success',
-                    '0' => 'warning',
-                    default => 'warning',
-                })->icon(fn (string $state): string => match ($state) {
-                    '0' => 'heroicon-o-x-circle',
-                    '1' => 'heroicon-o-check-circle',
-                    default => 'heroicon-o-x-circle',
-                });
+                ->color(fn ($state): string => $state ? 'success' : 'warning')
+                ->icon(fn ($state): string => $state) ? 'heroicon-o-x-circle' : 'heroicon-o-check-circle');
         })->toArray();
 
         return $table

--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -84,9 +84,11 @@ class CustomerGroupRelationManager extends BaseRelationManager
                 ->color(fn (string $state): string => match ($state) {
                     '1' => 'success',
                     '0' => 'warning',
+                    default => 'warning',
                 })->icon(fn (string $state): string => match ($state) {
                     '0' => 'heroicon-o-x-circle',
                     '1' => 'heroicon-o-check-circle',
+                    default => 'heroicon-o-x-circle',
                 });
         })->toArray();
 

--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupRelationManager.php
@@ -82,7 +82,7 @@ class CustomerGroupRelationManager extends BaseRelationManager
                 __("lunarpanel::relationmanagers.customer_groups.table.{$column}.label")
             )
                 ->color(fn ($state): string => $state ? 'success' : 'warning')
-                ->icon(fn ($state): string => $state) ? 'heroicon-o-x-circle' : 'heroicon-o-check-circle');
+                ->icon(fn ($state): string => $state ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle');
         })->toArray();
 
         return $table


### PR DESCRIPTION
Add support for when postgres casts booleans to php bool, thereby casting `false` to an empty string for the match case

Please describe your Pull Request as best as possible, explaining what it provides and why it is of value, referencing any related Issues.

Try to include the following in your Pull Request, where applicable...

- Documentation updates
- Automated tests
