### PR TITLE
Add and enforce shipping:manage permission

### DIFF
--- a/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_permission.php
+++ b/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_permission.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Admin\Support\Facades\LunarPanel;
+use Lunar\Base\Migration;
+use Spatie\Permission\Models\Permission;
+
+class AddCanManagePermission extends Migration
+{
+    public function up()
+    {
+        $guard = LunarPanel::getPanel()->getAuthGuard();
+
+        $tableNames = config('permission.table_names');
+
+        if (! Schema::hasTable($tableNames['permissions'])) {
+            return;
+        }
+
+        Permission::firstOrCreate([
+            'name' => 'shipping:manage',
+            'guard_name' => $guard,
+        ]);
+    }
+
+    public function down()
+    {
+        $tableNames = config('permission.table_names');
+
+        if (! Schema::hasTable($tableNames['permissions'])) {
+            return;
+        }
+
+        Permission::query()->where('name', 'shipping:manage')->delete();
+    }
+}

--- a/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_permission.php
+++ b/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_permission.php
@@ -9,7 +9,11 @@ class AddCanManagePermission extends Migration
 {
     public function up()
     {
-        $guard = LunarPanel::getPanel()->getAuthGuard();
+        try {
+            $guard = LunarPanel::getPanel()->getAuthGuard();
+        } catch (\Exception $e) {
+            return;
+        }
 
         $tableNames = config('permission.table_names');
 

--- a/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_permission.php
+++ b/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_permission.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Lunar\Admin\Support\Facades\LunarPanel;
 use Lunar\Base\Migration;

--- a/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_shipping_permission.php
+++ b/packages/table-rate-shipping/database/migrations/2026_02_16_100000_add_can_manage_shipping_permission.php
@@ -5,7 +5,7 @@ use Lunar\Admin\Support\Facades\LunarPanel;
 use Lunar\Base\Migration;
 use Spatie\Permission\Models\Permission;
 
-class AddCanManagePermission extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -37,4 +37,4 @@ class AddCanManagePermission extends Migration
 
         Permission::query()->where('name', 'shipping:manage')->delete();
     }
-}
+};

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingExclusionListResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingExclusionListResource.php
@@ -18,6 +18,8 @@ class ShippingExclusionListResource extends BaseResource
 {
     protected static ?string $model = ShippingExclusionList::class;
 
+    protected static ?string $permission = 'shipping:manage';
+
     protected static ?int $navigationSort = 1;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::End;

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -20,6 +20,7 @@ class ShippingMethodResource extends BaseResource
     protected static ?string $model = ShippingMethod::class;
 
     protected static ?string $permission = 'shipping:manage';
+
     protected static ?int $navigationSort = 1;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::End;

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -19,6 +19,7 @@ class ShippingMethodResource extends BaseResource
 {
     protected static ?string $model = ShippingMethod::class;
 
+    protected static ?string $permission = 'shipping:manage';
     protected static ?int $navigationSort = 1;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::End;

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource.php
@@ -23,6 +23,8 @@ class ShippingZoneResource extends BaseResource
 {
     protected static ?string $model = ShippingZone::class;
 
+    protected static ?string $permission = 'shipping:manage';
+
     protected static ?int $navigationSort = 1;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::End;


### PR DESCRIPTION
At the moment there is no enforcement of a permission for the table rate shipping resources in the panel, this PR adds that.