### PR TITLE
Update cut off to be an availability schedule

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./vendor/bin/pest:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./vendor/bin/pest:*)"
-    ]
-  }
-}

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
             "Lunar\\Search\\": "packages/search/src/",
             "Lunar\\Shipping\\": "packages/table-rate-shipping/src",
             "Lunar\\Shipping\\Database\\Factories\\": "packages/table-rate-shipping/database/factories",
+            "Lunar\\Shipping\\Database\\State\\": "packages/table-rate-shipping/database/state",
             "Lunar\\Stripe\\": "packages/stripe/src/"
         }
     },

--- a/packages/table-rate-shipping/composer.json
+++ b/packages/table-rate-shipping/composer.json
@@ -22,7 +22,8 @@
   "autoload": {
     "psr-4": {
       "Lunar\\Shipping\\": "src",
-      "Lunar\\Shipping\\Database\\Factories\\": "database/factories"
+      "Lunar\\Shipping\\Database\\Factories\\": "database/factories",
+      "Lunar\\Shipping\\Database\\State\\": "database/state"
     }
   },
   "extra": {

--- a/packages/table-rate-shipping/database/migrations/2026_04_07_100000_remove_cutoff_from_shipping_methods_table.php
+++ b/packages/table-rate-shipping/database/migrations/2026_04_07_100000_remove_cutoff_from_shipping_methods_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Base\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->prefix.'shipping_methods', function (Blueprint $table) {
+            $table->dropColumn('cutoff');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->prefix.'shipping_methods', function (Blueprint $table) {
+            $table->time('cutoff')->nullable()->after('stock_available');
+        });
+    }
+};

--- a/packages/table-rate-shipping/database/state/MigrateCutoffToSchedule.php
+++ b/packages/table-rate-shipping/database/state/MigrateCutoffToSchedule.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Lunar\Shipping\Database\State;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class MigrateCutoffToSchedule
+{
+    public function prepare(): void
+    {
+        if (! $this->cutoffColumnExists()) {
+            return;
+        }
+
+        $prefix = config('lunar.database.table_prefix');
+
+        DB::table("{$prefix}shipping_methods")
+            ->whereNotNull('cutoff')
+            ->orderBy('id')
+            ->chunk(100, function ($methods) use ($prefix) {
+                foreach ($methods as $method) {
+                    $data = json_decode($method->data ?? '{}', true) ?? [];
+
+                    if (! empty($data['schedule'])) {
+                        continue;
+                    }
+
+                    // Strip seconds from "H:i:s" to get "H:i"
+                    $to = substr($method->cutoff, 0, 5);
+
+                    $schedule = [];
+                    for ($day = 1; $day <= 7; $day++) {
+                        $schedule[(string) $day] = [
+                            'enabled' => true,
+                            'from' => null,
+                            'to' => $to,
+                        ];
+                    }
+
+                    $data['schedule'] = $schedule;
+
+                    DB::table("{$prefix}shipping_methods")
+                        ->where('id', $method->id)
+                        ->update([
+                            'data' => json_encode($data),
+                            'updated_at' => now(),
+                        ]);
+                }
+            });
+    }
+
+    public function run(): void
+    {
+        //
+    }
+
+    protected function cutoffColumnExists(): bool
+    {
+        $prefix = config('lunar.database.table_prefix');
+
+        return Schema::hasTable("{$prefix}shipping_methods")
+            && Schema::hasColumn("{$prefix}shipping_methods", 'cutoff');
+    }
+}

--- a/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
@@ -29,6 +29,9 @@ return [
             ],
             'to' => [
                 'label' => 'Until',
+                'validation' => [
+                    'after' => 'The until time must be after the from time.',
+                ],
             ],
         ],
         'charge_by' => [

--- a/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
@@ -16,23 +16,19 @@ return [
         'schedule' => [
             'label' => 'Availability Schedule',
             'days' => [
-                'label' => 'Available Days',
-                'helper' => 'Leave empty to allow all days.',
-                'options' => [
-                    'monday' => 'Monday',
-                    'tuesday' => 'Tuesday',
-                    'wednesday' => 'Wednesday',
-                    'thursday' => 'Thursday',
-                    'friday' => 'Friday',
-                    'saturday' => 'Saturday',
-                    'sunday' => 'Sunday',
-                ],
+                'monday' => 'Monday',
+                'tuesday' => 'Tuesday',
+                'wednesday' => 'Wednesday',
+                'thursday' => 'Thursday',
+                'friday' => 'Friday',
+                'saturday' => 'Saturday',
+                'sunday' => 'Sunday',
             ],
             'from' => [
-                'label' => 'Available From',
+                'label' => 'From',
             ],
             'to' => [
-                'label' => 'Available Until',
+                'label' => 'Until',
             ],
         ],
         'charge_by' => [

--- a/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
@@ -13,8 +13,27 @@ return [
         'code' => [
             'label' => 'Code',
         ],
-        'cutoff' => [
-            'label' => 'Cutoff',
+        'schedule' => [
+            'label' => 'Availability Schedule',
+            'days' => [
+                'label' => 'Available Days',
+                'helper' => 'Leave empty to allow all days.',
+                'options' => [
+                    'monday' => 'Monday',
+                    'tuesday' => 'Tuesday',
+                    'wednesday' => 'Wednesday',
+                    'thursday' => 'Thursday',
+                    'friday' => 'Friday',
+                    'saturday' => 'Saturday',
+                    'sunday' => 'Sunday',
+                ],
+            ],
+            'from' => [
+                'label' => 'Available From',
+            ],
+            'to' => [
+                'label' => 'Available Until',
+            ],
         ],
         'charge_by' => [
             'label' => 'Charge By',

--- a/packages/table-rate-shipping/resources/views/widgets/availability-schedule.blade.php
+++ b/packages/table-rate-shipping/resources/views/widgets/availability-schedule.blade.php
@@ -1,0 +1,11 @@
+<x-filament-widgets::widget>
+    <form wire:submit="save">
+        {{ $this->form }}
+
+        <div class="mt-4 flex justify-end">
+            {{ $this->saveAction }}
+        </div>
+    </form>
+
+    <x-filament-actions::modals />
+</x-filament-widgets::widget>

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -81,10 +81,8 @@ class ShippingMethodResource extends BaseResource
                 static::getCodeFormComponent(),
                 static::getDriverFormComponent(),
             ])->columns(2),
-            Group::make([
-                static::getCutoffFormComponent(),
-                static::getChargeByFormComponent(),
-            ])->columns(2),
+            static::getChargeByFormComponent(),
+            static::getAvailabilityScheduleFormComponent(),
             static::getStockAvailableFormComponent(),
             static::getDescriptionFormComponent(),
         ];
@@ -113,10 +111,32 @@ class ShippingMethodResource extends BaseResource
             ->unique(ignoreRecord: true);
     }
 
-    public static function getCutoffFormComponent(): Component
+    public static function getAvailabilityScheduleFormComponent(): Component
     {
-        return Forms\Components\TimePicker::make('cutoff')
-            ->label(__('lunarpanel.shipping::shippingmethod.form.cutoff.label'));
+        return Section::make(__('lunarpanel.shipping::shippingmethod.form.schedule.label'))
+            ->schema([
+                Forms\Components\CheckboxList::make('days')
+                    ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.days.label'))
+                    ->helperText(__('lunarpanel.shipping::shippingmethod.form.schedule.days.helper'))
+                    ->options([
+                        1 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.monday'),
+                        2 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.tuesday'),
+                        3 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.wednesday'),
+                        4 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.thursday'),
+                        5 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.friday'),
+                        6 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.saturday'),
+                        7 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.sunday'),
+                    ])
+                    ->columns(4),
+                Group::make([
+                    Forms\Components\TimePicker::make('from')
+                        ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.from.label'))
+                        ->seconds(false),
+                    Forms\Components\TimePicker::make('to')
+                        ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
+                        ->seconds(false),
+                ])->columns(2),
+            ])->statePath('data.schedule')->collapsed()->collapsible();
     }
 
     public static function getStockAvailableFormComponent(): Component

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -138,6 +138,10 @@ class ShippingMethodResource extends BaseResource
                 ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
                 ->seconds(false)
                 ->disabled(fn (Get $get) => ! $get('enabled'))
+                ->rules(fn (Get $get): array => filled($get('from')) ? ['after:'.$get('from')] : [])
+                ->validationMessages([
+                    'after' => __('lunarpanel.shipping::shippingmethod.form.schedule.to.validation.after'),
+                ])
                 ->columnSpan(1),
         ])->statePath((string) $day)->columns(3)
         )->values()->toArray();

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -124,23 +124,22 @@ class ShippingMethodResource extends BaseResource
             7 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.sunday'),
         ];
 
-        $rows = collect($days)->map(fn ($label, $day) =>
-            Group::make([
-                Forms\Components\Checkbox::make('enabled')
-                    ->label($label)
-                    ->live()
-                    ->columnSpan(1),
-                Forms\Components\TimePicker::make('from')
-                    ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.from.label'))
-                    ->seconds(false)
-                    ->disabled(fn (Get $get) => ! $get('enabled'))
-                    ->columnSpan(1),
-                Forms\Components\TimePicker::make('to')
-                    ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
-                    ->seconds(false)
-                    ->disabled(fn (Get $get) => ! $get('enabled'))
-                    ->columnSpan(1),
-            ])->statePath((string) $day)->columns(3)
+        $rows = collect($days)->map(fn ($label, $day) => Group::make([
+            Forms\Components\Checkbox::make('enabled')
+                ->label($label)
+                ->live()
+                ->columnSpan(1),
+            Forms\Components\TimePicker::make('from')
+                ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.from.label'))
+                ->seconds(false)
+                ->disabled(fn (Get $get) => ! $get('enabled'))
+                ->columnSpan(1),
+            Forms\Components\TimePicker::make('to')
+                ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
+                ->seconds(false)
+                ->disabled(fn (Get $get) => ! $get('enabled'))
+                ->columnSpan(1),
+        ])->statePath((string) $day)->columns(3)
         )->values()->toArray();
 
         return Section::make(__('lunarpanel.shipping::shippingmethod.form.schedule.label'))

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -11,6 +11,7 @@ use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Tables\Columns\TextColumn;
@@ -113,30 +114,40 @@ class ShippingMethodResource extends BaseResource
 
     public static function getAvailabilityScheduleFormComponent(): Component
     {
+        $days = [
+            1 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.monday'),
+            2 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.tuesday'),
+            3 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.wednesday'),
+            4 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.thursday'),
+            5 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.friday'),
+            6 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.saturday'),
+            7 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.sunday'),
+        ];
+
+        $rows = collect($days)->map(fn ($label, $day) =>
+            Group::make([
+                Forms\Components\Checkbox::make('enabled')
+                    ->label($label)
+                    ->live()
+                    ->columnSpan(1),
+                Forms\Components\TimePicker::make('from')
+                    ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.from.label'))
+                    ->seconds(false)
+                    ->disabled(fn (Get $get) => ! $get('enabled'))
+                    ->columnSpan(1),
+                Forms\Components\TimePicker::make('to')
+                    ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
+                    ->seconds(false)
+                    ->disabled(fn (Get $get) => ! $get('enabled'))
+                    ->columnSpan(1),
+            ])->statePath((string) $day)->columns(3)
+        )->values()->toArray();
+
         return Section::make(__('lunarpanel.shipping::shippingmethod.form.schedule.label'))
-            ->schema([
-                Forms\Components\CheckboxList::make('days')
-                    ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.days.label'))
-                    ->helperText(__('lunarpanel.shipping::shippingmethod.form.schedule.days.helper'))
-                    ->options([
-                        1 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.monday'),
-                        2 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.tuesday'),
-                        3 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.wednesday'),
-                        4 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.thursday'),
-                        5 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.friday'),
-                        6 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.saturday'),
-                        7 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.options.sunday'),
-                    ])
-                    ->columns(4),
-                Group::make([
-                    Forms\Components\TimePicker::make('from')
-                        ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.from.label'))
-                        ->seconds(false),
-                    Forms\Components\TimePicker::make('to')
-                        ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
-                        ->seconds(false),
-                ])->columns(2),
-            ])->statePath('data.schedule')->collapsed()->collapsible();
+            ->schema($rows)
+            ->statePath('data.schedule')
+            ->collapsed()
+            ->collapsible();
     }
 
     public static function getStockAvailableFormComponent(): Component

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Support\Resources\BaseResource;
 use Lunar\Shipping\Filament\Resources\ShippingMethodResource\Pages;
+use Lunar\Shipping\Filament\Resources\ShippingMethodResource\Widgets\AvailabilityScheduleWidget;
 use Lunar\Shipping\Models\Contracts\ShippingMethod;
 
 class ShippingMethodResource extends BaseResource
@@ -83,7 +84,6 @@ class ShippingMethodResource extends BaseResource
                 static::getDriverFormComponent(),
             ])->columns(2),
             static::getChargeByFormComponent(),
-            static::getAvailabilityScheduleFormComponent(),
             static::getStockAvailableFormComponent(),
             static::getDescriptionFormComponent(),
         ];
@@ -219,6 +219,13 @@ class ShippingMethodResource extends BaseResource
                 )->formatStateUsing(
                     fn ($state) => __("lunarpanel.shipping::shippingmethod.table.driver.options.{$state}")
                 ),
+        ];
+    }
+
+    public static function getWidgets(): array
+    {
+        return [
+            AvailabilityScheduleWidget::class,
         ];
     }
 

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource/Pages/ManageShippingMethodAvailability.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource/Pages/ManageShippingMethodAvailability.php
@@ -7,6 +7,7 @@ use Filament\Support\Facades\FilamentIcon;
 use Lunar\Admin\Filament\Resources\ProductResource\RelationManagers\CustomerGroupRelationManager;
 use Lunar\Admin\Support\Pages\BaseManageRelatedRecords;
 use Lunar\Shipping\Filament\Resources\ShippingMethodResource;
+use Lunar\Shipping\Filament\Resources\ShippingMethodResource\Widgets\AvailabilityScheduleWidget;
 
 class ManageShippingMethodAvailability extends BaseManageRelatedRecords
 {
@@ -28,6 +29,13 @@ class ManageShippingMethodAvailability extends BaseManageRelatedRecords
     public static function getNavigationLabel(): string
     {
         return __('lunarpanel.shipping::shippingmethod.pages.availability.label');
+    }
+
+    protected function getDefaultHeaderWidgets(): array
+    {
+        return [
+            AvailabilityScheduleWidget::class,
+        ];
     }
 
     public function getRelationManagers(): array

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource/Widgets/AvailabilityScheduleWidget.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource/Widgets/AvailabilityScheduleWidget.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Lunar\Shipping\Filament\Resources\ShippingMethodResource\Widgets;
+
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Group;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Widgets\Widget;
+use Illuminate\Database\Eloquent\Model;
+
+class AvailabilityScheduleWidget extends Widget implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    protected string $view = 'shipping::widgets.availability-schedule';
+
+    public ?Model $record = null;
+
+    public array $data = [];
+
+    protected static bool $isLazy = false;
+
+    protected int | string | array $columnSpan = 'full';
+
+    public function mount(): void
+    {
+        $schedule = $this->record?->data['schedule'] ?? [];
+
+        $this->form->fill([
+            'schedule' => $schedule,
+        ]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        $days = [
+            1 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.monday'),
+            2 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.tuesday'),
+            3 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.wednesday'),
+            4 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.thursday'),
+            5 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.friday'),
+            6 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.saturday'),
+            7 => __('lunarpanel.shipping::shippingmethod.form.schedule.days.sunday'),
+        ];
+
+        $rows = collect($days)->map(fn ($label, $day) => Group::make([
+            Forms\Components\Checkbox::make('enabled')
+                ->label($label)
+                ->live()
+                ->columnSpan(1),
+            Forms\Components\TimePicker::make('from')
+                ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.from.label'))
+                ->seconds(false)
+                ->disabled(fn (Get $get) => ! $get('enabled'))
+                ->columnSpan(1),
+            Forms\Components\TimePicker::make('to')
+                ->label(__('lunarpanel.shipping::shippingmethod.form.schedule.to.label'))
+                ->seconds(false)
+                ->disabled(fn (Get $get) => ! $get('enabled'))
+                ->rules(fn (Get $get): array => filled($get('from')) ? ['after:'.$get('from')] : [])
+                ->validationMessages([
+                    'after' => __('lunarpanel.shipping::shippingmethod.form.schedule.to.validation.after'),
+                ])
+                ->columnSpan(1),
+        ])->statePath((string) $day)->columns(3)
+        )->values()->toArray();
+
+        return $schema
+            ->components([
+                Section::make(__('lunarpanel.shipping::shippingmethod.form.schedule.label'))
+                    ->schema($rows)
+                    ->statePath('schedule'),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $state = $this->form->getState();
+
+        $data = $this->record->data ? $this->record->data->toArray() : [];
+        $data['schedule'] = $state['schedule'];
+
+        $this->record->data = $data;
+        $this->record->save();
+
+        Notification::make()
+            ->title(__('filament-panels::resources/pages/edit-record.notifications.saved.title'))
+            ->success()
+            ->send();
+    }
+
+    public function saveAction(): Action
+    {
+        return Action::make('save')
+            ->label(__('filament-panels::resources/pages/edit-record.form.actions.save.label'))
+            ->submit('save');
+    }
+}

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource/Widgets/AvailabilityScheduleWidget.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource/Widgets/AvailabilityScheduleWidget.php
@@ -29,7 +29,7 @@ class AvailabilityScheduleWidget extends Widget implements HasActions, HasForms
 
     protected static bool $isLazy = false;
 
-    protected int | string | array $columnSpan = 'full';
+    protected int|string|array $columnSpan = 'full';
 
     public function mount(): void
     {

--- a/packages/table-rate-shipping/src/Models/ShippingMethod.php
+++ b/packages/table-rate-shipping/src/Models/ShippingMethod.php
@@ -3,6 +3,7 @@
 namespace Lunar\Shipping\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -64,7 +65,7 @@ class ShippingMethod extends BaseModel implements Contracts\ShippingMethod
      * Each day entry has: enabled (bool), from (time string "H:i"), to (time string "H:i").
      * When no schedule is configured the method is always available.
      */
-    public function scopeAvailableAt(\Illuminate\Database\Eloquent\Builder $query, Carbon $now): \Illuminate\Database\Eloquent\Builder
+    public function scopeAvailableAt(Builder $query, Carbon $now): Builder
     {
         return $query->where(function ($query) use ($now) {
             $dayKey = (string) $now->isoWeekday();

--- a/packages/table-rate-shipping/src/Models/ShippingMethod.php
+++ b/packages/table-rate-shipping/src/Models/ShippingMethod.php
@@ -61,45 +61,36 @@ class ShippingMethod extends BaseModel implements Contracts\ShippingMethod
      * Determine whether this shipping method is available at the given moment.
      *
      * The schedule is stored in data.schedule keyed by ISO weekday (1=Monday … 7=Sunday).
-     * Each day entry has: enabled (bool), from (time string), to (time string).
-     * Falls back to the legacy cutoff column when no schedule is configured.
+     * Each day entry has: enabled (bool), from (time string "H:i"), to (time string "H:i").
+     * When no schedule is configured the method is always available.
      */
     public function isAvailableAt(?Carbon $now = null): bool
     {
         $now = $now ?? now();
         $schedule = $this->data['schedule'] ?? null;
 
-        if ($schedule) {
-            $dayKey = (string) $now->isoWeekday();
-            $day = (array) ($schedule[$dayKey] ?? []);
-
-            if (! ($day['enabled'] ?? false)) {
-                return false;
-            }
-
-            $from = $day['from'] ?? null;
-            if ($from && $now->lt($now->copy()->setTimeFromTimeString($from))) {
-                return false;
-            }
-
-            $to = $day['to'] ?? null;
-            if ($to && $now->gt($now->copy()->setTimeFromTimeString($to))) {
-                return false;
-            }
-
+        if (! $schedule) {
             return true;
         }
 
-        // Legacy cutoff fallback
-        if (! $this->cutoff) {
-            return true;
+        $dayKey = (string) $now->isoWeekday();
+        $day = (array) ($schedule[$dayKey] ?? []);
+
+        if (! ($day['enabled'] ?? false)) {
+            return false;
         }
 
-        [$h, $m, $s] = explode(':', $this->cutoff);
+        $from = $day['from'] ?? null;
+        if ($from && $now->lt($now->copy()->setTimeFromTimeString($from))) {
+            return false;
+        }
 
-        $cutoff = $now->copy()->set('hour', (int) $h)->set('minute', (int) $m)->set('second', (int) $s);
+        $to = $day['to'] ?? null;
+        if ($to && $now->gt($now->copy()->setTimeFromTimeString($to))) {
+            return false;
+        }
 
-        return $cutoff->gt($now);
+        return true;
     }
 
     public function driver(): ShippingRateInterface

--- a/packages/table-rate-shipping/src/Models/ShippingMethod.php
+++ b/packages/table-rate-shipping/src/Models/ShippingMethod.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Shipping\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -54,6 +55,52 @@ class ShippingMethod extends BaseModel implements Contracts\ShippingMethod
     public function shippingRates(): HasMany
     {
         return $this->hasMany(ShippingRate::modelClass());
+    }
+
+    /**
+     * Determine whether this shipping method is available at the given moment.
+     * Checks the schedule stored in data.schedule (days + from/to window) first,
+     * then falls back to the legacy cutoff column.
+     */
+    public function isAvailableAt(?Carbon $now = null): bool
+    {
+        $now = $now ?? now();
+        $schedule = $this->data['schedule'] ?? null;
+
+        if ($schedule) {
+            $days = (array) ($schedule['days'] ?? []);
+
+            if (! empty($days) && ! in_array($now->isoWeekday(), $days)) {
+                return false;
+            }
+
+            $from = $schedule['from'] ?? null;
+            if ($from) {
+                if ($now->lt($now->copy()->setTimeFromTimeString($from))) {
+                    return false;
+                }
+            }
+
+            $to = $schedule['to'] ?? null;
+            if ($to) {
+                if ($now->gt($now->copy()->setTimeFromTimeString($to))) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Legacy cutoff fallback
+        if (! $this->cutoff) {
+            return true;
+        }
+
+        [$h, $m, $s] = explode(':', $this->cutoff);
+
+        $cutoff = $now->copy()->set('hour', (int) $h)->set('minute', (int) $m)->set('second', (int) $s);
+
+        return $cutoff->gt($now);
     }
 
     public function driver(): ShippingRateInterface

--- a/packages/table-rate-shipping/src/Models/ShippingMethod.php
+++ b/packages/table-rate-shipping/src/Models/ShippingMethod.php
@@ -64,7 +64,27 @@ class ShippingMethod extends BaseModel implements Contracts\ShippingMethod
      * Each day entry has: enabled (bool), from (time string "H:i"), to (time string "H:i").
      * When no schedule is configured the method is always available.
      */
-    public function isAvailableAt(?Carbon $now = null): bool
+    public function scopeAvailableAt(\Illuminate\Database\Eloquent\Builder $query, Carbon $now): \Illuminate\Database\Eloquent\Builder
+    {
+        return $query->where(function ($query) use ($now) {
+            $dayKey = (string) $now->isoWeekday();
+            $time = $now->format('H:i');
+
+            // No schedule configured — always available
+            $query->whereNull('data->schedule')
+                ->orWhereJsonContains('data->schedule->'.$dayKey.'->enabled', true)
+                ->where(function ($query) use ($dayKey, $now) {
+                    $query->whereNull('data->schedule->'.$dayKey.'->from')
+                        ->orWhereTime('data->schedule->'.$dayKey.'->from', '<=', $now);
+                })
+                ->where(function ($query) use ($dayKey, $now) {
+                    $query->whereNull('data->schedule->'.$dayKey.'->to')
+                        ->orWhereTime('data->schedule->'.$dayKey.'->to', '>=', $now);
+                });
+        });
+    }
+
+    public function isAvailable(?Carbon $now = null): bool
     {
         $now = $now ?? now();
         $schedule = $this->data['schedule'] ?? null;

--- a/packages/table-rate-shipping/src/Models/ShippingMethod.php
+++ b/packages/table-rate-shipping/src/Models/ShippingMethod.php
@@ -59,8 +59,10 @@ class ShippingMethod extends BaseModel implements Contracts\ShippingMethod
 
     /**
      * Determine whether this shipping method is available at the given moment.
-     * Checks the schedule stored in data.schedule (days + from/to window) first,
-     * then falls back to the legacy cutoff column.
+     *
+     * The schedule is stored in data.schedule keyed by ISO weekday (1=Monday … 7=Sunday).
+     * Each day entry has: enabled (bool), from (time string), to (time string).
+     * Falls back to the legacy cutoff column when no schedule is configured.
      */
     public function isAvailableAt(?Carbon $now = null): bool
     {
@@ -68,24 +70,21 @@ class ShippingMethod extends BaseModel implements Contracts\ShippingMethod
         $schedule = $this->data['schedule'] ?? null;
 
         if ($schedule) {
-            $days = (array) ($schedule['days'] ?? []);
+            $dayKey = (string) $now->isoWeekday();
+            $day = (array) ($schedule[$dayKey] ?? []);
 
-            if (! empty($days) && ! in_array($now->isoWeekday(), $days)) {
+            if (! ($day['enabled'] ?? false)) {
                 return false;
             }
 
-            $from = $schedule['from'] ?? null;
-            if ($from) {
-                if ($now->lt($now->copy()->setTimeFromTimeString($from))) {
-                    return false;
-                }
+            $from = $day['from'] ?? null;
+            if ($from && $now->lt($now->copy()->setTimeFromTimeString($from))) {
+                return false;
             }
 
-            $to = $schedule['to'] ?? null;
-            if ($to) {
-                if ($now->gt($now->copy()->setTimeFromTimeString($to))) {
-                    return false;
-                }
+            $to = $day['to'] ?? null;
+            if ($to && $now->gt($now->copy()->setTimeFromTimeString($to))) {
+                return false;
             }
 
             return true;

--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -166,16 +166,7 @@ class ShippingRateResolver
                         return true;
                     }
 
-                    if (! $method->cutoff) {
-                        return false;
-                    }
-
-                    [$h, $m, $s] = explode(':', $method->cutoff);
-
-                    return now()->set('hour', (int) $h)
-                        ->set('minute', (int) $m)
-                        ->set('second', (int) $s)
-                        ->isPast();
+                    return ! $method->isAvailableAt();
                 })
                 ->reject(function ($rate) {
                     if ($this->allCartItemsAreInStock || ! ($rate->shippingMethod->stock_available ?? false)) {

--- a/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
+++ b/packages/table-rate-shipping/src/Resolvers/ShippingRateResolver.php
@@ -166,7 +166,7 @@ class ShippingRateResolver
                         return true;
                     }
 
-                    return ! $method->isAvailableAt();
+                    return ! $method->isAvailable();
                 })
                 ->reject(function ($rate) {
                     if ($this->allCartItemsAreInStock || ! ($rate->shippingMethod->stock_available ?? false)) {

--- a/packages/table-rate-shipping/src/ShippingServiceProvider.php
+++ b/packages/table-rate-shipping/src/ShippingServiceProvider.php
@@ -3,12 +3,17 @@
 namespace Lunar\Shipping;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Events\MigrationsEnded;
+use Illuminate\Database\Events\MigrationsStarted;
+use Illuminate\Database\Events\NoPendingMigrations;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Lunar\Base\ShippingModifiers;
 use Lunar\Facades\ModelManifest;
 use Lunar\Models\CustomerGroup;
 use Lunar\Models\Order;
 use Lunar\Models\Product;
+use Lunar\Shipping\Database\State\MigrateCutoffToSchedule;
 use Lunar\Shipping\Interfaces\ShippingMethodManagerInterface;
 use Lunar\Shipping\Managers\ShippingManager;
 use Lunar\Shipping\Models\ShippingExclusion;
@@ -76,6 +81,8 @@ class ShippingServiceProvider extends ServiceProvider
             __DIR__.'/Models'
         );
 
+        $this->registerStateListeners();
+
         Relation::morphMap([
             'shipping_exclusion' => ShippingExclusion::modelClass(),
             'shipping_exclusion_list' => ShippingExclusionList::modelClass(),
@@ -84,5 +91,26 @@ class ShippingServiceProvider extends ServiceProvider
             'shipping_zone' => ShippingZone::modelClass(),
             'shipping_zone_postcode' => ShippingZonePostcode::modelClass(),
         ]);
+    }
+
+    protected function registerStateListeners(): void
+    {
+        $states = [
+            MigrateCutoffToSchedule::class,
+        ];
+
+        foreach ($states as $state) {
+            $class = new $state;
+
+            Event::listen(
+                [MigrationsStarted::class],
+                [$class, 'prepare']
+            );
+
+            Event::listen(
+                [MigrationsEnded::class, NoPendingMigrations::class],
+                [$class, 'run']
+            );
+        }
     }
 }

--- a/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
+++ b/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
@@ -12,8 +12,8 @@ uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 // ── No schedule ──────────────────────────────────────────────────────────────
 
-test('is available when no schedule and no cutoff are set', function () {
-    $method = ShippingMethod::factory()->create(['cutoff' => null, 'data' => []]);
+test('is available when no schedule is set', function () {
+    $method = ShippingMethod::factory()->create(['data' => []]);
 
     expect($method->isAvailableAt(Carbon::now()))->toBeTrue();
 });
@@ -24,7 +24,6 @@ test('is available on an enabled day', function () {
     $monday = Carbon::parse('next Monday')->setTime(12, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true],
         ]],
@@ -37,7 +36,6 @@ test('is not available on a day that is not enabled', function () {
     $tuesday = Carbon::parse('next Tuesday')->setTime(12, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true],
             '2' => ['enabled' => false],
@@ -51,7 +49,6 @@ test('is not available on a day absent from the schedule', function () {
     $wednesday = Carbon::parse('next Wednesday')->setTime(12, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true],
         ]],
@@ -66,7 +63,6 @@ test('is available when current time is within the day\'s from/to window', funct
     $monday = Carbon::parse('next Monday')->setTime(13, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
         ]],
@@ -79,7 +75,6 @@ test('is not available when current time is before the day\'s from time', functi
     $monday = Carbon::parse('next Monday')->setTime(9, 30);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
         ]],
@@ -92,7 +87,6 @@ test('is not available when current time is after the day\'s to time', function 
     $monday = Carbon::parse('next Monday')->setTime(17, 1);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
         ]],
@@ -105,7 +99,6 @@ test('is available exactly at the from time', function () {
     $monday = Carbon::parse('next Monday')->setTime(10, 0, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
         ]],
@@ -118,7 +111,6 @@ test('is available exactly at the to time', function () {
     $monday = Carbon::parse('next Monday')->setTime(17, 0, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
         ]],
@@ -131,7 +123,6 @@ test('is available exactly at the to time', function () {
 
 test('each day can have its own time window', function () {
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '1' => ['enabled' => true, 'from' => '09:00', 'to' => '17:00'], // Mon 9–17
             '6' => ['enabled' => true, 'from' => '10:00', 'to' => '13:00'], // Sat 10–13
@@ -149,7 +140,6 @@ test('each day can have its own time window', function () {
 
 test('an enabled day with no from/to is available all day', function () {
     $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
         'data' => ['schedule' => [
             '3' => ['enabled' => true], // Wednesday, all day
         ]],
@@ -160,41 +150,4 @@ test('an enabled day with no from/to is available all day', function () {
 
     expect($method->isAvailableAt($earlyWednesday))->toBeTrue();
     expect($method->isAvailableAt($lateWednesday))->toBeTrue();
-});
-
-// ── Legacy cutoff fallback ───────────────────────────────────────────────────
-
-test('falls back to cutoff column when no schedule and cutoff has not passed', function () {
-    $now = Carbon::parse('next Monday')->setTime(14, 0);
-
-    $method = ShippingMethod::factory()->create([
-        'cutoff' => '17:00:00',
-        'data' => [],
-    ]);
-
-    expect($method->isAvailableAt($now))->toBeTrue();
-});
-
-test('falls back to cutoff column when no schedule and cutoff has passed', function () {
-    $now = Carbon::parse('next Monday')->setTime(18, 0);
-
-    $method = ShippingMethod::factory()->create([
-        'cutoff' => '17:00:00',
-        'data' => [],
-    ]);
-
-    expect($method->isAvailableAt($now))->toBeFalse();
-});
-
-test('schedule takes priority over the legacy cutoff column', function () {
-    $now = Carbon::parse('next Monday')->setTime(14, 0);
-
-    $method = ShippingMethod::factory()->create([
-        'cutoff' => '10:00:00', // would reject at 14:00 if used
-        'data' => ['schedule' => [
-            '1' => ['enabled' => true, 'from' => '09:00', 'to' => '18:00'],
-        ]],
-    ]);
-
-    expect($method->isAvailableAt($now))->toBeTrue();
 });

--- a/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
+++ b/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
@@ -16,7 +16,7 @@ uses(TestCase::class);
 test('is available when no schedule is set', function () {
     $method = ShippingMethod::factory()->create(['data' => []]);
 
-    expect($method->isAvailableAt(Carbon::now()))->toBeTrue();
+    expect($method->isAvailable(Carbon::now()))->toBeTrue();
 });
 
 // ── Day-level availability ───────────────────────────────────────────────────
@@ -30,7 +30,7 @@ test('is available on an enabled day', function () {
         ]],
     ]);
 
-    expect($method->isAvailableAt($monday))->toBeTrue();
+    expect($method->isAvailable($monday))->toBeTrue();
 });
 
 test('is not available on a day that is not enabled', function () {
@@ -43,7 +43,7 @@ test('is not available on a day that is not enabled', function () {
         ]],
     ]);
 
-    expect($method->isAvailableAt($tuesday))->toBeFalse();
+    expect($method->isAvailable($tuesday))->toBeFalse();
 });
 
 test('is not available on a day absent from the schedule', function () {
@@ -55,7 +55,7 @@ test('is not available on a day absent from the schedule', function () {
         ]],
     ]);
 
-    expect($method->isAvailableAt($wednesday))->toBeFalse();
+    expect($method->isAvailable($wednesday))->toBeFalse();
 });
 
 // ── Per-day time windows ─────────────────────────────────────────────────────
@@ -69,7 +69,7 @@ test('is available when current time is within the day\'s from/to window', funct
         ]],
     ]);
 
-    expect($method->isAvailableAt($monday))->toBeTrue();
+    expect($method->isAvailable($monday))->toBeTrue();
 });
 
 test('is not available when current time is before the day\'s from time', function () {
@@ -81,7 +81,7 @@ test('is not available when current time is before the day\'s from time', functi
         ]],
     ]);
 
-    expect($method->isAvailableAt($monday))->toBeFalse();
+    expect($method->isAvailable($monday))->toBeFalse();
 });
 
 test('is not available when current time is after the day\'s to time', function () {
@@ -93,7 +93,7 @@ test('is not available when current time is after the day\'s to time', function 
         ]],
     ]);
 
-    expect($method->isAvailableAt($monday))->toBeFalse();
+    expect($method->isAvailable($monday))->toBeFalse();
 });
 
 test('is available exactly at the from time', function () {
@@ -105,7 +105,7 @@ test('is available exactly at the from time', function () {
         ]],
     ]);
 
-    expect($method->isAvailableAt($monday))->toBeTrue();
+    expect($method->isAvailable($monday))->toBeTrue();
 });
 
 test('is available exactly at the to time', function () {
@@ -117,7 +117,7 @@ test('is available exactly at the to time', function () {
         ]],
     ]);
 
-    expect($method->isAvailableAt($monday))->toBeTrue();
+    expect($method->isAvailable($monday))->toBeTrue();
 });
 
 // ── Different windows per day ─────────────────────────────────────────────────
@@ -134,9 +134,9 @@ test('each day can have its own time window', function () {
     $saturdayMorning = Carbon::parse('next Saturday')->setTime(11, 0);
     $saturdayAfternoon = Carbon::parse('next Saturday')->setTime(14, 0);
 
-    expect($method->isAvailableAt($mondayMorning))->toBeTrue();
-    expect($method->isAvailableAt($saturdayMorning))->toBeTrue();
-    expect($method->isAvailableAt($saturdayAfternoon))->toBeFalse();
+    expect($method->isAvailable($mondayMorning))->toBeTrue();
+    expect($method->isAvailable($saturdayMorning))->toBeTrue();
+    expect($method->isAvailable($saturdayAfternoon))->toBeFalse();
 });
 
 test('an enabled day with no from/to is available all day', function () {
@@ -149,6 +149,6 @@ test('an enabled day with no from/to is available all day', function () {
     $earlyWednesday = Carbon::parse('next Wednesday')->setTime(0, 1);
     $lateWednesday = Carbon::parse('next Wednesday')->setTime(23, 59);
 
-    expect($method->isAvailableAt($earlyWednesday))->toBeTrue();
-    expect($method->isAvailableAt($lateWednesday))->toBeTrue();
+    expect($method->isAvailable($earlyWednesday))->toBeTrue();
+    expect($method->isAvailable($lateWednesday))->toBeTrue();
 });

--- a/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
+++ b/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
@@ -7,7 +7,10 @@ use Lunar\Shipping\Models\ShippingMethod;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
-// ── Schedule-based availability ──────────────────────────────────────────────
+// Schedule is stored as data.schedule keyed by ISO weekday (1=Monday … 7=Sunday).
+// Each entry: { enabled: bool, from: "HH:MM", to: "HH:MM" }
+
+// ── No schedule ──────────────────────────────────────────────────────────────
 
 test('is available when no schedule and no cutoff are set', function () {
     $method = ShippingMethod::factory()->create(['cutoff' => null, 'data' => []]);
@@ -15,141 +18,153 @@ test('is available when no schedule and no cutoff are set', function () {
     expect($method->isAvailableAt(Carbon::now()))->toBeTrue();
 });
 
-test('is available when schedule days matches the current day', function () {
+// ── Day-level availability ───────────────────────────────────────────────────
+
+test('is available on an enabled day', function () {
     $monday = Carbon::parse('next Monday')->setTime(12, 0);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5]]],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true],
+        ]],
     ]);
 
     expect($method->isAvailableAt($monday))->toBeTrue();
 });
 
-test('is not available when schedule days does not include the current day', function () {
-    $saturday = Carbon::parse('next Saturday')->setTime(12, 0);
+test('is not available on a day that is not enabled', function () {
+    $tuesday = Carbon::parse('next Tuesday')->setTime(12, 0);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5]]],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true],
+            '2' => ['enabled' => false],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($saturday))->toBeFalse();
+    expect($method->isAvailableAt($tuesday))->toBeFalse();
 });
 
-test('is available on any day when schedule days is empty', function () {
-    $sunday = Carbon::parse('next Sunday')->setTime(12, 0);
+test('is not available on a day absent from the schedule', function () {
+    $wednesday = Carbon::parse('next Wednesday')->setTime(12, 0);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['days' => []]],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($sunday))->toBeTrue();
+    expect($method->isAvailableAt($wednesday))->toBeFalse();
 });
 
-test('is available when current time is within the from/to window', function () {
-    $now = Carbon::parse('next Monday')->setTime(13, 0);
+// ── Per-day time windows ─────────────────────────────────────────────────────
+
+test('is available when current time is within the day\'s from/to window', function () {
+    $monday = Carbon::parse('next Monday')->setTime(13, 0);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($now))->toBeTrue();
+    expect($method->isAvailableAt($monday))->toBeTrue();
 });
 
-test('is not available when current time is before the from time', function () {
-    $now = Carbon::parse('next Monday')->setTime(9, 30);
+test('is not available when current time is before the day\'s from time', function () {
+    $monday = Carbon::parse('next Monday')->setTime(9, 30);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($now))->toBeFalse();
+    expect($method->isAvailableAt($monday))->toBeFalse();
 });
 
-test('is not available when current time is after the to time', function () {
-    $now = Carbon::parse('next Monday')->setTime(17, 1);
+test('is not available when current time is after the day\'s to time', function () {
+    $monday = Carbon::parse('next Monday')->setTime(17, 1);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($now))->toBeFalse();
+    expect($method->isAvailableAt($monday))->toBeFalse();
 });
 
 test('is available exactly at the from time', function () {
-    $now = Carbon::parse('next Monday')->setTime(10, 0, 0);
+    $monday = Carbon::parse('next Monday')->setTime(10, 0, 0);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($now))->toBeTrue();
+    expect($method->isAvailableAt($monday))->toBeTrue();
 });
 
 test('is available exactly at the to time', function () {
-    $now = Carbon::parse('next Monday')->setTime(17, 0, 0);
+    $monday = Carbon::parse('next Monday')->setTime(17, 0, 0);
 
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '10:00', 'to' => '17:00'],
+        ]],
     ]);
 
-    expect($method->isAvailableAt($now))->toBeTrue();
+    expect($method->isAvailableAt($monday))->toBeTrue();
 });
 
-test('combines day and time checks — rejects wrong day even within time window', function () {
-    $saturday = Carbon::parse('next Saturday')->setTime(12, 0);
+// ── Different windows per day ─────────────────────────────────────────────────
 
+test('each day can have its own time window', function () {
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5], 'from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '09:00', 'to' => '17:00'], // Mon 9–17
+            '6' => ['enabled' => true, 'from' => '10:00', 'to' => '13:00'], // Sat 10–13
+        ]],
     ]);
 
-    expect($method->isAvailableAt($saturday))->toBeFalse();
+    $mondayMorning = Carbon::parse('next Monday')->setTime(9, 30);
+    $saturdayMorning = Carbon::parse('next Saturday')->setTime(11, 0);
+    $saturdayAfternoon = Carbon::parse('next Saturday')->setTime(14, 0);
+
+    expect($method->isAvailableAt($mondayMorning))->toBeTrue();
+    expect($method->isAvailableAt($saturdayMorning))->toBeTrue();
+    expect($method->isAvailableAt($saturdayAfternoon))->toBeFalse();
 });
 
-test('combines day and time checks — rejects correct day but outside time window', function () {
-    $mondayEvening = Carbon::parse('next Monday')->setTime(18, 0);
-
+test('an enabled day with no from/to is available all day', function () {
     $method = ShippingMethod::factory()->create([
         'cutoff' => null,
-        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5], 'from' => '10:00', 'to' => '17:00']],
+        'data' => ['schedule' => [
+            '3' => ['enabled' => true], // Wednesday, all day
+        ]],
     ]);
 
-    expect($method->isAvailableAt($mondayEvening))->toBeFalse();
-});
+    $earlyWednesday = Carbon::parse('next Wednesday')->setTime(0, 1);
+    $lateWednesday = Carbon::parse('next Wednesday')->setTime(23, 59);
 
-test('is available when only a from time is set and current time is after it', function () {
-    $now = Carbon::parse('next Monday')->setTime(11, 0);
-
-    $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
-        'data' => ['schedule' => ['from' => '10:00']],
-    ]);
-
-    expect($method->isAvailableAt($now))->toBeTrue();
-});
-
-test('is available when only a to time is set and current time is before it', function () {
-    $now = Carbon::parse('next Monday')->setTime(14, 0);
-
-    $method = ShippingMethod::factory()->create([
-        'cutoff' => null,
-        'data' => ['schedule' => ['to' => '17:00']],
-    ]);
-
-    expect($method->isAvailableAt($now))->toBeTrue();
+    expect($method->isAvailableAt($earlyWednesday))->toBeTrue();
+    expect($method->isAvailableAt($lateWednesday))->toBeTrue();
 });
 
 // ── Legacy cutoff fallback ───────────────────────────────────────────────────
 
-test('falls back to cutoff column when no schedule is set and cutoff has not passed', function () {
+test('falls back to cutoff column when no schedule and cutoff has not passed', function () {
     $now = Carbon::parse('next Monday')->setTime(14, 0);
 
     $method = ShippingMethod::factory()->create([
@@ -160,7 +175,7 @@ test('falls back to cutoff column when no schedule is set and cutoff has not pas
     expect($method->isAvailableAt($now))->toBeTrue();
 });
 
-test('falls back to cutoff column when no schedule is set and cutoff has passed', function () {
+test('falls back to cutoff column when no schedule and cutoff has passed', function () {
     $now = Carbon::parse('next Monday')->setTime(18, 0);
 
     $method = ShippingMethod::factory()->create([
@@ -172,12 +187,13 @@ test('falls back to cutoff column when no schedule is set and cutoff has passed'
 });
 
 test('schedule takes priority over the legacy cutoff column', function () {
-    // Schedule says available, cutoff would say not available
     $now = Carbon::parse('next Monday')->setTime(14, 0);
 
     $method = ShippingMethod::factory()->create([
-        'cutoff' => '10:00:00', // would reject at 14:00
-        'data' => ['schedule' => ['from' => '09:00', 'to' => '18:00']],
+        'cutoff' => '10:00:00', // would reject at 14:00 if used
+        'data' => ['schedule' => [
+            '1' => ['enabled' => true, 'from' => '09:00', 'to' => '18:00'],
+        ]],
     ]);
 
     expect($method->isAvailableAt($now))->toBeTrue();

--- a/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
+++ b/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
@@ -1,13 +1,12 @@
 <?php
 
-uses(TestCase::class);
-
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Shipping\Models\ShippingMethod;
 use Lunar\Tests\Shipping\TestCase;
 
 uses(RefreshDatabase::class);
+uses(TestCase::class);
 
 // Schedule is stored as data.schedule keyed by ISO weekday (1=Monday … 7=Sunday).
 // Each entry: { enabled: bool, from: "HH:MM", to: "HH:MM" }

--- a/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
+++ b/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
@@ -1,0 +1,184 @@
+<?php
+
+uses(\Lunar\Tests\Shipping\TestCase::class);
+
+use Carbon\Carbon;
+use Lunar\Shipping\Models\ShippingMethod;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+// ── Schedule-based availability ──────────────────────────────────────────────
+
+test('is available when no schedule and no cutoff are set', function () {
+    $method = ShippingMethod::factory()->create(['cutoff' => null, 'data' => []]);
+
+    expect($method->isAvailableAt(Carbon::now()))->toBeTrue();
+});
+
+test('is available when schedule days matches the current day', function () {
+    $monday = Carbon::parse('next Monday')->setTime(12, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5]]],
+    ]);
+
+    expect($method->isAvailableAt($monday))->toBeTrue();
+});
+
+test('is not available when schedule days does not include the current day', function () {
+    $saturday = Carbon::parse('next Saturday')->setTime(12, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5]]],
+    ]);
+
+    expect($method->isAvailableAt($saturday))->toBeFalse();
+});
+
+test('is available on any day when schedule days is empty', function () {
+    $sunday = Carbon::parse('next Sunday')->setTime(12, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['days' => []]],
+    ]);
+
+    expect($method->isAvailableAt($sunday))->toBeTrue();
+});
+
+test('is available when current time is within the from/to window', function () {
+    $now = Carbon::parse('next Monday')->setTime(13, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});
+
+test('is not available when current time is before the from time', function () {
+    $now = Carbon::parse('next Monday')->setTime(9, 30);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeFalse();
+});
+
+test('is not available when current time is after the to time', function () {
+    $now = Carbon::parse('next Monday')->setTime(17, 1);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeFalse();
+});
+
+test('is available exactly at the from time', function () {
+    $now = Carbon::parse('next Monday')->setTime(10, 0, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});
+
+test('is available exactly at the to time', function () {
+    $now = Carbon::parse('next Monday')->setTime(17, 0, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});
+
+test('combines day and time checks — rejects wrong day even within time window', function () {
+    $saturday = Carbon::parse('next Saturday')->setTime(12, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5], 'from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($saturday))->toBeFalse();
+});
+
+test('combines day and time checks — rejects correct day but outside time window', function () {
+    $mondayEvening = Carbon::parse('next Monday')->setTime(18, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['days' => [1, 2, 3, 4, 5], 'from' => '10:00', 'to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($mondayEvening))->toBeFalse();
+});
+
+test('is available when only a from time is set and current time is after it', function () {
+    $now = Carbon::parse('next Monday')->setTime(11, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['from' => '10:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});
+
+test('is available when only a to time is set and current time is before it', function () {
+    $now = Carbon::parse('next Monday')->setTime(14, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => null,
+        'data' => ['schedule' => ['to' => '17:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});
+
+// ── Legacy cutoff fallback ───────────────────────────────────────────────────
+
+test('falls back to cutoff column when no schedule is set and cutoff has not passed', function () {
+    $now = Carbon::parse('next Monday')->setTime(14, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => '17:00:00',
+        'data' => [],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});
+
+test('falls back to cutoff column when no schedule is set and cutoff has passed', function () {
+    $now = Carbon::parse('next Monday')->setTime(18, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => '17:00:00',
+        'data' => [],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeFalse();
+});
+
+test('schedule takes priority over the legacy cutoff column', function () {
+    // Schedule says available, cutoff would say not available
+    $now = Carbon::parse('next Monday')->setTime(14, 0);
+
+    $method = ShippingMethod::factory()->create([
+        'cutoff' => '10:00:00', // would reject at 14:00
+        'data' => ['schedule' => ['from' => '09:00', 'to' => '18:00']],
+    ]);
+
+    expect($method->isAvailableAt($now))->toBeTrue();
+});

--- a/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
+++ b/tests/shipping/Unit/Models/ShippingMethodAvailabilityTest.php
@@ -1,11 +1,13 @@
 <?php
 
-uses(\Lunar\Tests\Shipping\TestCase::class);
+uses(TestCase::class);
 
 use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Shipping\Models\ShippingMethod;
+use Lunar\Tests\Shipping\TestCase;
 
-uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+uses(RefreshDatabase::class);
 
 // Schedule is stored as data.schedule keyed by ISO weekday (1=Monday … 7=Sunday).
 // Each entry: { enabled: bool, from: "HH:MM", to: "HH:MM" }


### PR DESCRIPTION
This PR updates the cut off in Shipping Methods to be an availability schedule:

<img width="2056" height="1460" alt="CleanShot 2026-04-07 at 09 09 54@2x" src="https://github.com/user-attachments/assets/167693dd-821f-43da-9d0a-71fa45e88d37" />

This provides much finer control over when the method is available to customers.