### PR TITLE
Enforce max_uses_per_user in the standalone CouponValidator

### DIFF
--- a/packages/core/src/Base/Validation/CouponValidator.php
+++ b/packages/core/src/Base/Validation/CouponValidator.php
@@ -8,11 +8,27 @@ class CouponValidator implements CouponValidatorInterface
 {
     public function validate(string $coupon): bool
     {
-        return Discount::query()
+        $discount = Discount::query()
             ->active()
             ->where(function ($query) {
                 $query->whereNull('max_uses')
                     ->orWhereRaw('uses < max_uses');
-            })->where('coupon', '=', strtoupper($coupon))->exists();
+            })->where('coupon', '=', strtoupper($coupon))->first();
+
+        if (! $discount) {
+            return false;
+        }
+
+        if ($discount->max_uses_per_user && $user = auth()->user()) {
+            $uses = $discount->users()
+                ->whereUserId($user->getKey())
+                ->count();
+
+            if ($uses >= $discount->max_uses_per_user) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/core/Unit/Base/Validation/CouponValidatorTest.php
+++ b/tests/core/Unit/Base/Validation/CouponValidatorTest.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Base\Validation\CouponValidator;
 use Lunar\DiscountTypes\AmountOff;
 use Lunar\Models\Discount;
+use Lunar\Tests\Core\Stubs\User;
 use Lunar\Tests\Core\TestCase;
 
 uses(TestCase::class);
@@ -58,6 +59,82 @@ test('can validate based on uses', function () {
     $discount->update([
         'max_uses' => null,
     ]);
+
+    expect($validator->validate('10OFF'))->toBeTrue();
+});
+
+test('enforces max uses per user for the authenticated user', function () {
+    setAuthUserConfig();
+
+    $validator = app(CouponValidator::class);
+
+    $user = User::factory()->create();
+
+    $discount = Discount::factory()->create([
+        'type' => AmountOff::class,
+        'name' => 'Test Coupon',
+        'max_uses_per_user' => 1,
+        'coupon' => '10OFF',
+        'data' => [
+            'fixed_value' => false,
+            'percentage' => 10,
+        ],
+    ]);
+
+    $this->actingAs($user);
+
+    expect($validator->validate('10OFF'))->toBeTrue();
+
+    $discount->users()->attach($user->id);
+
+    expect($validator->validate('10OFF'))->toBeFalse();
+});
+
+test('does not enforce max uses per user for a guest', function () {
+    setAuthUserConfig();
+
+    $validator = app(CouponValidator::class);
+
+    $user = User::factory()->create();
+
+    $discount = Discount::factory()->create([
+        'type' => AmountOff::class,
+        'name' => 'Test Coupon',
+        'max_uses_per_user' => 1,
+        'coupon' => '10OFF',
+        'data' => [
+            'fixed_value' => false,
+            'percentage' => 10,
+        ],
+    ]);
+
+    $discount->users()->attach($user->id);
+
+    expect($validator->validate('10OFF'))->toBeTrue();
+});
+
+test('allows another user when one is at the per-user limit', function () {
+    setAuthUserConfig();
+
+    $validator = app(CouponValidator::class);
+
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+
+    $discount = Discount::factory()->create([
+        'type' => AmountOff::class,
+        'name' => 'Test Coupon',
+        'max_uses_per_user' => 1,
+        'coupon' => '10OFF',
+        'data' => [
+            'fixed_value' => false,
+            'percentage' => 10,
+        ],
+    ]);
+
+    $discount->users()->attach($userA->id);
+
+    $this->actingAs($userB);
 
     expect($validator->validate('10OFF'))->toBeTrue();
 });


### PR DESCRIPTION
## Summary

- `CouponValidator::validate()` now also checks `max_uses_per_user` against the authenticated user when both are present.
- Guests skip the per-user check (consistent with the cart-side fix from #2442).
- Adds three tests covering: authenticated user at the limit, guest with another user at the limit, separate user under the limit.

## Why

The standalone validator only checked the global `max_uses` count, while the cart-side path (`AbstractDiscountType::checkDiscountConditions()`) also enforces `max_uses_per_user`. That left the two entry points in conflict — `Discounts::validateCoupon('FOO')` or the `ValidCoupon` rule would return `true` for a user who had already hit their cap, while applying the same coupon via `cart->update(['coupon_code' => 'FOO'])` correctly rejected it.

The reporter calls this out as an abuse vector — front-end coupon-check endpoints that use the validator give the wrong answer.

Looking up `auth()->user()` inside the validator keeps the interface signature unchanged (`validate(string $coupon): bool`). Guests still pass because there is no per-user state to enforce.

Fixes #2253.

## Test plan

- [x] `vendor/bin/pest --testsuite=core` — 506 passing
- [ ] Manual: user with one redeemed use of a coupon → re-call `Discounts::validateCoupon($coupon)` → returns `false`