### PR TITLE
Enhancement: make card_type column nullable

### DIFF
--- a/packages/core/database/migrations/2026_03_21_204650_set_card_type_to_nullable_on_transactions.php
+++ b/packages/core/database/migrations/2026_03_21_204650_set_card_type_to_nullable_on_transactions.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->prefix.'transactions', function (Blueprint $table) {
+            $table->string('card_type')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->prefix.'transactions', function (Blueprint $table) {
+            $table->string('card_type')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
This PR makes `card_type` column on `transactions` table nullable.

It also removes `varchar(25)` type from the column and lets it default to `varchar(255)` for consistency. Column `last_four` is already `varchar(255)` - I don't see a good reason to constrain `card_type`.