### PR TITLE
Fix non-deterministic activity log order for same-second events

### DIFF
--- a/packages/admin/src/Livewire/Components/ActivityLogFeed.php
+++ b/packages/admin/src/Livewire/Components/ActivityLogFeed.php
@@ -101,7 +101,7 @@ class ActivityLogFeed extends Component implements HasActions, HasForms
     public function activityLog(): LengthAwarePaginator
     {
         $activities = $this->subject->activities()
-            ->orderBy('created_at', 'desc')
+            ->orderBy('id', 'desc')
             ->with(['causer', 'subject'])
             ->paginate(10, ['*'], $this->pageName);
 


### PR DESCRIPTION
## Bug Report

### Description

The order timeline in the admin panel displays activity log entries in a non-deterministic order when multiple events occur within the same second. This causes entries like "order updated" to appear before "order created", which is confusing and incorrect.

### Root Cause

In `ActivityLogFeed.php`, activities are sorted by `created_at`:

```php
$activities = $this->subject->activities()
    ->orderBy('created_at', 'desc')
    ->with(['causer', 'subject'])
    ->paginate(10, ['*'], $this->pageName);
```

When an order is placed, multiple activity log entries are created within the same request cycle (order created, order updated, order line created, payment capture, etc.). These all share the **exact same `created_at` timestamp**, so the database returns them in an undefined order.

### Steps to Reproduce

1. Place an order through the storefront
2. Open the order in the admin panel
3. Observe the timeline — "order updated" may appear before "order created"

### Fix

Replace `orderBy('created_at', 'desc')` with `orderBy('id', 'desc')`. The auto-incrementing `id` column preserves the true insertion order, even when multiple events share the same timestamp.

```diff
- ->orderBy('created_at', 'desc')
+ ->orderBy('id', 'desc')
```