### PR TITLE
Allow shipping rates to be disabled

### DIFF
--- a/packages/table-rate-shipping/resources/lang/en/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/en/relationmanagers.php
@@ -47,8 +47,15 @@ return [
             ],
         ],
         'table' => [
+            'enabled' => [
+                'label' => 'Enabled',
+            ],
+            'disabled' => [
+                'label' => 'disabled',
+            ],
             'shipping_method' => [
                 'label' => 'Shipping Method',
+                'disabled' => 'Disabled',
             ],
             'price' => [
                 'label' => 'Price',

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource/Pages/ManageShippingRates.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource/Pages/ManageShippingRates.php
@@ -2,6 +2,8 @@
 
 namespace Lunar\Shipping\Filament\Resources\ShippingZoneResource\Pages;
 
+use Awcodes\FilamentBadgeableColumn\Components\Badge;
+use Awcodes\FilamentBadgeableColumn\Components\BadgeableColumn;
 use Awcodes\Shout\Components\Shout;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -147,10 +149,15 @@ class ManageShippingRates extends ManageRelatedRecords
     public function table(Table $table): Table
     {
         return $table->columns([
-            TextColumn::make('shippingMethod.name')
-                ->label(
-                    __('lunarpanel.shipping::relationmanagers.shipping_rates.table.shipping_method.label')
-                ),
+            BadgeableColumn::make('shippingMethod.name')
+                ->separator('')
+                ->suffixBadges([
+                    Badge::make('default')
+                        ->label(__('lunarpanel.shipping::relationmanagers.shipping_rates.table.shipping_method.disabled'))
+                        ->color('warning')
+                        ->visible(fn (Model $record) => ! $record->enabled),
+                ])
+                ->label(__('lunarpanel.shipping::relationmanagers.shipping_rates.table.shipping_method.label')),
             TextColumn::make('basePrices.0')->formatStateUsing(
                 fn ($state = null) => $state->price->formatted
             )->label(
@@ -178,6 +185,21 @@ class ManageShippingRates extends ManageRelatedRecords
                 static::saveShippingRate($shippingRate, $data);
             }),
             Tables\Actions\DeleteAction::make()->requiresConfirmation(),
+            Tables\Actions\Action::make('disable')->color('warning')->action(function (ShippingRate $shippingRate) {
+                $shippingRate->updateQuietly([
+                    'enabled' => false,
+                ]);
+            })->hidden(
+                fn (ShippingRate $shippingRate) => ! $shippingRate->enabled
+            ),
+            Tables\Actions\Action::make('enable')->color('success')->action(function (ShippingRate $shippingRate) {
+                $shippingRate->updateQuietly([
+                    'enabled' => true,
+                ]);
+            })->hidden(
+                fn (ShippingRate $shippingRate) => (bool) $shippingRate->enabled
+            ),
+
         ]);
     }
 

--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -151,6 +151,9 @@ class ShippingRateResolver
 
         foreach ($zones as $zone) {
             $zoneShippingRates = $zone->rates
+                ->reject(function ($state) {
+                    return !$state->enabled;
+                })
                 ->reject(function ($rate) {
                     $method = $rate->shippingMethod()->customerGroup($this->customerGroups)->first();
 

--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -152,7 +152,7 @@ class ShippingRateResolver
         foreach ($zones as $zone) {
             $zoneShippingRates = $zone->rates
                 ->reject(function ($state) {
-                    return !$state->enabled;
+                    return ! $state->enabled;
                 })
                 ->reject(function ($rate) {
                     $method = $rate->shippingMethod()->customerGroup($this->customerGroups)->first();

--- a/tests/shipping/Unit/Resolvers/ShippingRateResolverTest.php
+++ b/tests/shipping/Unit/Resolvers/ShippingRateResolverTest.php
@@ -454,3 +454,97 @@ test('doesnt_include_unshippable_items_in_calculations', function () {
 
     expect($shippingRates)->toHaveCount(0);
 });
+
+test('will not resolve rates which are not enabled.', function () {
+    $currency = Currency::factory()->create([
+        'default' => true,
+    ]);
+
+    $country = Country::factory()->create();
+
+    TaxClass::factory()->create([
+        'default' => true,
+    ]);
+
+    $shippingZone = ShippingZone::factory()->create([
+        'type' => 'postcodes',
+    ]);
+
+    $shippingZone->postcodes()->create([
+        'postcode' => 'AB1',
+    ]);
+
+    $shippingZone->countries()->attach($country);
+
+    $shippingMethod = ShippingMethod::factory()->create([
+        'driver' => 'ship-by',
+        'data' => [],
+        'stock_available' => 0,
+    ]);
+
+    $customerGroup = \Lunar\Models\CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+    $shippingMethod->customerGroups()->sync([
+        $customerGroup->id => ['enabled' => true, 'visible' => true, 'starts_at' => now(), 'ends_at' => null],
+    ]);
+
+    $shippingRate = \Lunar\Shipping\Models\ShippingRate::factory()->create([
+        'shipping_method_id' => $shippingMethod->id,
+        'shipping_zone_id' => $shippingZone->id,
+        'enabled' => false,
+    ]);
+
+    $shippingRate->prices()->createMany([
+        [
+            'price' => 600,
+            'min_quantity' => 1,
+            'currency_id' => $currency->id,
+        ],
+        [
+            'price' => 500,
+            'min_quantity' => 700,
+            'currency_id' => $currency->id,
+        ],
+        [
+            'price' => 0,
+            'min_quantity' => 800,
+            'currency_id' => $currency->id,
+        ],
+    ]);
+
+    $cart = $this->createCart($currency, 500);
+
+    $cart->lines()->delete();
+
+    $purchasable = ProductVariant::factory()->create();
+    $purchasable->shippable = true;
+
+    Price::factory()->create([
+        'price' => 200,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->shippingAddress()->create(
+        CartAddress::factory()->make([
+            'country_id' => $country->id,
+            'state' => null,
+            'postcode' => 'AB1 1CD',
+        ])->toArray()
+    );
+
+    $shippingRates = Shipping::shippingRates(
+        $cart->refresh()->calculate()
+    )->get();
+
+    expect($shippingRates)->toHaveCount(0);
+});


### PR DESCRIPTION
Currently the `enabled` column on a Shipping Rate doesn't actually get taken into account during resolution. This PR looks to add the `enabled` check to the `ShippingRateResolver` whilst also providing an action in the panel to toggle this value.