### PR TITLE
Allow product association types to be customised

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php
@@ -52,11 +52,7 @@ class ManageProductAssociations extends BaseManageRelatedRecords
                     }),
                 Forms\Components\Select::make('type')
                     ->required()
-                    ->options([
-                        ProductAssociation::ALTERNATE => 'Alternate',
-                        ProductAssociation::CROSS_SELL => 'Cross-Sell',
-                        ProductAssociation::UP_SELL => 'Upsell',
-                    ]),
+                    ->options(ProductAssociation::getTypes()),
             ]);
     }
 
@@ -82,7 +78,11 @@ class ManageProductAssociations extends BaseManageRelatedRecords
                     ->label(__('lunarpanel::product.table.name.label')),
                 Tables\Columns\TextColumn::make('target.variants.sku')
                     ->label('SKU'),
-                Tables\Columns\TextColumn::make('type'),
+                Tables\Columns\TextColumn::make('type')->formatStateUsing(function ($state) {
+                    $enum = config('lunar.products.association_types_enum', \Lunar\Base\Enums\ProductAssociation::class);
+
+                    return $enum::tryFrom($state)?->label() ?: $state;
+                }),
             ])
             ->filters([
                 //

--- a/packages/core/config/products.php
+++ b/packages/core/config/products.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'association_types_enum' => \Lunar\Base\Enums\ProductAssociation::class,
+];

--- a/packages/core/resources/lang/de/base.php
+++ b/packages/core/resources/lang/de/base.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'product-association-types' => [
+        'cross-sell' => 'Cross-Selling',
+        'up-sell' => 'Up-Selling',
+        'alternate' => 'Alternative',
+    ],
+];

--- a/packages/core/resources/lang/en/base.php
+++ b/packages/core/resources/lang/en/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Images',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Cross Sell',
+        'up-sell' => 'Up Sell',
+        'alternate' => 'Alternate',
+    ],
 ];

--- a/packages/core/resources/lang/es/base.php
+++ b/packages/core/resources/lang/es/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Imágenes',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Venta cruzada',
+        'up-sell' => 'Venta adicional',
+        'alternate' => 'Alternativa',
+    ],
 ];

--- a/packages/core/resources/lang/fr/base.php
+++ b/packages/core/resources/lang/fr/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Images',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Vente croisée',
+        'up-sell' => 'Montée en gamme',
+        'alternate' => 'Alternative',
+    ],
 ];

--- a/packages/core/resources/lang/hu/base.php
+++ b/packages/core/resources/lang/hu/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Képek',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Keresztértékesítés',
+        'up-sell' => 'Felülértékesítés',
+        'alternate' => 'Alternatíva',
+    ],
 ];

--- a/packages/core/resources/lang/nl/base.php
+++ b/packages/core/resources/lang/nl/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Afbeeldingen',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Cross-sell',
+        'up-sell'    => 'Up-sell',
+        'alternate'  => 'Alternatief',
+    ],
 ];

--- a/packages/core/resources/lang/nl/base.php
+++ b/packages/core/resources/lang/nl/base.php
@@ -8,7 +8,7 @@ return [
     ],
     'product-association-types' => [
         'cross-sell' => 'Cross-sell',
-        'up-sell'    => 'Up-sell',
-        'alternate'  => 'Alternatief',
+        'up-sell' => 'Up-sell',
+        'alternate' => 'Alternatief',
     ],
 ];

--- a/packages/core/resources/lang/pl/base.php
+++ b/packages/core/resources/lang/pl/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Obrazy',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Sprzedaż krzyżowa',
+        'up-sell' => 'Sprzedaż dodatkowa',
+        'alternate' => 'Alternatywa',
+    ],
 ];

--- a/packages/core/resources/lang/pt_BR/base.php
+++ b/packages/core/resources/lang/pt_BR/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Imagens',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Venda cruzada',
+        'up-sell' => 'Venda adicional',
+        'alternate' => 'Alternativa',
+    ],
 ];

--- a/packages/core/resources/lang/ro/base.php
+++ b/packages/core/resources/lang/ro/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Imagini',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Vânzare încrucișată',
+        'up-sell' => 'Vânzare superioară',
+        'alternate' => 'Alternativă',
+    ],
 ];

--- a/packages/core/resources/lang/tr/base.php
+++ b/packages/core/resources/lang/tr/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Görseller',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Çapraz satış',
+        'up-sell' => 'Üst satış',
+        'alternate' => 'Alternatif',
+    ],
 ];

--- a/packages/core/resources/lang/vi/base.php
+++ b/packages/core/resources/lang/vi/base.php
@@ -6,4 +6,9 @@ return [
             'images' => 'Hình ảnh',
         ],
     ],
+    'product-association-types' => [
+        'cross-sell' => 'Bán chéo',
+        'up-sell' => 'Bán nâng cấp',
+        'alternate' => 'Thay thế',
+    ],
 ];

--- a/packages/core/src/Base/Enums/Concerns/ProvidesProductAssociationType.php
+++ b/packages/core/src/Base/Enums/Concerns/ProvidesProductAssociationType.php
@@ -2,6 +2,11 @@
 
 namespace Lunar\Base\Enums\Concerns;
 
+use Lunar\Base\Enums\ProductAssociation;
+
+/**
+ * @mixin ProductAssociation
+ */
 interface ProvidesProductAssociationType
 {
     public function label(): string;

--- a/packages/core/src/Base/Enums/Concerns/ProvidesProductAssociationType.php
+++ b/packages/core/src/Base/Enums/Concerns/ProvidesProductAssociationType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lunar\Base\Enums\Concerns;
+
+interface ProvidesProductAssociationType
+{
+    public function label(): string;
+}

--- a/packages/core/src/Base/Enums/ProductAssociation.php
+++ b/packages/core/src/Base/Enums/ProductAssociation.php
@@ -2,7 +2,6 @@
 
 namespace Lunar\Base\Enums;
 
-
 use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
 
 enum ProductAssociation: string implements ProvidesProductAssociationType

--- a/packages/core/src/Base/Enums/ProductAssociation.php
+++ b/packages/core/src/Base/Enums/ProductAssociation.php
@@ -13,9 +13,9 @@ enum ProductAssociation: string implements ProvidesProductAssociationType
     public function label(): string
     {
         return match ($this) {
-            self::CROSS_SELL => 'Cross Sell',
-            self::UP_SELL => 'Up Sell',
-            self::ALTERNATE => 'Alternate',
+            self::CROSS_SELL => __('lunar::base.product-association-types.cross-sell'),
+            self::UP_SELL => __('lunar::base.product-association-types.up-sell'),
+            self::ALTERNATE => __('lunar::base.product-association-types.alternate'),
         };
     }
 }

--- a/packages/core/src/Base/Enums/ProductAssociation.php
+++ b/packages/core/src/Base/Enums/ProductAssociation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Lunar\Base\Enums;
+
+
+use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
+
+enum ProductAssociation: string implements ProvidesProductAssociationType
+{
+    case CROSS_SELL = 'cross-sell';
+    case UP_SELL = 'up-sell';
+    case ALTERNATE = 'alternate';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CROSS_SELL => 'Cross Sell',
+            self::UP_SELL => 'Up Sell',
+            self::ALTERNATE => 'Alternate',
+        };
+    }
+}

--- a/packages/core/src/Jobs/Products/Associations/Associate.php
+++ b/packages/core/src/Jobs/Products/Associations/Associate.php
@@ -69,7 +69,7 @@ class Associate implements ShouldQueue
                 $this->targets->map(function ($model) {
                     return [
                         'product_target_id' => $model->id,
-                        'type' => $this->type->value,
+                        'type' => $this->type?->value,
                     ];
                 })
             );

--- a/packages/core/src/Jobs/Products/Associations/Associate.php
+++ b/packages/core/src/Jobs/Products/Associations/Associate.php
@@ -37,12 +37,12 @@ class Associate implements ShouldQueue
     /**
      * The product association type.
      */
-    protected ?ProvidesProductAssociationType $type = null;
+    protected ProvidesProductAssociationType $type;
 
     /**
      * Create a new job instance.
      */
-    public function __construct(ProductContract $product, mixed $targets, ?ProvidesProductAssociationType $type = null)
+    public function __construct(ProductContract $product, mixed $targets, ProvidesProductAssociationType $type)
     {
         if (is_array($targets)) {
             $targets = collect($targets);
@@ -69,7 +69,7 @@ class Associate implements ShouldQueue
                 $this->targets->map(function ($model) {
                     return [
                         'product_target_id' => $model->id,
-                        'type' => $this->type?->value,
+                        'type' => $this->type->value,
                     ];
                 })
             );

--- a/packages/core/src/Jobs/Products/Associations/Associate.php
+++ b/packages/core/src/Jobs/Products/Associations/Associate.php
@@ -35,7 +35,7 @@ class Associate implements ShouldQueue
     protected ProductContract $product;
 
     /**
-     * The product association type
+     * The product association type.
      */
     protected ?ProvidesProductAssociationType $type = null;
 

--- a/packages/core/src/Jobs/Products/Associations/Associate.php
+++ b/packages/core/src/Jobs/Products/Associations/Associate.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
 use Lunar\Facades\DB;
 use Lunar\Models\Contracts\Product as ProductContract;
 use Lunar\Models\Product;
@@ -34,19 +35,14 @@ class Associate implements ShouldQueue
     protected ProductContract $product;
 
     /**
-     * The SKU for the generated variant.
-     *
-     * @var string
+     * The product association type
      */
-    protected $type = null;
+    protected ?ProvidesProductAssociationType $type = null;
 
     /**
      * Create a new job instance.
-     *
-     * @param  mixed  $targets
-     * @param  string  $type
      */
-    public function __construct(ProductContract $product, $targets, $type = null)
+    public function __construct(ProductContract $product, mixed $targets, ?ProvidesProductAssociationType $type = null)
     {
         if (is_array($targets)) {
             $targets = collect($targets);
@@ -73,7 +69,7 @@ class Associate implements ShouldQueue
                 $this->targets->map(function ($model) {
                     return [
                         'product_target_id' => $model->id,
-                        'type' => $this->type,
+                        'type' => $this->type->value,
                     ];
                 })
             );

--- a/packages/core/src/Jobs/Products/Associations/Associate.php
+++ b/packages/core/src/Jobs/Products/Associations/Associate.php
@@ -37,12 +37,12 @@ class Associate implements ShouldQueue
     /**
      * The product association type.
      */
-    protected ProvidesProductAssociationType $type;
+    protected ProvidesProductAssociationType|string $type;
 
     /**
      * Create a new job instance.
      */
-    public function __construct(ProductContract $product, mixed $targets, ProvidesProductAssociationType $type)
+    public function __construct(ProductContract $product, mixed $targets, ProvidesProductAssociationType|string $type)
     {
         if (is_array($targets)) {
             $targets = collect($targets);
@@ -69,7 +69,7 @@ class Associate implements ShouldQueue
                 $this->targets->map(function ($model) {
                     return [
                         'product_target_id' => $model->id,
-                        'type' => $this->type->value,
+                        'type' => is_string($this->type) ? $this->type : $this->type->value,
                     ];
                 })
             );

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -113,6 +113,7 @@ class LunarServiceProvider extends ServiceProvider
         'orders',
         'payments',
         'pricing',
+        'products',
         'search',
         'shipping',
         'taxes',

--- a/packages/core/src/Models/Contracts/Product.php
+++ b/packages/core/src/Models/Contracts/Product.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
 
 interface Product
 {
@@ -56,12 +57,12 @@ interface Product
     /**
      * Associate a product to another with a type.
      */
-    public function associate(mixed $product, string $type): void;
+    public function associate(mixed $product, ProvidesProductAssociationType $type): void;
 
     /**
      * Dissociate a product to another with a type.
      */
-    public function dissociate(mixed $product, ?string $type = null): void;
+    public function dissociate(mixed $product, ?ProvidesProductAssociationType $type = null): void;
 
     /**
      * Return the customer groups relationship.

--- a/packages/core/src/Models/Contracts/ProductAssociation.php
+++ b/packages/core/src/Models/Contracts/ProductAssociation.php
@@ -4,6 +4,7 @@ namespace Lunar\Models\Contracts;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
 
 interface ProductAssociation
 {
@@ -35,5 +36,5 @@ interface ProductAssociation
     /**
      * Apply the type scope.
      */
-    public function scopeType(Builder $query, string $type): Builder;
+    public function scopeType(Builder $query, ProvidesProductAssociationType $type): Builder;
 }

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Casts\AsAttributeData;
+use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
 use Lunar\Base\HasThumbnailImage;
 use Lunar\Base\Traits\HasChannels;
 use Lunar\Base\Traits\HasCustomerGroups;
@@ -144,7 +145,7 @@ class Product extends BaseModel implements Contracts\Product, HasThumbnailImage,
         return $this->hasMany(ProductAssociation::modelClass(), 'product_target_id');
     }
 
-    public function associate(mixed $product, string $type): void
+    public function associate(mixed $product, ProvidesProductAssociationType $type): void
     {
         Associate::dispatch($this, $product, $type);
     }
@@ -152,7 +153,7 @@ class Product extends BaseModel implements Contracts\Product, HasThumbnailImage,
     /**
      * Dissociate a product to another with a type.
      */
-    public function dissociate(mixed $product, ?string $type = null): void
+    public function dissociate(mixed $product, ?ProvidesProductAssociationType $type = null): void
     {
         Dissociate::dispatch($this, $product, $type);
     }

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -145,7 +145,7 @@ class Product extends BaseModel implements Contracts\Product, HasThumbnailImage,
         return $this->hasMany(ProductAssociation::modelClass(), 'product_target_id');
     }
 
-    public function associate(mixed $product, ProvidesProductAssociationType $type): void
+    public function associate(mixed $product, ProvidesProductAssociationType|string $type): void
     {
         Associate::dispatch($this, $product, $type);
     }
@@ -153,7 +153,7 @@ class Product extends BaseModel implements Contracts\Product, HasThumbnailImage,
     /**
      * Dissociate a product to another with a type.
      */
-    public function dissociate(mixed $product, ?ProvidesProductAssociationType $type = null): void
+    public function dissociate(mixed $product, ProvidesProductAssociationType|string|null $type = null): void
     {
         Dissociate::dispatch($this, $product, $type);
     }

--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -6,8 +6,10 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
+use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\ProductAssociationFactory;
+use Lunar\Base\Enums\ProductAssociation as ProductAssociationEnum;
 
 /**
  * @property int $id
@@ -24,16 +26,25 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
 
     /**
      * Define the cross-sell type.
+     *
+     * @deprecated 1.2.0
+     * @see \Lunar\Base\Enums\ProductAssociation
      */
     const CROSS_SELL = 'cross-sell';
 
     /**
      * Define the upsell type.
+     *
+     * @deprecated 1.2.0
+     * @see \Lunar\Base\Enums\ProductAssociation
      */
     const UP_SELL = 'up-sell';
 
     /**
      * Define the alternate type.
+     *
+     * @deprecated 1.2.0
+     * @see \Lunar\Base\Enums\ProductAssociation
      */
     const ALTERNATE = 'alternate';
 
@@ -77,7 +88,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeCrossSell(Builder $query): Builder
     {
-        return $query->type(self::CROSS_SELL);
+        return $query->type(ProductAssociationEnum::CROSS_SELL->value);
     }
 
     /**
@@ -85,7 +96,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeUpSell(Builder $query): Builder
     {
-        return $query->type(self::UP_SELL);
+        return $query->type(ProductAssociationEnum::UP_SELL->value);
     }
 
     /**
@@ -93,14 +104,25 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeAlternate(Builder $query): Builder
     {
-        return $query->type(self::ALTERNATE);
+        return $query->type(ProductAssociationEnum::ALTERNATE->value);
     }
 
     /**
      * Apply the type scope.
      */
-    public function scopeType(Builder $query, string $type): Builder
+    public function scopeType(Builder $query, ProvidesProductAssociationType $type): Builder
     {
-        return $query->whereType($type);
+        return $query->whereType($type->value);
+    }
+
+    public static function getTypes(): array
+    {
+        $enum = config('lunar.products.association_types_enum', \Lunar\Base\Enums\ProductAssociation::class);
+
+        return collect($enum::cases())->mapWithKeys(function ($item) {
+            return [
+                $item->value => $item->label(),
+            ];
+        })->toArray();
     }
 }

--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -88,7 +88,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeCrossSell(Builder $query): Builder
     {
-        return $query->type(ProductAssociationEnum::CROSS_SELL->value);
+        return $query->type(ProductAssociationEnum::CROSS_SELL);
     }
 
     /**
@@ -96,7 +96,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeUpSell(Builder $query): Builder
     {
-        return $query->type(ProductAssociationEnum::UP_SELL->value);
+        return $query->type(ProductAssociationEnum::UP_SELL);
     }
 
     /**
@@ -104,7 +104,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeAlternate(Builder $query): Builder
     {
-        return $query->type(ProductAssociationEnum::ALTERNATE->value);
+        return $query->type(ProductAssociationEnum::ALTERNATE);
     }
 
     /**

--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -110,9 +110,13 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
     /**
      * Apply the type scope.
      */
-    public function scopeType(Builder $query, ProvidesProductAssociationType $type): Builder
+    public function scopeType(Builder $query, ProvidesProductAssociationType|string $type): Builder
     {
-        return $query->whereType($type->value);
+        if ($type instanceof ProvidesProductAssociationType) {
+            $type = $type->value;
+        }
+
+        return $query->where('type', '=', $type);
     }
 
     public static function getTypes(): array

--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -7,9 +7,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Enums\Concerns\ProvidesProductAssociationType;
+use Lunar\Base\Enums\ProductAssociation as ProductAssociationEnum;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Database\Factories\ProductAssociationFactory;
-use Lunar\Base\Enums\ProductAssociation as ProductAssociationEnum;
 
 /**
  * @property int $id

--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -112,11 +112,11 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function scopeType(Builder $query, ProvidesProductAssociationType|string $type): Builder
     {
-        if ($type instanceof ProvidesProductAssociationType) {
-            $type = $type->value;
-        }
-
-        return $query->where('type', '=', $type);
+        return $query->where(
+            'type',
+            '=',
+            is_string($type) ? $type : $type->value
+        );
     }
 
     public static function getTypes(): array

--- a/tests/core/Unit/Models/ProductTest.php
+++ b/tests/core/Unit/Models/ProductTest.php
@@ -407,9 +407,9 @@ test('can associate multiple products', function () {
     $targetA = Product::factory()->create();
     $targetB = Product::factory()->create();
 
-    $parent->associate([$targetA, $targetB], ProductAssociation::UP_SELL);
+    $parent->associate([$targetA, $targetB], \Lunar\Base\Enums\ProductAssociation::UP_SELL);
 
-    $assoc = $parent->associations()->type(ProductAssociation::UP_SELL)->get();
+    $assoc = $parent->associations()->type(\Lunar\Base\Enums\ProductAssociation::UP_SELL)->get();
 
     expect($assoc)->toHaveCount(2);
 });
@@ -418,12 +418,12 @@ test('can associate products via helper', function () {
     $parent = Product::factory()->create();
     $target = Product::factory()->create();
 
-    $parent->associate($target, 'custom-type');
+    $parent->associate($target, \Lunar\Base\Enums\ProductAssociation::UP_SELL);
 
-    $assoc = $parent->associations()->type('custom-type')->get();
+    $assoc = $parent->associations()->type(\Lunar\Base\Enums\ProductAssociation::UP_SELL)->get();
 
-    expect($assoc)->toHaveCount(1);
-    expect($assoc->first()->type)->toEqual('custom-type');
+    expect($assoc)->toHaveCount(1)
+        ->and($assoc->first()->type)->toEqual(\Lunar\Base\Enums\ProductAssociation::UP_SELL->value);
 });
 
 test('can remove all associations', function () {
@@ -450,21 +450,23 @@ test('can only remove associations of a certain type', function () {
     ProductAssociation::factory()->create([
         'product_parent_id' => $parent,
         'product_target_id' => $target,
-        'type' => 'cross-sell',
+        'type' => \Lunar\Base\Enums\ProductAssociation::CROSS_SELL->value,
     ]);
 
     ProductAssociation::factory()->create([
         'product_parent_id' => $parent,
         'product_target_id' => $target,
-        'type' => 'up-sell',
+        'type' => \Lunar\Base\Enums\ProductAssociation::UP_SELL->value,
     ]);
 
     expect($parent->refresh()->associations)->toHaveCount(2);
 
-    $parent->dissociate($target, 'cross-sell');
+    $parent->dissociate($target, \Lunar\Base\Enums\ProductAssociation::CROSS_SELL);
 
-    expect($parent->refresh()->associations)->toHaveCount(1);
-    expect($parent->refresh()->associations->first()->type)->toEqual('up-sell');
+    expect($parent->refresh()->associations)->toHaveCount(1)
+        ->and($parent->refresh()->associations->first()->type)->toEqual(
+            \Lunar\Base\Enums\ProductAssociation::UP_SELL->value
+        );
 });
 
 test('can have collections relationship', function () {
@@ -472,11 +474,11 @@ test('can have collections relationship', function () {
     $product = Product::factory()->create();
     $product->collections()->sync($collection);
 
-    expect($product->collections)->toBeInstanceOf(EloquentCollection::class);
-    expect($product->collections)->toHaveCount(1);
-    expect($product->collections->first())->toBeInstanceOf(Collection::class);
-    expect($product->collections->first()->pivot)->not->toBeNull();
-    expect($product->collections->first()->pivot->position)->not->toBeNull();
+    expect($product->collections)->toBeInstanceOf(EloquentCollection::class)
+        ->and($product->collections)->toHaveCount(1)
+        ->and($product->collections->first())->toBeInstanceOf(Collection::class)
+        ->and($product->collections->first()->pivot)->not->toBeNull()
+        ->and($product->collections->first()->pivot->position)->not->toBeNull();
 });
 
 test('can retrieve prices', function () {


### PR DESCRIPTION
PR to allow product association types to be customised.

- Deprecates the use of constants like `UP_SELL` on the model
- Introduces a new enum to handle association types
- Allow the enum to be replaced in config by developers.

Closes #2337 