### PR TITLE
Remove unused service provider in Tests

### DIFF
--- a/tests/admin/TestCase.php
+++ b/tests/admin/TestCase.php
@@ -24,7 +24,6 @@ use Lunar\LunarServiceProvider;
 use Lunar\Tests\Admin\Providers\LunarPanelTestServiceProvider;
 use Lunar\Tests\Admin\Stubs\User;
 use Lunar\Tests\TestCase as BaseTestCase;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\LaravelBlink\BlinkServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
@@ -52,7 +51,6 @@ class TestCase extends BaseTestCase
             LunarPanelProvider::class,
 
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,


### PR DESCRIPTION
Looks like after the Filament 4 upgrade a service provider was removed in Filament, this was still being called by the Lunar tests and therefore creating problems with the test runner.