### PR TITLE
Clean up product associations on product delete

### DIFF
--- a/packages/core/src/Models/ProductAssociation.php
+++ b/packages/core/src/Models/ProductAssociation.php
@@ -73,7 +73,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function parent(): BelongsTo
     {
-        return $this->belongsTo(Product::modelClass(), 'product_parent_id');
+        return $this->belongsTo(Product::modelClass(), 'product_parent_id')->withTrashed();
     }
 
     /**
@@ -81,7 +81,7 @@ class ProductAssociation extends BaseModel implements Contracts\ProductAssociati
      */
     public function target(): BelongsTo
     {
-        return $this->belongsTo(Product::modelClass(), 'product_target_id');
+        return $this->belongsTo(Product::modelClass(), 'product_target_id')->withTrashed();
     }
 
     /**

--- a/packages/core/src/Observers/ProductObserver.php
+++ b/packages/core/src/Observers/ProductObserver.php
@@ -22,16 +22,15 @@ class ProductObserver
 
             $product->productOptions()->detach();
 
-            $product->associations()->delete();
-
-            $product->inverseAssociations()->delete();
-
             $product->channels()->detach();
 
             $product->tags()->detach();
         } else {
             $product->variants()->get()->each->delete();
         }
+
+        $product->associations()->delete();
+        $product->inverseAssociations()->delete();
     }
 
     public function restored(ProductContract $product): void

--- a/tests/core/Unit/Models/ProductTest.php
+++ b/tests/core/Unit/Models/ProductTest.php
@@ -379,6 +379,48 @@ test('product can get all associations', function () {
     expect($parent->refresh()->associations)->toHaveCount(5);
 });
 
+test('soft deleting a product cleans up its associations', function () {
+    $parent = Product::factory()->create();
+    $target = Product::factory()->create();
+
+    ProductAssociation::factory()->create([
+        'product_parent_id' => $parent,
+        'product_target_id' => $target,
+        'type' => 'cross-sell',
+    ]);
+
+    ProductAssociation::factory()->create([
+        'product_parent_id' => $target,
+        'product_target_id' => $parent,
+        'type' => 'cross-sell',
+    ]);
+
+    $target->delete();
+
+    expect($parent->refresh()->associations()->count())->toBe(0);
+    expect(ProductAssociation::query()->where('product_target_id', $target->id)->count())->toBe(0);
+    expect(ProductAssociation::query()->where('product_parent_id', $target->id)->count())->toBe(0);
+});
+
+test('association target resolves a soft-deleted product', function () {
+    $parent = Product::factory()->create();
+    $target = Product::factory()->create();
+
+    $association = ProductAssociation::factory()->create([
+        'product_parent_id' => $parent,
+        'product_target_id' => $target,
+        'type' => 'cross-sell',
+    ]);
+
+    DB::table((new ProductAssociation)->getTable())
+        ->where('id', $association->id)
+        ->update(['updated_at' => now()]);
+    Product::withoutEvents(fn () => $target->delete());
+
+    expect($association->fresh()->target)->not->toBeNull();
+    expect($association->fresh()->target->trashed())->toBeTrue();
+});
+
 test('product can have custom association types', function () {
     $parent = Product::factory()->create();
     $target = Product::factory()->create();


### PR DESCRIPTION
## Summary

- `ProductObserver::deleting` now deletes a product's `associations` and `inverseAssociations` on **soft-delete** as well as force-delete (previously only force-delete cleaned them up).
- `ProductAssociation::parent()` and `target()` now chain `withTrashed()` so any pre-existing orphan rows resolve through the relation rather than returning `null`.
- Tests covering both behaviours.

## Why

`ProductAssociation` has no `SoftDeletes` trait — it's a join-style metadata table. When a product was soft-deleted via the admin, the rows in `lunar_product_associations` referencing it stayed behind as orphans. The associations relation manager then crashed on render:

> Call to a member function translateAttribute() on null
> at `packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductAssociations.php:76`

Treating associations as metadata that doesn't outlive the product (the same way the existing force-delete branch already did) is the correct behaviour and matches the reporter's expectation that "the deleted product just stop[s] showing as a related product".

The `withTrashed()` on the BelongsTo is purely defensive — any orphan rows that already exist in production from before this fix will now resolve to the trashed product and render its name, so the admin user can delete the stale row instead of being met with a 500.

Fixes #2293.

## Test plan

- [x] `vendor/bin/pest --testsuite=core` — 505 passing
- [x] `vendor/bin/pest --testsuite=admin` — 179 passing
- [ ] Manual: associate product A → product B → soft-delete B → admin associations page for A renders without crashing; row can be deleted