### PR TITLE
fix: dispatch SyncPriceCurrencies only when other sync_prices currenc…

### DIFF
--- a/packages/core/src/Observers/PriceObserver.php
+++ b/packages/core/src/Observers/PriceObserver.php
@@ -5,20 +5,29 @@ namespace Lunar\Observers;
 use Illuminate\Contracts\Events\ShouldHandleEventsAfterCommit;
 use Lunar\Jobs\Currencies\SyncPriceCurrencies;
 use Lunar\Models\Contracts\Price;
+use Lunar\Models\Currency;
 
 class PriceObserver implements ShouldHandleEventsAfterCommit
 {
     public function created(Price $price): void
     {
-        if ($price->currency->default) {
+        if ($price->currency->default && $this->hasCurrenciesToSync($price)) {
             SyncPriceCurrencies::dispatch($price);
         }
     }
 
     public function updated(Price $price): void
     {
-        if ($price->currency->default) {
+        if ($price->currency->default && $this->hasCurrenciesToSync($price)) {
             SyncPriceCurrencies::dispatch($price);
         }
+    }
+
+    protected function hasCurrenciesToSync(Price $price): bool
+    {
+        return Currency::query()
+            ->where('id', '!=', $price->currency_id)
+            ->where('sync_prices', true)
+            ->exists();
     }
 }


### PR DESCRIPTION
## Problem

`SyncPriceCurrencies` is dispatched on every price creation/update in the default currency (see `PriceObserver`). The job then loads all other currencies with `sync_prices = true` and syncs prices using exchange rates.

When there is only one currency (or no other currency with `sync_prices` enabled), that query returns an empty set and the job does nothing—but it is still queued and executed on every price change, adding unnecessary queue and DB overhead.

## Solution

Add a guard in `PriceObserver`: only dispatch `SyncPriceCurrencies` when there exists at least one other currency with `sync_prices = true`. The condition matches the logic already used inside the job (`Currency::where('id', '!=', $price->currency_id)->where('sync_prices', true)`), so behavior in multi-currency setups is unchanged.

## Changes

- **`Observers/PriceObserver.php`**
  - Import `Lunar\Models\Currency`.
  - Add `hasCurrenciesToSync(Price $price): bool` that returns whether any other currency has `sync_prices` enabled.
  - In `created()` and `updated()`, dispatch the job only when `$price->currency->default && $this->hasCurrenciesToSync($price)`.

Single-currency installations no longer queue this job on every price change; multi-currency behavior is unchanged.