### PR TITLE
Scope attribute handle uniqueness by attribute_type

### DIFF
--- a/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
+++ b/packages/admin/src/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManager.php
@@ -76,7 +76,7 @@ class AttributesRelationManager extends BaseRelationManager
                         $set('handle', Str::snake(Str::lower($state)));
                     })
                     ->unique(ignoreRecord: true, modifyRuleUsing: function (Unique $rule, RelationManager $livewire) {
-                        return $rule->where('attribute_group_id', $livewire->ownerRecord->id);
+                        return $rule->where('attribute_type', $livewire->ownerRecord->attributable_type);
                     })->disabled(
                         fn (?Model $record) => (bool) $record
                     )

--- a/tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
+++ b/tests/admin/Feature/Filament/Resources/AttributeGroupResource/RelationManagers/AttributesRelationManagerTest.php
@@ -106,6 +106,72 @@ it('can create attributes', function ($type, $configuration = [], $expectedData 
     ],
 ]);
 
+it('rejects duplicate handles across groups of the same attribute type', function () {
+    Language::factory()->create([
+        'default' => true,
+        'code' => 'en',
+    ]);
+
+    $this->asStaff();
+
+    $groupOne = AttributeGroup::factory()->create([
+        'attributable_type' => 'product',
+    ]);
+
+    $groupTwo = AttributeGroup::factory()->create([
+        'attributable_type' => 'product',
+    ]);
+
+    Attribute::factory()->create([
+        'attribute_group_id' => $groupOne->id,
+        'attribute_type' => 'product',
+        'handle' => 'size',
+    ]);
+
+    Livewire::test(AttributesRelationManager::class, [
+        'ownerRecord' => $groupTwo,
+        'pageClass' => EditAttributeGroup::class,
+    ])->callTableAction(CreateAction::class, data: [
+        'name.en' => 'Size',
+        'type' => Text::class,
+        'handle' => 'size',
+        'configuration' => ['richtext' => false],
+    ])->assertHasTableActionErrors(['handle']);
+});
+
+it('allows duplicate handles across groups of different attribute types', function () {
+    Language::factory()->create([
+        'default' => true,
+        'code' => 'en',
+    ]);
+
+    $this->asStaff();
+
+    $productGroup = AttributeGroup::factory()->create([
+        'attributable_type' => 'product',
+    ]);
+
+    $collectionGroup = AttributeGroup::factory()->create([
+        'attributable_type' => 'collection',
+    ]);
+
+    Attribute::factory()->create([
+        'attribute_group_id' => $productGroup->id,
+        'attribute_type' => 'product',
+        'handle' => 'size',
+    ]);
+
+    Livewire::test(AttributesRelationManager::class, [
+        'ownerRecord' => $collectionGroup,
+        'pageClass' => EditAttributeGroup::class,
+    ])->callTableAction(CreateAction::class, data: [
+        'name.en' => 'Size',
+        'type' => Text::class,
+        'handle' => 'size',
+        'configuration' => ['richtext' => false],
+    ])->assertHasNoTableActionErrors();
+});
+
 it('hydrates dropdown lookups when editing attributes', function () {
     Language::factory()->create([
         'default' => true,


### PR DESCRIPTION
## Summary

- `AttributesRelationManager` form's handle uniqueness rule now scopes by `attribute_type` (matching the DB unique constraint), not by `attribute_group_id`.
- Two new tests: rejects duplicate handle across groups of the same type, allows duplicate handle across groups of different types.

## Why

The DB constraint on `lunar_attributes` is `unique(['attribute_type', 'handle'])`, but the admin form scoped its uniqueness rule by `attribute_group_id`. Creating an attribute with a handle that already existed in a different group of the same `attribute_type` (e.g. two product-typed groups both wanting a `size` handle) sailed past form validation and then died at insert time with:

> SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'product-size' for key 'lunar_attributes.lunar_attributes_attribute_type_handle_unique'

Switching the rule to match the DB constraint surfaces the conflict as a normal validation error on the `handle` field. Same-group duplicates are still caught (same `attribute_type`), and groups with different `attribute_type` can reuse handles freely.

Fixes #2295.

## Test plan

- [x] `vendor/bin/pest --testsuite=admin` — 181 passing
- [ ] Manual: two product-typed groups; create `size` in one; try `size` in the other → handle field shows a validation error instead of 500