### PR TITLE
Prevent activity log button being unreachable

### DIFF
--- a/packages/admin/resources/views/livewire/components/activity-log-feed.blade.php
+++ b/packages/admin/resources/views/livewire/components/activity-log-feed.blade.php
@@ -18,7 +18,7 @@
         </form>
     </div>
 
-    <div class="relative pt-8 -ml-[5px] z-10">
+    <div class="relative pt-8 -ml-[5px] z-10 pointer-events-none">
         <span class="absolute inset-y-0 left-5 w-[2px] bg-gray-200 dark:bg-gray-600 rounded-full"></span>
 
         <div class="flow-root">
@@ -30,7 +30,7 @@
                             {{ $log['date']->format('F jS, Y') }}
                         </p>
 
-                        <ul class="mt-4 space-y-6">
+                        <ul class="mt-4 space-y-6 pointer-events-auto">
                             @foreach ($log['items'] as $item)
                                 @php
                                     $logUserName = $item['log']->causer ? ($item['log']->causer->fullName ?: $item['log']->causer->name) : null;

--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -72,7 +72,7 @@ trait HasModelExtending
             return parent::getTable();
         }
 
-        if (!empty($this->table)) {
+        if (! empty($this->table)) {
             return $this->table;
         }
 
@@ -98,7 +98,7 @@ trait HasModelExtending
         $reflection = new ReflectionClass($modelClass);
         $defaultProperties = $reflection->getDefaultProperties();
 
-        if (!empty($defaultProperties['table'])) {
+        if (! empty($defaultProperties['table'])) {
             return $defaultProperties['table'];
         }
 

--- a/tests/core/Stubs/Models/Custom/DeepCustomProduct.php
+++ b/tests/core/Stubs/Models/Custom/DeepCustomProduct.php
@@ -8,6 +8,4 @@ namespace Lunar\Tests\Core\Stubs\Models\Custom;
  * This model extends CustomProduct which already extends \Lunar\Models\Product.
  * This creates a 3-level inheritance chain to test the table prefix bug fix.
  */
-class DeepCustomProduct extends CustomProduct
-{
-}
+class DeepCustomProduct extends CustomProduct {}


### PR DESCRIPTION
Currently the activity log feed overlaps the submit button, meaning in some cases users cannot submit comments. This PR prevents pointer events on that overlap, but not on the items themselves, so whatever happens you can click the submit button.