### PR TITLE
fix collection group resource permission

### DIFF
--- a/packages/admin/src/Filament/Resources/CollectionGroupResource.php
+++ b/packages/admin/src/Filament/Resources/CollectionGroupResource.php
@@ -15,7 +15,7 @@ use Lunar\Models\Contracts\CollectionGroup as CollectionGroupContract;
 
 class CollectionGroupResource extends BaseResource
 {
-    protected static ?string $permission = 'catalog:manage-products';
+    protected static ?string $permission = 'catalog:manage-collections';
 
     protected static ?string $model = CollectionGroupContract::class;
 


### PR DESCRIPTION

<img width="531" height="135" alt="image" src="https://github.com/user-attachments/assets/cf79cd5b-3c77-4d49-8e09-270f8c1d6562" />


In Access control screen, Manage Collections permission is described to manage collections and groups. however currently the menu/permission follows Manage Products. This PR is to fix the permission to follow the description