### PR TITLE
Fix table prefix duplication in multi-level model inheritance

### DIFF
--- a/tests/core/Stubs/Models/Custom/DeepCustomProduct.php
+++ b/tests/core/Stubs/Models/Custom/DeepCustomProduct.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs\Models\Custom;
+
+/**
+ * Multi-level inheritance test model.
+ *
+ * This model extends CustomProduct which already extends \Lunar\Models\Product.
+ * This creates a 3-level inheritance chain to test the table prefix bug fix.
+ */
+class DeepCustomProduct extends CustomProduct
+{
+}

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -93,3 +93,22 @@ test('core model events are triggered with extended models', function () {
         'eloquent.deleted: '.Product::class
     );
 });
+
+test('multi-level extended model returns correct table name without prefix duplication', function () {
+    $lunarProduct = new \Lunar\Models\Product;
+    $customProduct = new \Lunar\Tests\Core\Stubs\Models\Custom\CustomProduct;
+    $deepCustomProduct = new \Lunar\Tests\Core\Stubs\Models\Custom\DeepCustomProduct;
+
+    // All three models should return the same table name
+    expect($customProduct->getTable())
+        ->toBe($lunarProduct->getTable())
+        ->and($deepCustomProduct->getTable())
+        ->toBe($lunarProduct->getTable());
+
+    // Verify the table name is correctly prefixed (not duplicated)
+    $expectedTable = config('lunar.database.table_prefix').'products';
+    expect($deepCustomProduct->getTable())->toBe($expectedTable);
+
+    // Ensure prefix is not duplicated
+    expect($deepCustomProduct->getTable())->not->toContain(config('lunar.database.table_prefix').config('lunar.database.table_prefix'));
+});


### PR DESCRIPTION
When extending a model multiple times (e.g., CustomProduct extends Product extends BaseModel), the table prefix was being applied multiple times, resulting in table names like "lunar_lunar_products" instead of "lunar_products".

**Problem:**
The `HasModelExtending::getTable()` method instantiated parent classes recursively with `(new $parentClass)->table`, causing the BaseModel constructor to apply the prefix at each inheritance level.

**Solution:**
- Added `resolveRootModelClass()` to find the root Lunar model in the inheritance chain
- Added `resolveBaseTableName()` to get the base table name using reflection without triggering the constructor
- Modified `getTable()` to resolve the root model and apply the prefix only once

**Test Coverage:**
Added test case for multi-level inheritance to ensure prefix is not duplicated across multiple levels of model extension.

