### PR TITLE
Allow shipping tax rate to be determined by a callable

### DIFF
--- a/packages/table-rate-shipping/config/shipping-tables.php
+++ b/packages/table-rate-shipping/config/shipping-tables.php
@@ -6,7 +6,8 @@ return [
     /*
      * What method should we use for a shipping rate tax calculation?
      * Options are 'default' for the system-wide default tax rate,
-     * or 'highest' to select the highest tax rate in the cart
+     * 'highest' to select the highest tax rate in the cart
+     * or add a callable to use your own logic (eg => [MyTaxRateCalculator::class, 'calculate'])
      */
     'shipping_rate_tax_calculation' => 'default',
 ];

--- a/packages/table-rate-shipping/src/Models/ShippingRate.php
+++ b/packages/table-rate-shipping/src/Models/ShippingRate.php
@@ -144,8 +144,14 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
      */
     public function getShippingOption(CartContract $cart): ?ShippingOption
     {
-        if (config('lunar.shipping-tables.shipping_rate_tax_calculation') == 'highest') {
-            $this->resolvedTaxClass = $this->resolveHighestTaxRateInCart($cart);
+        $calculateBy = config('lunar.shipping-tables.shipping_rate_tax_calculation');
+
+        if ($calculateBy != 'default') {
+            if (is_callable($calculateBy)) {
+                $this->resolvedTaxClass = call_user_func($calculateBy, $cart);
+            } else {
+                $this->resolvedTaxClass = $this->resolveHighestTaxRateInCart($cart);
+            }
         }
 
         return $this->shippingMethod->driver()->resolve(

--- a/packages/table-rate-shipping/src/Models/ShippingRate.php
+++ b/packages/table-rate-shipping/src/Models/ShippingRate.php
@@ -148,7 +148,7 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
 
         if (is_callable($calculateBy)) {
             $this->resolvedTaxClass = call_user_func($calculateBy, $cart);
-        } else if ($calculateBy == 'highest') {
+        } elseif ($calculateBy == 'highest') {
             $this->resolvedTaxClass = $this->resolveHighestTaxRateInCart($cart);
         }
 

--- a/packages/table-rate-shipping/src/Models/ShippingRate.php
+++ b/packages/table-rate-shipping/src/Models/ShippingRate.php
@@ -146,12 +146,10 @@ class ShippingRate extends BaseModel implements Contracts\ShippingRate, Purchasa
     {
         $calculateBy = config('lunar.shipping-tables.shipping_rate_tax_calculation');
 
-        if ($calculateBy != 'default') {
-            if (is_callable($calculateBy)) {
-                $this->resolvedTaxClass = call_user_func($calculateBy, $cart);
-            } else {
-                $this->resolvedTaxClass = $this->resolveHighestTaxRateInCart($cart);
-            }
+        if (is_callable($calculateBy)) {
+            $this->resolvedTaxClass = call_user_func($calculateBy, $cart);
+        } else if ($calculateBy == 'highest') {
+            $this->resolvedTaxClass = $this->resolveHighestTaxRateInCart($cart);
         }
 
         return $this->shippingMethod->driver()->resolve(

--- a/tests/shipping/Unit/Models/ShippingRateTest.php
+++ b/tests/shipping/Unit/Models/ShippingRateTest.php
@@ -7,8 +7,6 @@ uses(\Lunar\Tests\Shipping\TestUtils::class);
 use Illuminate\Support\Facades\Config;
 use Lunar\Models\Cart;
 use Lunar\Models\Currency;
-use Lunar\Models\Price;
-use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Shipping\Models\ShippingMethod;
 use Lunar\Shipping\Models\ShippingRate;
@@ -99,7 +97,8 @@ test('getTaxClass uses an invokable class as callable config', function () {
     TaxClass::factory()->create(['default' => true]);
     $customTaxClass = TaxClass::factory()->create(['name' => 'Invokable Tax Class']);
 
-    $resolver = new class($customTaxClass) {
+    $resolver = new class($customTaxClass)
+    {
         public function __construct(private TaxClass $taxClass) {}
 
         public function __invoke(Cart $cart): TaxClass

--- a/tests/shipping/Unit/Models/ShippingRateTest.php
+++ b/tests/shipping/Unit/Models/ShippingRateTest.php
@@ -1,0 +1,119 @@
+<?php
+
+uses(\Lunar\Tests\Shipping\TestCase::class);
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+uses(\Lunar\Tests\Shipping\TestUtils::class);
+
+use Illuminate\Support\Facades\Config;
+use Lunar\Models\Cart;
+use Lunar\Models\Currency;
+use Lunar\Models\Price;
+use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
+use Lunar\Shipping\Models\ShippingMethod;
+use Lunar\Shipping\Models\ShippingRate;
+use Lunar\Shipping\Models\ShippingZone;
+
+function makeShippingRate(Currency $currency): ShippingRate
+{
+    $shippingZone = ShippingZone::factory()->create(['type' => 'countries']);
+
+    $shippingMethod = ShippingMethod::factory()->create([
+        'driver' => 'flat-rate',
+        'data' => ['charge' => ["{$currency->code}" => 500]],
+    ]);
+
+    $customerGroup = \Lunar\Models\CustomerGroup::factory()->create(['default' => true]);
+    $shippingMethod->customerGroups()->sync([
+        $customerGroup->id => ['enabled' => true, 'visible' => true, 'starts_at' => now(), 'ends_at' => null],
+    ]);
+
+    $shippingRate = ShippingRate::factory()->create([
+        'shipping_method_id' => $shippingMethod->id,
+        'shipping_zone_id' => $shippingZone->id,
+    ]);
+
+    $shippingRate->prices()->create([
+        'price' => 500,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+    ]);
+
+    return $shippingRate;
+}
+
+test('getTaxClass returns the default tax class when config is default', function () {
+    $currency = Currency::factory()->create(['default' => true]);
+    $defaultTaxClass = TaxClass::factory()->create(['default' => true]);
+
+    Config::set('lunar.shipping-tables.shipping_rate_tax_calculation', 'default');
+
+    $shippingRate = makeShippingRate($currency);
+    $cart = $this->createCart($currency, calculate: false);
+
+    $shippingRate->getShippingOption($cart);
+
+    expect($shippingRate->getTaxClass()->id)->toBe($defaultTaxClass->id);
+})->group('shipping-rate');
+
+test('getTaxClass uses callable config to resolve tax class', function () {
+    $currency = Currency::factory()->create(['default' => true]);
+    TaxClass::factory()->create(['default' => true]);
+    $customTaxClass = TaxClass::factory()->create(['name' => 'Custom Tax Class']);
+
+    Config::set('lunar.shipping-tables.shipping_rate_tax_calculation', function (Cart $cart) use ($customTaxClass) {
+        return $customTaxClass;
+    });
+
+    $shippingRate = makeShippingRate($currency);
+    $cart = $this->createCart($currency, calculate: false);
+
+    $shippingRate->getShippingOption($cart);
+
+    expect($shippingRate->getTaxClass()->id)->toBe($customTaxClass->id);
+})->group('shipping-rate');
+
+test('callable config receives the cart instance', function () {
+    $currency = Currency::factory()->create(['default' => true]);
+    $defaultTaxClass = TaxClass::factory()->create(['default' => true]);
+
+    $receivedCart = null;
+
+    Config::set('lunar.shipping-tables.shipping_rate_tax_calculation', function (Cart $cart) use (&$receivedCart, $defaultTaxClass) {
+        $receivedCart = $cart;
+
+        return $defaultTaxClass;
+    });
+
+    $shippingRate = makeShippingRate($currency);
+    $cart = $this->createCart($currency, calculate: false);
+
+    $shippingRate->getShippingOption($cart);
+
+    expect($receivedCart)->not->toBeNull()
+        ->and($receivedCart->id)->toBe($cart->id);
+})->group('shipping-rate');
+
+test('getTaxClass uses an invokable class as callable config', function () {
+    $currency = Currency::factory()->create(['default' => true]);
+    TaxClass::factory()->create(['default' => true]);
+    $customTaxClass = TaxClass::factory()->create(['name' => 'Invokable Tax Class']);
+
+    $resolver = new class($customTaxClass) {
+        public function __construct(private TaxClass $taxClass) {}
+
+        public function __invoke(Cart $cart): TaxClass
+        {
+            return $this->taxClass;
+        }
+    };
+
+    Config::set('lunar.shipping-tables.shipping_rate_tax_calculation', $resolver);
+
+    $shippingRate = makeShippingRate($currency);
+    $cart = $this->createCart($currency, calculate: false);
+
+    $shippingRate->getShippingOption($cart);
+
+    expect($shippingRate->getTaxClass()->id)->toBe($customTaxClass->id);
+})->group('shipping-rate');


### PR DESCRIPTION
  Adds support for a callable config value for `shipping_rate_tax_calculation`, allowing applications to provide custom logic to determine which tax class should be applied to shipping rates.

  Previously the config only accepted `'default'` (system default tax class) or `'highest'` (highest tax rate among cart lines). Any value other than `'default'` would fall through to the highest-rate resolver, with no way to supply arbitrary logic.

  ## Changes

  - **`ShippingRate::getShippingOption()`** — when `shipping_rate_tax_calculation` is set to a callable (closure or invokable class), it is called with the `Cart` instance and the return value is used as the resolved `TaxClass`

  ## Usage

  ```php
  // config/shipping-tables.php
  'shipping_rate_tax_calculation' => function (\Lunar\Models\Cart $cart): \Lunar\Models\TaxClass {
      // custom logic — e.g. return a fixed tax class for B2B customers
      return $cart->user?->isBusinessCustomer()
          ? TaxClass::where('name', 'B2B')->first()
          : TaxClass::getDefault();
  },
```
  An invokable class is also supported:

  ```
  'shipping_rate_tax_calculation' => [\App\Shipping\CustomTaxClassResolver, 'handle'],
  ```
