### PR TITLE
Fix attribute fieldtypes in 1.5

### DIFF
--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -54,12 +54,13 @@ class AttributeData
             )
             ->formatStateUsing(function ($state) use ($attribute) {
                 if ($state instanceof FieldType) {
-                    return $state->getValue();
+                    $value = $state->getValue();
+                } else {
+                    $instance = new $attribute->type;
+                    $value = $instance->getValue();
                 }
 
-                $instance = new $attribute->type;
-
-                return $instance->getValue();
+                return is_string($value) && blank($value) ? null : $value;
             })
             ->mutateStateForValidationUsing(function ($state) {
                 if ($state instanceof FieldType) {

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -53,11 +53,10 @@ class AttributeData
                 $attribute->translate('name')
             )
             ->formatStateUsing(function ($state) use ($attribute) {
-                if ($state instanceof FieldType) {
-                    $value = $state->getValue();
-                } else {
-                    $instance = new $attribute->type;
-                    $value = $instance->getValue();
+                $value = $state instanceof FieldType ? $state->getValue() : $state;
+
+                if ($value === null) {
+                    $value = (new $attribute->type)->getValue();
                 }
 
                 return is_string($value) && blank($value) ? null : $value;

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component as Livewire;
 use Lunar\Admin\Support\Facades\AttributeData;
@@ -48,6 +49,30 @@ class Attributes extends Group
     public function getKey(bool $isAbsolute = true): ?string
     {
         return 'attributeData'.$this->modelClassOverride;
+    }
+
+    public function loadStateFromRelationships(bool $hydrateAll = false): void
+    {
+        parent::loadStateFromRelationships($hydrateAll);
+
+        $rawState = $this->getRawState();
+
+        if (! ($rawState instanceof Arrayable || is_array($rawState))) {
+            return;
+        }
+
+        $data = $rawState instanceof Arrayable ? $rawState->toArray() : $rawState;
+
+        foreach ($data as $key => $value) {
+            if ($value instanceof FieldType) {
+                $fieldValue = $value->getValue();
+                if (is_scalar($fieldValue) || is_null($fieldValue)) {
+                    $data[$key] = is_string($fieldValue) && blank($fieldValue) ? null : $fieldValue;
+                }
+            }
+        }
+
+        $this->rawState($data);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
formatStateUsing in Filament 4 is implemented as `afterStateHydrated(fn => $component->state($callback()))`, and state() re-runs all state casts on whatever the callback returns. 

So when `Text('')->getValue()` returned "", `RichEditorStateCast::set("")` was called and DOMParser crashed on the emptystring.                                                                                                                                                                  
    
This PR fixes that by ensuring we pass null, not ''