### PR TITLE
Updated config key for allowsMultipleOrdersPerCart function in CartSessionManager

### DIFF
--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -30,7 +30,7 @@ class CartSessionManager implements CartSessionInterface
 
     public function allowsMultipleOrdersPerCart(): bool
     {
-        return config('lunar.cart_session.allow_multiple_per_order', false);
+        return config('lunar.cart_session.allow_multiple_orders_per_cart', false);
     }
 
     /**


### PR DESCRIPTION
Replaced a typo in the `allowsMultipleOrdersPerCart` function in `packages/core/src/Managers/CartSessionManager.php`

the function was trying to access the the `cart_session` config with a wrong key: `allowsMultipleOrdersPerCart`. I replaced it with the key that was actually in the config: `allow_multiple_orders_per_cart`