### PR TITLE
Use max to prevent negative sub totals

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -173,10 +173,12 @@ class BuyXGetY extends AbstractDiscountType
             $remainingRewardQty -= $qtyToAllocate;
 
             $subTotal = $rewardLine->subTotal->value;
+
             $unitPrice = $rewardLine->unitPrice->value;
 
             $lineDiscountTotal = $unitPrice * $qtyToAllocate;
             $discountTotal += $lineDiscountTotal;
+
 
             $rewardLine->discountTotal = new Price(
                 $lineDiscountTotal,
@@ -289,8 +291,9 @@ class BuyXGetY extends AbstractDiscountType
                     1
                 );
 
+
                 $rewardLine->subTotalDiscounted = new Price(
-                    $rewardLine->subTotal->value - $rewardLine->discountTotal->value,
+                    max(0, $rewardLine->subTotal->value - $rewardLine->discountTotal->value),
                     $cart->currency,
                     1
                 );

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -284,6 +284,10 @@ class BuyXGetY extends AbstractDiscountType
 
                 $discountTotal += $unitPrice;
 
+                if ($discountTotal > $rewardLine->subTotal->value) {
+                    $discountTotal = $rewardLine->subTotal->value;
+                }
+
                 $rewardLine->discountTotal = new Price(
                     ($rewardLine->discountTotal?->value ?? 0) + $unitPrice,
                     $cart->currency,

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -179,7 +179,6 @@ class BuyXGetY extends AbstractDiscountType
             $lineDiscountTotal = $unitPrice * $qtyToAllocate;
             $discountTotal += $lineDiscountTotal;
 
-
             $rewardLine->discountTotal = new Price(
                 $lineDiscountTotal,
                 $cart->currency,
@@ -290,7 +289,6 @@ class BuyXGetY extends AbstractDiscountType
                     $cart->currency,
                     1
                 );
-
 
                 $rewardLine->subTotalDiscounted = new Price(
                     max(0, $rewardLine->subTotal->value - $rewardLine->discountTotal->value),

--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -289,7 +289,7 @@ class BuyXGetY extends AbstractDiscountType
                 }
 
                 $rewardLine->discountTotal = new Price(
-                    ($rewardLine->discountTotal?->value ?? 0) + $unitPrice,
+                    $discountTotal,
                     $cart->currency,
                     1
                 );

--- a/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
@@ -1285,7 +1285,6 @@ test('discounted sub total will not fall below zero', function () {
         'priceable_id' => $purchasableB->id,
     ]);
 
-
     /**
      * Cart set up.
      */
@@ -1305,7 +1304,6 @@ test('discounted sub total will not fall below zero', function () {
         'purchasable_id' => $purchasableB->id,
         'quantity' => 1,
     ]);
-
 
     /**
      * Discount set up.

--- a/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
@@ -1242,3 +1242,117 @@ test('can add eligible products when not in cart', function () {
     $this->assertCount(1, $cart->freeItems);
 
 });
+
+test('discounted sub total will not fall below zero', function () {
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $channel = Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'code' => 'GBP',
+    ]);
+
+    /**
+     * Product set up.
+     */
+    $productA = Product::factory()->create();
+    $productB = Product::factory()->create();
+
+    $purchasableA = ProductVariant::factory()->create([
+        'product_id' => $productA->id,
+    ]);
+    $purchasableB = ProductVariant::factory()->create([
+        'product_id' => $productB->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000, // £10
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableA->getMorphClass(),
+        'priceable_id' => $purchasableA->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 500, // £5
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableB->getMorphClass(),
+        'priceable_id' => $purchasableB->id,
+    ]);
+
+
+    /**
+     * Cart set up.
+     */
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableA->getMorphClass(),
+        'purchasable_id' => $purchasableA->id,
+        'quantity' => 20,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableB->getMorphClass(),
+        'purchasable_id' => $purchasableB->id,
+        'quantity' => 1,
+    ]);
+
+
+    /**
+     * Discount set up.
+     */
+    $discountA = Discount::factory()->create([
+        'type' => BuyXGetY::class,
+        'priority' => 1,
+        'name' => 'Test Product Discount',
+        'data' => [
+            'min_qty' => 10,
+            'reward_qty' => 1,
+            'max_reward_qty' => null,
+            'automatically_add_rewards' => true,
+        ],
+    ]);
+
+    foreach ([$discountA] as $discount) {
+        $discount->customerGroups()->sync([
+            $customerGroup->id => [
+                'enabled' => true,
+                'starts_at' => now(),
+            ],
+        ]);
+        $discount->channels()->sync([
+            $channel->id => [
+                'enabled' => true,
+                'starts_at' => now()->subHour(),
+            ],
+        ]);
+    }
+
+    $discountA->discountableConditions()->create([
+        'discountable_type' => $productA->getMorphClass(),
+        'discountable_id' => $productA->id,
+    ]);
+
+    $discountA->discountableRewards()->create([
+        'discountable_type' => $productB->getMorphClass(),
+        'discountable_id' => $productB->id,
+        'type' => 'reward',
+    ]);
+
+    $cart = $cart->calculate();
+
+    $lineB = $cart->lines->first(function ($line) use ($purchasableB) {
+        return $line->purchasable_id == $purchasableB->id;
+    });
+
+    expect($lineB->subTotalDiscounted->value)->toEqual(0);
+});


### PR DESCRIPTION
This PR prevents reward lines from producing a negative discounted subtotal. Currently, if a BuyXGetY discount grants multiple free items but the cart contains fewer qualifying products, the discount calculation can push the subtotal below zero.

By wrapping the final discounted amount in max(0, ...), we ensure the subtotal never becomes negative. If the discount exceeds the cart line value, the subtotal is simply set to 0.00 until the customer adds enough qualifying items.