### PR TITLE
Fix list field on 1.5 / Filament 4

### DIFF
--- a/packages/core/src/FieldTypes/ListField.php
+++ b/packages/core/src/FieldTypes/ListField.php
@@ -2,11 +2,12 @@
 
 namespace Lunar\FieldTypes;
 
+use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
 use Lunar\Base\FieldType;
 use Lunar\Exceptions\FieldTypeException;
 
-class ListField implements FieldType, JsonSerializable
+class ListField implements FieldType, JsonSerializable, Arrayable
 {
     /**
      * @var array
@@ -67,5 +68,15 @@ class ListField implements FieldType, JsonSerializable
                 'max_items' => 'numeric|nullable',
             ],
         ];
+    }
+
+    /**
+     * Return the value as an array (implements Arrayable for Filament 4 compatibility).
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return (array) json_decode($this->value ?? '[]', associative: true);
     }
 }

--- a/packages/core/src/FieldTypes/ListField.php
+++ b/packages/core/src/FieldTypes/ListField.php
@@ -3,6 +3,7 @@
 namespace Lunar\FieldTypes;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use JsonSerializable;
 use Lunar\Base\FieldType;
 use Lunar\Exceptions\FieldTypeException;
@@ -75,6 +76,6 @@ class ListField implements Arrayable, FieldType, JsonSerializable
      */
     public function toArray(): array
     {
-        return (array) json_decode($this->value ?? '[]', associative: true);
+        return Arr::wrap((array) json_decode($this->value ?? '[]', associative: true));
     }
 }

--- a/packages/core/src/FieldTypes/ListField.php
+++ b/packages/core/src/FieldTypes/ListField.php
@@ -7,7 +7,7 @@ use JsonSerializable;
 use Lunar\Base\FieldType;
 use Lunar\Exceptions\FieldTypeException;
 
-class ListField implements FieldType, JsonSerializable, Arrayable
+class ListField implements Arrayable, FieldType, JsonSerializable
 {
     /**
      * @var array
@@ -72,8 +72,6 @@ class ListField implements FieldType, JsonSerializable, Arrayable
 
     /**
      * Return the value as an array (implements Arrayable for Filament 4 compatibility).
-     *
-     * @return array
      */
     public function toArray(): array
     {

--- a/tests/core/Unit/FieldTypes/ListFieldTest.php
+++ b/tests/core/Unit/FieldTypes/ListFieldTest.php
@@ -26,3 +26,15 @@ test('check does not allow non arrays', function () {
 
     new ListField('Not an array');
 });
+
+test('toArray returns associative array for keyed values', function () {
+    $field = new ListField([
+        'foo' => 'bar',
+        'baz' => 'qux',
+    ]);
+
+    expect($field->toArray())->toBe([
+        'foo' => 'bar',
+        'baz' => 'qux',
+    ]);
+});


### PR DESCRIPTION
The list field on the 1.5 beta currently fails with the error `json_decode(): Argument #1 ($json) must be of type string, Lunar\FieldTypes\ListField given`

this PR changes the field type to be arrayable to get around this.