### PR TITLE
Revert breadcrumbs back to ancestors

### DIFF
--- a/packages/admin/src/Filament/Resources/CollectionResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource.php
@@ -47,7 +47,7 @@ class CollectionResource extends BaseResource
             ]) => $collection->group->name,
         ];
 
-        foreach ($collection->children as $childCollection) {
+        foreach ($collection->ancestors as $childCollection) {
             $crumbs[
             CollectionResource::getUrl('edit', [
                 'record' => $childCollection,


### PR DESCRIPTION
PR to revert #2249 as this is seems to have broken breadcrumbs on collections. Suggest we have a look at performance in more depth as the collection tree will also stall if you have over 1k collections in a group, suggesting there is a bigger issue at player with that.

Closes #2360 