### PR TITLE
Fix dropdown lookup state normalization for attribute edit forms

### DIFF
--- a/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
+++ b/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
@@ -127,12 +127,6 @@ class AttributesRelationManager extends BaseRelationManager
                     ->schema(function (Get $get) {
                         return AttributeData::getConfigurationFields($get('type'));
                     })
-                    ->afterStateHydrated(function (Grid $component, $state, Get $get): void {
-                        $component->state(AttributeData::mutateConfigurationForForm(
-                            $get('type'),
-                            is_array($state) ? $state : [],
-                        ));
-                    })
                     ->key('configuration')
                     ->statePath('configuration'),
             ]);

--- a/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
+++ b/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
@@ -126,7 +126,15 @@ class AttributesRelationManager extends BaseRelationManager
                 Grid::make(1)
                     ->schema(function (Get $get) {
                         return AttributeData::getConfigurationFields($get('type'));
-                    })->key('configuration')->statePath('configuration'),
+                    })
+                    ->afterStateHydrated(function (Grid $component, $state, Get $get): void {
+                        $component->state(AttributeData::mutateConfigurationForForm(
+                            $get('type'),
+                            is_array($state) ? $state : [],
+                        ));
+                    })
+                    ->key('configuration')
+                    ->statePath('configuration'),
             ]);
     }
 
@@ -162,7 +170,15 @@ class AttributesRelationManager extends BaseRelationManager
                 }),
             ])
             ->recordActions([
-                EditAction::make(),
+                EditAction::make()
+                    ->mutateRecordDataUsing(function (array $data): array {
+                        $data['configuration'] = AttributeData::mutateConfigurationForForm(
+                            $data['type'] ?? null,
+                            $data['configuration'] ?? [],
+                        );
+
+                        return $data;
+                    }),
                 DeleteAction::make(),
             ])
             ->toolbarActions([

--- a/packages/admin/src/Support/Facades/AttributeData.php
+++ b/packages/admin/src/Support/Facades/AttributeData.php
@@ -11,6 +11,7 @@ use Lunar\Models\Attribute;
  * @method static Component getFilamentComponent(Attribute $attribute)
  * @method static \Lunar\Admin\Support\Forms\AttributeData registerFieldType(string $coreFieldType, string $panelFieldType)
  * @method static Collection getFieldTypes()
+ * @method static array mutateConfigurationForForm(string|null $type = null, array $configuration = [])
  * @method static array getConfigurationFields(string|null $type = null)
  * @method static void synthesizeLivewireProperties()
  *

--- a/packages/admin/src/Support/FieldTypes/BaseFieldType.php
+++ b/packages/admin/src/Support/FieldTypes/BaseFieldType.php
@@ -11,6 +11,15 @@ abstract class BaseFieldType
 {
     protected static string $synthesizer = TextSynth::class;
 
+    /**
+     * @param  array<string, mixed>  $configuration
+     * @return array<string, mixed>
+     */
+    public static function mutateConfigurationForForm(array $configuration): array
+    {
+        return $configuration;
+    }
+
     public static function getConfigurationFields(): array
     {
         return [];

--- a/packages/admin/src/Support/FieldTypes/Dropdown.php
+++ b/packages/admin/src/Support/FieldTypes/Dropdown.php
@@ -12,6 +12,38 @@ class Dropdown extends BaseFieldType
 {
     protected static string $synthesizer = DropdownSynth::class;
 
+    /**
+     * @param  array<string, mixed>  $configuration
+     * @return array<string, mixed>
+     */
+    public static function mutateConfigurationForForm(array $configuration): array
+    {
+        $lookups = $configuration['lookups'] ?? [];
+
+        if (! is_array($lookups)) {
+            return $configuration;
+        }
+
+        $configuration['lookups'] = collect($lookups)
+            ->mapWithKeys(function (mixed $lookup, mixed $key): array {
+                if (! is_array($lookup)) {
+                    return [$key => $lookup];
+                }
+
+                $label = $lookup['label'] ?? $lookup['key'] ?? null;
+                $value = $lookup['value'] ?? $label;
+
+                if (blank($label)) {
+                    return [];
+                }
+
+                return [$label => $value];
+            })
+            ->all();
+
+        return $configuration;
+    }
+
     public static function getFilamentComponent(Attribute $attribute): Component
     {
         return Select::make($attribute->handle)
@@ -33,10 +65,10 @@ class Dropdown extends BaseFieldType
             )
                 ->keyLabel(__('lunarpanel::fieldtypes.dropdown.form.lookups.key_label'))
                 ->valueLabel(__('lunarpanel::fieldtypes.dropdown.form.lookups.value_label'))
-                ->formatStateUsing(function ($state) {
-                    return collect($state)->mapWithKeys(
-                        fn ($lookup) => [$lookup['label'] => $lookup['value'] ?? $lookup['label']]
-                    )->toArray();
+                ->afterStateHydrated(function (KeyValue $component, $state): void {
+                    $component->state(static::mutateConfigurationForForm([
+                        'lookups' => is_array($state) ? $state : [],
+                    ])['lookups'] ?? []);
                 })
                 ->mutateDehydratedStateUsing(function ($state) {
                     return collect($state)->map(function ($value, $label) {

--- a/packages/admin/src/Support/Forms/AttributeData.php
+++ b/packages/admin/src/Support/Forms/AttributeData.php
@@ -104,6 +104,17 @@ class AttributeData
         return collect($this->fieldTypes)->keys();
     }
 
+    /**
+     * @param  array<string, mixed>  $configuration
+     * @return array<string, mixed>
+     */
+    public function mutateConfigurationForForm(?string $type = null, array $configuration = []): array
+    {
+        $fieldType = $this->fieldTypes[$type] ?? null;
+
+        return $fieldType ? $fieldType::mutateConfigurationForForm($configuration) : $configuration;
+    }
+
     public function getConfigurationFields(?string $type = null): array
     {
         $fieldType = $this->fieldTypes[$type] ?? null;

--- a/tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
+++ b/tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Filament\Actions\CreateAction;
+use Filament\Actions\EditAction;
 use Livewire\Livewire;
 use Lunar\Admin\Filament\Resources\AttributeGroupResource\Pages\EditAttributeGroup;
 use Lunar\Admin\Filament\Resources\AttributeGroupResource\RelationManagers\AttributesRelationManager;
@@ -104,3 +105,37 @@ it('can create attributes', function ($type, $configuration = [], $expectedData 
         '{"min":5,"max":10}',
     ],
 ]);
+
+it('hydrates dropdown lookups when editing attributes', function () {
+    Language::factory()->create([
+        'default' => true,
+        'code' => 'en',
+    ]);
+
+    $this->asStaff();
+
+    $attributeGroup = AttributeGroup::factory()->create();
+
+    $attribute = Attribute::factory()->create([
+        'attribute_group_id' => $attributeGroup->id,
+        'type' => Dropdown::class,
+        'configuration' => [
+            'lookups' => [
+                ['label' => 'aaaa', 'value' => 'bbbb'],
+            ],
+        ],
+    ]);
+
+    Livewire::test(AttributesRelationManager::class, [
+        'ownerRecord' => $attributeGroup,
+        'pageClass' => EditAttributeGroup::class,
+    ])
+        ->mountTableAction(EditAction::class, $attribute)
+        ->assertTableActionDataSet([
+            'configuration' => [
+                'lookups' => [
+                    'aaaa' => 'bbbb',
+                ],
+            ],
+        ]);
+});

--- a/tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
+++ b/tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
@@ -131,10 +131,19 @@ it('hydrates dropdown lookups when editing attributes', function () {
         'pageClass' => EditAttributeGroup::class,
     ])
         ->mountTableAction(EditAction::class, $attribute)
+        ->assertSet('mountedActions.0.data.configuration.lookups', [
+            [
+                'key' => 'aaaa',
+                'value' => 'bbbb',
+            ],
+        ])
         ->assertTableActionDataSet([
             'configuration' => [
                 'lookups' => [
-                    'aaaa' => 'bbbb',
+                    [
+                        'key' => 'aaaa',
+                        'value' => 'bbbb',
+                    ],
                 ],
             ],
         ]);

--- a/tests/admin/Unit/Support/Forms/AttributeConverters/DropdownConverterTest.php
+++ b/tests/admin/Unit/Support/Forms/AttributeConverters/DropdownConverterTest.php
@@ -43,4 +43,23 @@ describe('dropdown converter', function () {
             ->toHaveKey('bar')
             ->toContain('Foo');
     });
+
+    test('can normalize dropdown lookups for edit forms', function () {
+        $configuration = Lunar\Admin\Support\FieldTypes\Dropdown::mutateConfigurationForForm([
+            'lookups' => [
+                [
+                    'label' => 'Foo',
+                    'value' => 'bar',
+                ],
+                'Baz' => 'qux',
+            ],
+        ]);
+
+        expect($configuration)->toBe([
+            'lookups' => [
+                'Foo' => 'bar',
+                'Baz' => 'qux',
+            ],
+        ]);
+    });
 });


### PR DESCRIPTION
## Summary

This fixes dropdown attribute lookup hydration when editing attributes in the admin panel. This should resolve PR #2443 too.

Dropdown `lookups` are stored as an array of `{ label, value }` pairs, but the edit form expects keyed state for the `KeyValue` component. That mismatch caused lookup state to hydrate incorrectly in attribute edit flows.

## What changed

- add configuration normalization support for field types
- normalize dropdown lookup configuration for edit-form state
- normalize attribute relation-manager configuration state during hydration
- add focused regression coverage for:
  - dropdown lookup normalization
  - editing dropdown attribute lookups in the relation manager

## Why

The admin attribute edit flow needs dropdown lookup state in keyed form like:

```php
[
    'lookups' => [
        'Foo' => 'bar',
    ],
]
```
but persisted configuration is stored like:

```php
[
    'lookups' => [
        ['label' => 'Foo', 'value' => 'bar'],
    ],
]
```
Without normalization, the edit form mounts with the wrong shape and the lookup field does not hydrate correctly.

## Tests
- tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
- tests/admin/Unit/Support/Forms/AttributeConverters/DropdownConverterTest.php
