### PR TITLE
Ensure BuyXGetY pushes itself to $cart->discounts

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -208,6 +208,8 @@ class BuyXGetY extends AbstractDiscountType
             discount: $this->discount,
         ));
 
+        $cart->discounts->push($this);
+
         return $cart;
     }
 


### PR DESCRIPTION
We noticed that BuyXGetY discounts don't log uses in discount_users as the discount never marks itself in `$cart->discounts`.

This PR adds the line necessary to make it happen.