### PR TITLE
Number fieldtype fixes

### DIFF
--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -52,7 +52,7 @@ class AttributeData
             ->label(
                 $attribute->translate('name')
             )
-            ->formatStateUsing(function ($state) use ($attribute) {
+            ->formatStateUsing(function ($state) {
                 if ($state instanceof FieldType) {
                     return $state->getValue();
                 }

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -57,9 +57,7 @@ class AttributeData
                     return $state->getValue();
                 }
 
-                $instance = new $attribute->type;
-
-                return $instance->getValue();
+                return $state;
             })
             ->mutateStateForValidationUsing(function ($state) {
                 if ($state instanceof FieldType) {

--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component as Livewire;
 use Lunar\Admin\Support\Facades\AttributeData;
@@ -48,6 +49,35 @@ class Attributes extends Group
     public function getKey(bool $isAbsolute = true): ?string
     {
         return 'attributeData'.$this->modelClassOverride;
+    }
+
+    public function hydrateState(?array &$hydratedDefaultState, bool $shouldCallHydrationHooks = true): void
+    {
+        if ($hydratedDefaultState === null) {
+            $this->unwrapFieldTypeState();
+        }
+
+        parent::hydrateState($hydratedDefaultState, $shouldCallHydrationHooks);
+    }
+
+    public function hydrateStatePartially(array $statePaths, bool $shouldCallHydrationHooks = true): void
+    {
+        $this->unwrapFieldTypeState();
+
+        parent::hydrateStatePartially($statePaths, $shouldCallHydrationHooks);
+    }
+
+    protected function unwrapFieldTypeState(): void
+    {
+        $rawState = $this->getRawState();
+
+        if (is_array($rawState) || $rawState instanceof Arrayable) {
+            $rawState = collect($rawState)->map(
+                fn ($value) => $value instanceof FieldType ? $value->getValue() : $value,
+            )->toArray();
+
+            $this->rawState($rawState);
+        }
     }
 
     protected function setUp(): void

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Pages/EditProductTest.php
@@ -85,6 +85,56 @@ it('can edit variant attributes', function ($attributeType, $attributeValue) {
     [Number::class, 100],
 ]);
 
+it('can load edit page with existing number attribute', function () {
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $product = Product::factory()->create();
+    ProductVariant::factory()->create([
+        'product_id' => $product->id,
+    ]);
+
+    $group = AttributeGroup::factory()->create([
+        'attributable_type' => 'product',
+        'name' => ['en' => 'Details'],
+        'handle' => 'details',
+        'position' => 1,
+    ]);
+
+    $attribute = Attribute::factory()->create([
+        'attribute_type' => 'product',
+        'attribute_group_id' => $group->id,
+        'position' => 1,
+        'name' => ['en' => 'Quantity'],
+        'handle' => 'quantity',
+        'section' => 'main',
+        'type' => Number::class,
+        'required' => false,
+        'system' => false,
+        'searchable' => false,
+    ]);
+
+    DB::table('lunar_attributables')->insert([
+        'attribute_id' => $attribute->id,
+        'attributable_type' => 'product_type',
+        'attributable_id' => $product->productType->id,
+    ]);
+
+    $product->update([
+        'attribute_data' => collect([
+            'quantity' => new Number(123),
+        ]),
+    ]);
+
+    $this->asStaff(admin: true);
+
+    Livewire::test(EditProduct::class, [
+        'record' => $product->getRouteKey(),
+        'pageClass' => 'productEdit',
+    ])->assertSuccessful();
+});
+
 it('can save attributes', function () {
     Language::factory()->create([
         'default' => true,


### PR DESCRIPTION
Fix Number field type breaking on edit page after saving

When a Number attribute value is saved and the product edit page reloads, Filament's `NumberStateCast` calls `floatval()` on a `Lunar\FieldTypes\Number` object during form state hydration, which fails because PHP cannot convert objects to float.

  The root cause is an execution order issue in Filament's `hydrateState` - state casts run on child components before `formatStateUsing` can unwrap the FieldType object to a raw value.

  Changes

  - Attributes.php - Override `hydrateState` and `hydrateStatePartially` to unwrap FieldType values from the raw state before the parent distributes them to child components. This mirrors what mutateRelationshipDataBeforeFillUsing already does for the relationship case.
  - AttributeData.php - Fix `formatStateUsing` fallback to return the raw state as-is instead of constructing a new empty FieldType instance (which would discard the real value and return 0).