### PR TITLE
Add cart_session config option to allow for the prevention of the cart deletion on user logout

### DIFF
--- a/packages/core/config/cart_session.php
+++ b/packages/core/config/cart_session.php
@@ -44,5 +44,5 @@ return [
     | Determines whether the cart sholud be soft deleted when the user logs out.
     |
     */
-    'delete_on_logout' => true,
+    'delete_on_forget' => true,
 ];

--- a/packages/core/config/cart_session.php
+++ b/packages/core/config/cart_session.php
@@ -35,4 +35,14 @@ return [
     |
     */
     'allow_multiple_orders_per_cart' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Delete cart on logout
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether the cart sholud be soft deleted when the user logs out.
+    |
+    */
+    'delete_on_logout' => true,
 ];

--- a/packages/core/src/Listeners/CartSessionAuthListener.php
+++ b/packages/core/src/Listeners/CartSessionAuthListener.php
@@ -61,6 +61,6 @@ class CartSessionAuthListener
             return;
         }
 
-        CartSession::forget(config('lunar.cart_session.delete_on_logout', true));
+        CartSession::forget();
     }
 }

--- a/packages/core/src/Listeners/CartSessionAuthListener.php
+++ b/packages/core/src/Listeners/CartSessionAuthListener.php
@@ -61,6 +61,6 @@ class CartSessionAuthListener
             return;
         }
 
-        CartSession::forget();
+        CartSession::forget(config('lunar.cart_session.delete_on_logout', true));
     }
 }

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -68,8 +68,10 @@ class CartSessionManager implements CartSessionInterface
     /**
      * {@inheritDoc}
      */
-    public function forget(bool $delete = true): void
+    public function forget(?bool $delete = null): void
     {
+        $delete = is_null($delete) ? config('lunar.cart_session.delete', true) : $delete;
+
         if ($delete) {
             Cart::destroy(
                 $this->sessionManager->get(

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -70,7 +70,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function forget(?bool $delete = null): void
     {
-        $delete = is_null($delete) ? config('lunar.cart_session.delete', true) : $delete;
+        $delete = is_null($delete) ? config('lunar.cart_session.delete_on_forget', true) : $delete;
 
         if ($delete) {
             Cart::destroy(

--- a/tests/core/Unit/Listeners/CartSessionAuthListenerTest.php
+++ b/tests/core/Unit/Listeners/CartSessionAuthListenerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Session;
+use Lunar\Facades\CartSession;
+use Lunar\Models\Cart;
+use Lunar\Models\Channel;
+use Lunar\Models\Currency;
+
+use function Pest\Laravel\actingAs;
+
+uses(\Lunar\Tests\Core\TestCase::class)->group('cart_session');
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+test('cart is soft deleted on logout when delete_on_logout is true', function () {
+    // Ensure required defaults exist
+    Currency::factory()->create(['default' => true]);
+    Channel::factory()->create(['default' => true]);
+
+    // Create a session cart
+    Config::set('lunar.cart_session.auto_create', true);
+
+    $cart = CartSession::current();
+
+    // Authenticate a Lunar user so the Logout listener will act on it
+    $user = \Lunar\Tests\Core\Stubs\User::factory()->create();
+    actingAs($user);
+
+    // Sanity checks
+    expect($cart)->toBeInstanceOf(Cart::class);
+    expect(Session::get(config('lunar.cart_session.session_key')))->toEqual($cart->id);
+
+    // Config dictates cart should be soft deleted on logout
+    Config::set('lunar.cart_session.delete_on_logout', true);
+
+    // Fire the logout event (this triggers CartSessionAuthListener@logout)
+    event(new Logout('web', $user));
+
+    // Session cart should be cleared and the cart soft deleted
+    expect(Session::get(config('lunar.cart_session.session_key')))->toBeNull();
+    expect($cart->refresh()->deleted_at)->not->toBeNull();
+});
+
+test('cart is not soft deleted on logout when delete_on_logout is false', function () {
+    // Ensure required defaults exist
+    Currency::factory()->create(['default' => true]);
+    Channel::factory()->create(['default' => true]);
+
+    // Create a session cart
+    Config::set('lunar.cart_session.auto_create', true);
+
+    $cart = CartSession::current();
+
+    // Authenticate a Lunar user so the Logout listener will act on it
+    $user = \Lunar\Tests\Core\Stubs\User::factory()->create();
+    actingAs($user);
+
+    // Sanity checks
+    expect($cart)->toBeInstanceOf(Cart::class);
+    expect(Session::get(config('lunar.cart_session.session_key')))->toEqual($cart->id);
+
+    // Config dictates cart should NOT be soft deleted on logout
+    Config::set('lunar.cart_session.delete_on_logout', false);
+
+    // Fire the logout event (this triggers CartSessionAuthListener@logout)
+    event(new Logout('web', $user));
+
+    // Session cart should be cleared but the cart should remain not-deleted
+    expect(Session::get(config('lunar.cart_session.session_key')))->toBeNull();
+    expect($cart->refresh()->deleted_at)->toBeNull();
+});

--- a/tests/core/Unit/Listeners/CartSessionAuthListenerTest.php
+++ b/tests/core/Unit/Listeners/CartSessionAuthListenerTest.php
@@ -32,7 +32,7 @@ test('cart is soft deleted on logout when delete_on_logout is true', function ()
     expect(Session::get(config('lunar.cart_session.session_key')))->toEqual($cart->id);
 
     // Config dictates cart should be soft deleted on logout
-    Config::set('lunar.cart_session.delete_on_logout', true);
+    Config::set('lunar.cart_session.delete_on_forget', true);
 
     // Fire the logout event (this triggers CartSessionAuthListener@logout)
     event(new Logout('web', $user));
@@ -61,7 +61,7 @@ test('cart is not soft deleted on logout when delete_on_logout is false', functi
     expect(Session::get(config('lunar.cart_session.session_key')))->toEqual($cart->id);
 
     // Config dictates cart should NOT be soft deleted on logout
-    Config::set('lunar.cart_session.delete_on_logout', false);
+    Config::set('lunar.cart_session.delete_on_forget', false);
 
     // Fire the logout event (this triggers CartSessionAuthListener@logout)
     event(new Logout('web', $user));


### PR DESCRIPTION
Added 'delete_on_logout' config option within cart_session.php config file to allow the prevention of the cart deletion when a user logs out 