### PR TITLE
Add meta to product options and values

### DIFF
--- a/packages/core/database/migrations/2025_11_12_005200_add_meta_to_product_options.php
+++ b/packages/core/database/migrations/2025_11_12_005200_add_meta_to_product_options.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->prefix.'product_options', function (Blueprint $table) {
+            $table->jsonb('meta')->nullable()->after('shared');
+        });
+
+        Schema::table($this->prefix.'product_option_values', function (Blueprint $table) {
+            $table->jsonb('meta')->nullable()->after('position');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->prefix.'product_options', function (Blueprint $table) {
+            $table->dropColumn('meta');
+        });
+
+        Schema::table($this->prefix.'product_option_values', function (Blueprint $table) {
+            $table->dropColumn('meta');
+        });
+    }
+};

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -18,10 +18,12 @@ use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
 
 /**
  * @property int $id
- * @property \Illuminate\Support\Collection $name
- * @property \Illuminate\Support\Collection $label
+ * @property AsArrayObject $name
+ * @property ?AsArrayObject $label
  * @property int $position
  * @property ?string $handle
+ * @property bool $shared
+ * @property ?AsArrayObject $meta
  * @property ?\Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
  */
@@ -43,6 +45,7 @@ class ProductOption extends BaseModel implements Contracts\ProductOption, Spatie
         'name' => AsArrayObject::class,
         'label' => AsArrayObject::class,
         'shared' => 'boolean',
+        'meta' => AsArrayObject::class,
     ];
 
     /**

--- a/packages/core/src/Models/ProductOptionValue.php
+++ b/packages/core/src/Models/ProductOptionValue.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Models;
 
-use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -16,8 +16,9 @@ use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
 /**
  * @property int $id
  * @property int $product_option_id
- * @property string $name
+ * @property AsArrayObject $name
  * @property int $position
+ * @property ?AsArrayObject $meta
  * @property ?\Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
  */
@@ -34,7 +35,8 @@ class ProductOptionValue extends BaseModel implements Contracts\ProductOptionVal
      * @var array
      */
     protected $casts = [
-        'name' => AsCollection::class,
+        'name' => AsArrayObject::class,
+        'meta' => AsArrayObject::class,
     ];
 
     /**


### PR DESCRIPTION
This adds meta to Product Options & Product Option Values to support customisation, e.g. assigning hex colours.

It also updates the model annotations and corrects the `name` cast on ProductOptionValue (this might be considered a breaking change...)

## TODO

- [ ] Add docs PR, including upgrade guide entry