### PR TITLE
Ensure PDF outputs when an order has no shipping address

### DIFF
--- a/packages/admin/resources/views/pdf/order.blade.php
+++ b/packages/admin/resources/views/pdf/order.blade.php
@@ -114,6 +114,7 @@
                                     @endif
                                 </td>
 
+                                @if ($record->shippingAddress)
                                 <td align="left" width="33%">
                                     <h3>Shipping</h3>
                                     {{ $record->shippingAddress->fullName }}<br>
@@ -135,6 +136,7 @@
                                     {{ $record->shippingAddress->postcode }}<br>
                                     {{ $record->shippingAddress->country->name }}<br>
                                 </td>
+                                @endif
 
                                 <td align="right" width="33%">
                                 </td>


### PR DESCRIPTION
This PR fixes a 500 error from being displayed when a PDF is generated for an order with no shipping address.