### PR TITLE
Nullify product brand_id when a brand is deleted

### DIFF
--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -61,6 +61,7 @@ class Brand extends BaseModel implements Contracts\Brand, SpatieHasMedia
     {
         static::deleting(function (self $brand) {
             DB::beginTransaction();
+            $brand->products()->withTrashed()->update(['brand_id' => null]);
             $brand->discounts()->detach();
             $brand->collections()->detach();
             DB::commit();

--- a/tests/core/Unit/Models/BrandTest.php
+++ b/tests/core/Unit/Models/BrandTest.php
@@ -91,9 +91,14 @@ test('can delete a brand', function () {
         'name' => 'Test Brand',
     ]);
 
-    Product::factory()->create([
+    $activeProduct = Product::factory()->create([
         'brand_id' => $brand->id,
     ]);
+
+    $trashedProduct = Product::factory()->create([
+        'brand_id' => $brand->id,
+    ]);
+    $trashedProduct->delete();
 
     $discount = Discount::factory()->create();
     $collection = Collection::factory()->create();
@@ -125,5 +130,15 @@ test('can delete a brand', function () {
 
     assertDatabaseMissing(Brand::class, [
         'id' => $brand->id,
+    ]);
+
+    assertDatabaseHas(Product::class, [
+        'id' => $activeProduct->id,
+        'brand_id' => null,
+    ]);
+
+    assertDatabaseHas(Product::class, [
+        'id' => $trashedProduct->id,
+        'brand_id' => null,
     ]);
 });


### PR DESCRIPTION
## Summary

- `Brand::deleting` now also sets `brand_id = null` on every product (active and soft-deleted) belonging to the brand before the brand row is removed.
- Extends the existing "can delete a brand" test to assert both an active and a soft-deleted product have their `brand_id` cleared.

## Why

The brand delete hook was detaching the `brand_discount` and `brand_collection` pivots but doing nothing with the `lunar_products.brand_id` FK. On databases that actually enforce FKs the brand delete then failed with:

> SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`…`.`lunar_products`, CONSTRAINT `lunar_products_brand_id_foreign` …)

The reporter's repro removes all active products first but the FK still fires because Product uses `SoftDeletes` — the rows are still there with the brand reference. Clearing `brand_id` on both active and trashed products lets the delete go through cleanly. `brand_id` is already nullable on the products table, so there is no schema change.

Fixes #2030.

## Test plan

- [x] `vendor/bin/pest --testsuite=core` — 503 passing
- [ ] Manual on MySQL/MariaDB: create brand → assign product → soft-delete product → delete brand from admin (no FK error)