### PR TITLE
Fix Price object cast error when editing tier and customer group prices

### DIFF
--- a/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManager.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rules\Unique;
 use Lunar\Admin\Events\ProductPricingUpdated;
 use Lunar\Admin\Support\RelationManagers\BaseRelationManager;
+use Lunar\DataTypes\Price as PriceDataType;
 use Lunar\Facades\DB;
 use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
@@ -76,14 +77,10 @@ class CustomerGroupPricingRelationManager extends BaseRelationManager
                 ])->columns(2),
 
                 Group::make([
-                    TextInput::make('price')->formatStateUsing(
-                        fn ($state) => $state?->decimal(rounding: false)
-                    )->numeric()->helperText(
+                    TextInput::make('price')->numeric()->helperText(
                         __('lunarpanel::relationmanagers.pricing.form.price.helper_text')
                     )->required(),
-                    TextInput::make('compare_price')->formatStateUsing(
-                        fn ($state) => $state?->decimal(rounding: false)
-                    )->label(
+                    TextInput::make('compare_price')->label(
                         __('lunarpanel::relationmanagers.pricing.form.compare_price.label')
                     )->helperText(
                         __('lunarpanel::relationmanagers.pricing.form.compare_price.helper_text')
@@ -152,18 +149,31 @@ class CustomerGroupPricingRelationManager extends BaseRelationManager
                     ),
             ])
             ->recordActions([
-                EditAction::make()->mutateDataUsing(function (array $data): array {
-                    $currencyModel = Currency::find($data['currency_id']);
+                EditAction::make()
+                    ->mutateRecordDataUsing(fn (array $data): array => $this->unwrapPriceData($data))
+                    ->mutateDataUsing(function (array $data): array {
+                        $currencyModel = Currency::find($data['currency_id']);
 
-                    $data['min_quantity'] = 1;
-                    $data['price'] = (int) ($data['price'] * $currencyModel->factor);
-                    $data['compare_price'] = (int) ($data['compare_price'] * $currencyModel->factor);
+                        $data['min_quantity'] = 1;
+                        $data['price'] = (int) ($data['price'] * $currencyModel->factor);
+                        $data['compare_price'] = (int) ($data['compare_price'] * $currencyModel->factor);
 
-                    return $data;
-                })->after(
-                    fn () => ProductPricingUpdated::dispatch($this->getOwnerRecord())
-                ),
+                        return $data;
+                    })->after(
+                        fn () => ProductPricingUpdated::dispatch($this->getOwnerRecord())
+                    ),
                 DeleteAction::make(),
             ]);
+    }
+
+    protected function unwrapPriceData(array $data): array
+    {
+        foreach (['price', 'compare_price'] as $key) {
+            if (($data[$key] ?? null) instanceof PriceDataType) {
+                $data[$key] = $data[$key]->decimal(rounding: false);
+            }
+        }
+
+        return $data;
     }
 }

--- a/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
@@ -17,6 +17,7 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Events\ModelPricesUpdated;
+use Lunar\DataTypes\Price as PriceDataType;
 use Lunar\Facades\DB;
 use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
@@ -93,14 +94,10 @@ class PriceRelationManager extends BaseRelationManager
                 ])->columns(3),
 
                 Group::make([
-                    TextInput::make('price')->formatStateUsing(
-                        fn ($state) => $state?->decimal(rounding: false)
-                    )->numeric()->helperText(
+                    TextInput::make('price')->numeric()->helperText(
                         __('lunarpanel::relationmanagers.pricing.form.price.helper_text')
                     )->required(),
-                    TextInput::make('compare_price')->formatStateUsing(
-                        fn ($state) => $state?->decimal(rounding: false)
-                    )->label(
+                    TextInput::make('compare_price')->label(
                         __('lunarpanel::relationmanagers.pricing.form.compare_price.label')
                     )->helperText(
                         __('lunarpanel::relationmanagers.pricing.form.compare_price.helper_text')
@@ -179,22 +176,35 @@ class PriceRelationManager extends BaseRelationManager
                 ),
             ])
             ->recordActions([
-                EditAction::make()->mutateDataUsing(function (array $data): array {
-                    $currencyModel = Currency::find($data['currency_id']);
+                EditAction::make()
+                    ->mutateRecordDataUsing(fn (array $data): array => $this->unwrapPriceData($data))
+                    ->mutateDataUsing(function (array $data): array {
+                        $currencyModel = Currency::find($data['currency_id']);
 
-                    $data['price'] = (int) ($data['price'] * $currencyModel->factor);
+                        $data['price'] = (int) ($data['price'] * $currencyModel->factor);
 
-                    return $data;
-                })->after(
-                    fn () => ModelPricesUpdated::dispatch(
-                        $this->getOwnerRecord()
-                    )
-                ),
+                        return $data;
+                    })->after(
+                        fn () => ModelPricesUpdated::dispatch(
+                            $this->getOwnerRecord()
+                        )
+                    ),
                 DeleteAction::make()->after(
                     fn () => ModelPricesUpdated::dispatch(
                         $this->getOwnerRecord()
                     )
                 ),
             ]);
+    }
+
+    protected function unwrapPriceData(array $data): array
+    {
+        foreach (['price', 'compare_price'] as $key) {
+            if (($data[$key] ?? null) instanceof PriceDataType) {
+                $data[$key] = $data[$key]->decimal(rounding: false);
+            }
+        }
+
+        return $data;
     }
 }

--- a/tests/admin/Feature/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManagerTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/RelationManagers/CustomerGroupPricingRelationManagerTest.php
@@ -2,9 +2,9 @@
 
 use Filament\Actions\EditAction;
 use Livewire\Livewire;
-use Lunar\Admin\Filament\Resources\ProductResource\Pages\ManageProductPricing;
-use Lunar\Admin\Support\RelationManagers\PriceRelationManager;
+use Lunar\Admin\Filament\Resources\ProductResource\RelationManagers\CustomerGroupPricingRelationManager;
 use Lunar\Models\Currency;
+use Lunar\Models\CustomerGroup;
 use Lunar\Models\Language;
 use Lunar\Models\Price;
 use Lunar\Models\Product;
@@ -12,26 +12,9 @@ use Lunar\Models\ProductVariant;
 use Lunar\Tests\Admin\Feature\Filament\TestCase;
 
 uses(TestCase::class)
-    ->group('support.relation-managers');
+    ->group('resource.product');
 
-it('can render relation manager', function ($model, $page) {
-    $this->asStaff();
-
-    Language::factory()->create([
-        'default' => true,
-    ]);
-
-    $model = $model::factory()->create();
-
-    Livewire::test(PriceRelationManager::class, [
-        'ownerRecord' => $model,
-        'pageClass' => $page,
-    ])->assertSuccessful();
-})->with([
-    [Product::class, ManageProductPricing::class],
-]);
-
-it('can mount the edit action on a tier price without a Price object cast error', function () {
+it('can mount the edit action on a customer group price without a Price object cast error', function () {
     Language::factory()->create([
         'default' => true,
     ]);
@@ -39,6 +22,10 @@ it('can mount the edit action on a tier price without a Price object cast error'
     $currency = Currency::factory()->create([
         'default' => true,
         'decimal_places' => 2,
+    ]);
+
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
     ]);
 
     $product = Product::factory()->create();
@@ -50,22 +37,23 @@ it('can mount the edit action on a tier price without a Price object cast error'
         'priceable_type' => $variant->getMorphClass(),
         'priceable_id' => $variant->id,
         'currency_id' => $currency->id,
-        'min_quantity' => 5,
+        'customer_group_id' => $customerGroup->id,
+        'min_quantity' => 1,
         'price' => 1099,
         'compare_price' => 1299,
     ]);
 
     $this->asStaff(admin: true);
 
-    Livewire::test(PriceRelationManager::class, [
+    Livewire::test(CustomerGroupPricingRelationManager::class, [
         'ownerRecord' => $product,
-        'pageClass' => ManageProductPricing::class,
+        'pageClass' => 'productEdit',
     ])
         ->mountTableAction(EditAction::class, $price)
         ->assertTableActionDataSet([
             'price' => 10.99,
             'compare_price' => 12.99,
-            'min_quantity' => 5,
+            'customer_group_id' => $customerGroup->id,
             'currency_id' => $currency->id,
         ])
         ->assertHasNoErrors();


### PR DESCRIPTION
## Summary

Fixes a regression in 1.5.0-beta.2 / beta.3 where opening the edit modal for a tier price or customer group price throws:

> ErrorException: Object of class Lunar\DataTypes\Price could not be converted to float
> at vendor/filament/schemas/src/Components/StateCasts/NumberStateCast.php:28

This is the same ordering bug as #2441 — Filament v4's `NumberStateCast` (registered by `->numeric()`) runs `floatval()` on the raw state during hydration, before `formatStateUsing` is given a chance to unwrap the value. The two relation managers that bind a `Lunar\DataTypes\Price` object straight to a numeric `TextInput` were not covered by that fix.

PR #2441 solved the equivalent problem for `FieldType` attribute values by overriding `hydrateState`. For prices, the values arrive through plain record attributes, so `EditAction::mutateRecordDataUsing()` runs early enough to convert the `Price` object into its decimal value before child component hydration — which means the `formatStateUsing` calls can be removed entirely.

## Changes

- `PriceRelationManager` and `CustomerGroupPricingRelationManager`: add `mutateRecordDataUsing` on the `EditAction` to convert `Price` objects to their decimal value via a small `unwrapPriceData` helper.
- Drop the now-redundant `formatStateUsing` callbacks on `price` / `compare_price` text inputs.
- Add Pest feature tests that mount the edit action against a stored price and verify the form receives the expected decimal values (these tests fail on `1.x` without the fix with the original exception).

## Test plan

- [x] `vendor/bin/pest --testsuite=admin --group=resource.product`
- [x] `vendor/bin/pest --testsuite=admin --filter='customer group price|tier price'`
- [x] `vendor/bin/pint --format agent` on touched files
- [x] Confirmed the new tests fail on `1.x` without the fix (reproducing the original `Object of class Lunar\DataTypes\Price could not be converted to float` exception)