### PR TITLE
Add ordering by position to attribute queries

### DIFF
--- a/packages/admin/src/Support/Forms/Components/AttributeSelector.php
+++ b/packages/admin/src/Support/Forms/Components/AttributeSelector.php
@@ -65,7 +65,7 @@ class AttributeSelector extends CheckboxList
             $type = $this->attributableType;
         }
 
-        return AttributeGroup::whereAttributableType($type)->get();
+        return AttributeGroup::whereAttributableType($type)->orderBy('position')->get();
     }
 
     public function getSelectedAttributes($groupId)
@@ -75,6 +75,6 @@ class AttributeSelector extends CheckboxList
 
     public function getAttributes($groupId)
     {
-        return Attribute::where('attribute_group_id', $groupId)->get();
+        return Attribute::where('attribute_group_id', $groupId)->orderBy('position')->get();
     }
 }


### PR DESCRIPTION
In the panel, AtrributeGroup and Attibute position is not used to when configuring product type attributes