### PR TITLE
Fix collection breadcrumbs order on collections

### DIFF
--- a/packages/admin/src/Filament/Resources/CollectionResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource.php
@@ -47,7 +47,7 @@ class CollectionResource extends BaseResource
             ]) => $collection->group->name,
         ];
 
-        foreach ($collection->ancestors as $childCollection) {
+        foreach ($collection->ancestors->reverse() as $childCollection) {
             $crumbs[
             CollectionResource::getUrl('edit', [
                 'record' => $childCollection,

--- a/packages/admin/src/Filament/Resources/CollectionResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionResource.php
@@ -47,7 +47,7 @@ class CollectionResource extends BaseResource
             ]) => $collection->group->name,
         ];
 
-        foreach ($collection->ancestors->reverse() as $childCollection) {
+        foreach ($collection->ancestors()->defaultOrder()->get() as $childCollection) {
             $crumbs[
             CollectionResource::getUrl('edit', [
                 'record' => $childCollection,


### PR DESCRIPTION
Currently breadcrumbs are ordered incorrectly for sub collections, take this tree for example:

<img width="1230" height="395" alt="image" src="https://github.com/user-attachments/assets/b9ea6555-2f00-408c-9340-c7416513276c" />

If we go into the `Test B Child D Grandchild A Child A` collection, we see the breadcrumbs appear like so:

<img width="981" height="707" alt="image" src="https://github.com/user-attachments/assets/1abc6408-00c3-42b2-8e86-6f93508471dc" />

Which is incorrect as `->ancestors` will just be ordering the records based on their default Laravel sorting, not the order they appear in the tree.

This PR looks to solve this by introducing the nested set `defaultOrder` sorting to the query, afterwards the result is:

<img width="1054" height="563" alt="image" src="https://github.com/user-attachments/assets/b5a6420e-85f5-44a5-962a-f8c7839186f8" />
