### PR TITLE
Document currency initialization in storefront-session

### DIFF
--- a/docs/core/storefront-utils/storefront-session.md
+++ b/docs/core/storefront-utils/storefront-session.md
@@ -102,6 +102,17 @@ StorefrontSession::getCustomer();
 
 ## Currencies
 
+### Initialise the Currency
+
+This will set the Currency based on what's been previously set (from the session), otherwise it will use the default record.
+
+```php
+StorefrontSession::initCurrency();
+```
+
+:::tip This is automatically called when using the facade.
+:::
+
 ### Set the Currency
 
 ```php


### PR DESCRIPTION
This pull request adds new documentation to clarify how to initialize the currency in the `StorefrontSession` utility. The update explains that calling `StorefrontSession::initCurrency()` will set the currency based on the session or fall back to the default, and notes that this is automatically handled when using the facade.

Documentation improvements:

* Added a section describing how to initialize the currency with `StorefrontSession::initCurrency()`, including usage details and a tip about automatic invocation via the facade.