### PR TITLE
Apply discounts on guest carts when max_uses_per_user is set

### DIFF
--- a/packages/core/src/DiscountTypes/AbstractDiscountType.php
+++ b/packages/core/src/DiscountTypes/AbstractDiscountType.php
@@ -84,8 +84,8 @@ abstract class AbstractDiscountType implements DiscountTypeInterface
 
         $validMaxUses = $this->discount->max_uses ? $this->discount->uses < $this->discount->max_uses : true;
 
-        if ($validMaxUses && $this->discount->max_uses_per_user) {
-            $validMaxUses = $cart->user && ($this->usesByUser($cart->user) < $this->discount->max_uses_per_user);
+        if ($validMaxUses && $this->discount->max_uses_per_user && $cart->user) {
+            $validMaxUses = $this->usesByUser($cart->user) < $this->discount->max_uses_per_user;
         }
 
         return $validCoupon && $validMinSpend && $validMaxUses;

--- a/tests/core/Unit/DiscountTypes/AbstractDiscountTypeTest.php
+++ b/tests/core/Unit/DiscountTypes/AbstractDiscountTypeTest.php
@@ -11,6 +11,7 @@ use Lunar\Models\Price;
 use Lunar\Models\Product;
 use Lunar\Models\ProductVariant;
 use Lunar\Tests\Core\Stubs\TestAbstractDiscount;
+use Lunar\Tests\Core\Stubs\User;
 use Lunar\Tests\Core\TestCase;
 
 uses(TestCase::class);
@@ -92,4 +93,152 @@ test('will handle customer limitation', function () {
     $cart->refresh()->calculate();
 
     expect($cart->subTotalDiscounted->value)->toBe(900);
+});
+
+test('applies a discount with max uses per user on a guest cart', function () {
+    $channel = Channel::getDefault();
+    $currency = Currency::getDefault();
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+        'coupon_code' => '10OFF',
+    ]);
+
+    Discount::factory()->create([
+        'type' => TestAbstractDiscount::class,
+        'name' => 'Test Coupon',
+        'coupon' => '10OFF',
+        'max_uses_per_user' => 1,
+        'data' => [
+            'fixed_value' => true,
+            'fixed_values' => [
+                'GBP' => 10,
+            ],
+        ],
+    ]);
+
+    $purchasable = ProductVariant::factory()->create([
+        'product_id' => Product::factory(),
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->calculate();
+
+    expect($cart->subTotalDiscounted->value)->toBe(900);
+});
+
+test('applies a discount when the user is under the per-user limit', function () {
+    setAuthUserConfig();
+
+    $channel = Channel::getDefault();
+    $currency = Currency::getDefault();
+    $user = User::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+        'coupon_code' => '10OFF',
+        'user_id' => $user->id,
+    ]);
+
+    Discount::factory()->create([
+        'type' => TestAbstractDiscount::class,
+        'name' => 'Test Coupon',
+        'coupon' => '10OFF',
+        'max_uses_per_user' => 2,
+        'data' => [
+            'fixed_value' => true,
+            'fixed_values' => [
+                'GBP' => 10,
+            ],
+        ],
+    ]);
+
+    $purchasable = ProductVariant::factory()->create([
+        'product_id' => Product::factory(),
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->calculate();
+
+    expect($cart->subTotalDiscounted->value)->toBe(900);
+});
+
+test('does not apply a discount when the user is at the per-user limit', function () {
+    setAuthUserConfig();
+
+    $channel = Channel::getDefault();
+    $currency = Currency::getDefault();
+    $user = User::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+        'coupon_code' => '10OFF',
+        'user_id' => $user->id,
+    ]);
+
+    $discountModel = Discount::factory()->create([
+        'type' => TestAbstractDiscount::class,
+        'name' => 'Test Coupon',
+        'coupon' => '10OFF',
+        'max_uses_per_user' => 1,
+        'data' => [
+            'fixed_value' => true,
+            'fixed_values' => [
+                'GBP' => 10,
+            ],
+        ],
+    ]);
+
+    $discountModel->users()->attach($user->id);
+
+    $purchasable = ProductVariant::factory()->create([
+        'product_id' => Product::factory(),
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->calculate();
+
+    expect($cart->subTotalDiscounted->value)->toBe(1000);
 });


### PR DESCRIPTION
## Summary

- `AbstractDiscountType::checkDiscountConditions()` now only runs the per-user usage check when the cart actually has a user. Guest carts with `max_uses_per_user` set no longer silently fail the condition.
- Added three tests covering guest cart, under-limit user, at-limit user.

## Why

The old condition was:

```php
if ($validMaxUses && $this->discount->max_uses_per_user) {
    $validMaxUses = $cart->user && ($this->usesByUser($cart->user) < $this->discount->max_uses_per_user);
}
```

If the cart had no user attached (guest checkout, or anonymous cart pre-login), `$cart->user` was `null`, so `$validMaxUses` became `false` and the discount was filtered out — but only at calculation time, after the coupon code had already been accepted onto the cart. From the customer's point of view the coupon "worked" but their total never changed. This is exactly what #2442 reported.

A per-user limit only makes sense when a user is known, so the new condition skips the check entirely for guest carts and preserves whatever `$validMaxUses` was already set to:

```php
if ($validMaxUses && $this->discount->max_uses_per_user && $cart->user) {
    $validMaxUses = $this->usesByUser($cart->user) < $this->discount->max_uses_per_user;
}
```

Logged-in users still hit the limit correctly — the third test asserts that an attached usage row blocks reuse.

Fixes #2442.

## Test plan

- [x] `vendor/bin/pest --testsuite=core` — 506 passing
- [ ] Manual: discount with `max_uses_per_user = 1` on a guest cart → discount applies to total
- [ ] Manual: same discount on a logged-in user who has already used it → total unchanged