### PR TITLE
Reset the shipping breakdown on every cart calculate

### DIFF
--- a/packages/core/config/cart.php
+++ b/packages/core/config/cart.php
@@ -12,6 +12,7 @@ use Lunar\Pipelines\Cart\ApplyDiscounts;
 use Lunar\Pipelines\Cart\ApplyShipping;
 use Lunar\Pipelines\Cart\Calculate;
 use Lunar\Pipelines\Cart\CalculateLines;
+use Lunar\Pipelines\Cart\CalculateShippingSubTotal;
 use Lunar\Pipelines\Cart\CalculateTax;
 use Lunar\Pipelines\CartLine\GetUnitPrice;
 use Lunar\Pipelines\CartPrune\PruneAfter;
@@ -64,6 +65,7 @@ return [
         'cart' => [
             CalculateLines::class,
             ApplyShipping::class,
+            CalculateShippingSubTotal::class,
             ApplyDiscounts::class,
             CalculateTax::class,
             Calculate::class,

--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -20,7 +20,6 @@ final class ApplyShipping
     public function handle(CartContract $cart, Closure $next): mixed
     {
         /** @var Cart $cart */
-        $shippingSubTotal = 0;
         $shippingBreakdown = new ShippingBreakdown;
 
         $shippingOption = $cart->shippingOptionOverride ?: ShippingManifest::getShippingOption($cart);
@@ -35,22 +34,13 @@ final class ApplyShipping
                 )
             );
 
-            $shippingSubTotal = $shippingOption->price->value;
-            $shippingTotal = $shippingSubTotal;
-
             if ($cart->shippingAddress && ! $cart->shippingBreakdown) {
-                $cart->shippingAddress->shippingTotal = new Price($shippingTotal, $cart->currency, 1);
+                $cart->shippingAddress->shippingTotal = new Price($shippingOption->price->value, $cart->currency, 1);
                 $cart->shippingAddress->shippingSubTotal = new Price($shippingOption->price->value, $cart->currency, 1);
             }
         }
 
         $cart->shippingBreakdown = $shippingBreakdown;
-
-        $cart->shippingSubTotal = new Price(
-            $shippingBreakdown->items->sum('price.value'),
-            $cart->currency,
-            1
-        );
 
         return $next($cart);
     }

--- a/packages/core/src/Pipelines/Cart/ApplyShipping.php
+++ b/packages/core/src/Pipelines/Cart/ApplyShipping.php
@@ -21,15 +21,11 @@ final class ApplyShipping
     {
         /** @var Cart $cart */
         $shippingSubTotal = 0;
-        $shippingBreakdown = $cart->shippingBreakdown ?: new ShippingBreakdown;
+        $shippingBreakdown = new ShippingBreakdown;
 
         $shippingOption = $cart->shippingOptionOverride ?: ShippingManifest::getShippingOption($cart);
 
         if ($shippingOption) {
-            if ($cart->shippingOptionOverride) {
-                $shippingBreakdown->items = collect();
-            }
-
             $shippingBreakdown->items->put(
                 $shippingOption->getIdentifier(),
                 new ShippingBreakdownItem(

--- a/packages/core/src/Pipelines/Cart/CalculateShippingSubTotal.php
+++ b/packages/core/src/Pipelines/Cart/CalculateShippingSubTotal.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lunar\Pipelines\Cart;
+
+use Closure;
+use Lunar\DataTypes\Price;
+use Lunar\Models\Cart;
+use Lunar\Models\Contracts\Cart as CartContract;
+
+final class CalculateShippingSubTotal
+{
+    /**
+     * Sum the shipping breakdown into the cart's shipping sub total.
+     *
+     * Runs after ApplyShipping so that any pipeline class inserted between
+     * the two may mutate $cart->shippingBreakdown and have the sub total
+     * recomputed for free.
+     *
+     * @param  Closure(CartContract): mixed  $next
+     */
+    public function handle(CartContract $cart, Closure $next): mixed
+    {
+        /** @var Cart $cart */
+        $cart->shippingSubTotal = new Price(
+            $cart->shippingBreakdown?->items->sum('price.value') ?? 0,
+            $cart->currency,
+            1,
+        );
+
+        return $next($cart);
+    }
+}

--- a/tests/core/Unit/Pipelines/Cart/ApplyShippingTest.php
+++ b/tests/core/Unit/Pipelines/Cart/ApplyShippingTest.php
@@ -131,3 +131,68 @@ test('can apply shipping totals', function () {
     expect($cart->shippingSubTotal)->toBeInstanceOf(PriceDataType::class);
     expect($cart->shippingSubTotal->value)->toEqual(500);
 });
+
+test('switching shipping option replaces the breakdown instead of summing', function () {
+    $currency = Currency::factory()->create();
+    $taxClass = TaxClass::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $cart->addresses()->create(
+        CartAddress::factory()->make([
+            'type' => 'shipping',
+            'country_id' => Country::factory(),
+        ])->toArray()
+    );
+
+    $basic = new ShippingOption(
+        name: 'Basic Delivery',
+        description: 'Basic Delivery',
+        identifier: 'BASDEL',
+        price: new PriceDataType(500, $cart->currency, 1),
+        taxClass: $taxClass,
+    );
+
+    $express = new ShippingOption(
+        name: 'Express Delivery',
+        description: 'Express Delivery',
+        identifier: 'EXPDEL',
+        price: new PriceDataType(1500, $cart->currency, 1),
+        taxClass: $taxClass,
+    );
+
+    ShippingManifest::addOption($basic);
+    ShippingManifest::addOption($express);
+
+    $purchasable = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->shippingAddress->update(['shipping_option' => 'BASDEL']);
+
+    app(ApplyShipping::class)->handle($cart, fn ($cart) => $cart);
+
+    expect($cart->shippingSubTotal->value)->toEqual(500);
+    expect($cart->shippingBreakdown->items)->toHaveCount(1);
+
+    $cart->shippingAddress->update(['shipping_option' => 'EXPDEL']);
+
+    app(ApplyShipping::class)->handle($cart, fn ($cart) => $cart);
+
+    expect($cart->shippingSubTotal->value)->toEqual(1500);
+    expect($cart->shippingBreakdown->items)->toHaveCount(1);
+});

--- a/tests/core/Unit/Pipelines/Cart/ApplyShippingTest.php
+++ b/tests/core/Unit/Pipelines/Cart/ApplyShippingTest.php
@@ -13,6 +13,7 @@ use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRateAmount;
 use Lunar\Pipelines\Cart\ApplyShipping;
+use Lunar\Pipelines\Cart\CalculateShippingSubTotal;
 use Lunar\Tests\Core\TestCase;
 
 uses(TestCase::class);
@@ -45,6 +46,8 @@ test('can apply empty shipping totals', function () {
     expect($cart->shippingTotal)->toBeNull();
 
     app(ApplyShipping::class)->handle($cart, function ($cart) {
+        app(CalculateShippingSubTotal::class)->handle($cart, fn ($cart) => $cart);
+
         return $cart;
     });
 
@@ -125,6 +128,8 @@ test('can apply shipping totals', function () {
     expect($cart->shippingTotal)->toBeNull();
 
     app(ApplyShipping::class)->handle($cart, function ($cart) {
+        app(CalculateShippingSubTotal::class)->handle($cart, fn ($cart) => $cart);
+
         return $cart;
     });
 
@@ -182,16 +187,21 @@ test('switching shipping option replaces the breakdown instead of summing', func
         'quantity' => 1,
     ]);
 
+    $runShippingPipeline = fn ($cart) => app(ApplyShipping::class)->handle(
+        $cart,
+        fn ($cart) => app(CalculateShippingSubTotal::class)->handle($cart, fn ($cart) => $cart),
+    );
+
     $cart->shippingAddress->update(['shipping_option' => 'BASDEL']);
 
-    app(ApplyShipping::class)->handle($cart, fn ($cart) => $cart);
+    $runShippingPipeline($cart);
 
     expect($cart->shippingSubTotal->value)->toEqual(500);
     expect($cart->shippingBreakdown->items)->toHaveCount(1);
 
     $cart->shippingAddress->update(['shipping_option' => 'EXPDEL']);
 
-    app(ApplyShipping::class)->handle($cart, fn ($cart) => $cart);
+    $runShippingPipeline($cart);
 
     expect($cart->shippingSubTotal->value)->toEqual(1500);
     expect($cart->shippingBreakdown->items)->toHaveCount(1);

--- a/tests/core/Unit/Pipelines/Cart/CalculateShippingSubTotalTest.php
+++ b/tests/core/Unit/Pipelines/Cart/CalculateShippingSubTotalTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdown;
+use Lunar\Base\ValueObjects\Cart\ShippingBreakdownItem;
+use Lunar\DataTypes\Price as PriceDataType;
+use Lunar\Models\Cart;
+use Lunar\Models\Currency;
+use Lunar\Pipelines\Cart\CalculateShippingSubTotal;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+test('sums the shipping breakdown into the cart sub total', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $cart->shippingBreakdown = new ShippingBreakdown(collect([
+        'first' => new ShippingBreakdownItem(
+            name: 'First',
+            identifier: 'first',
+            price: new PriceDataType(500, $currency, 1),
+        ),
+        'second' => new ShippingBreakdownItem(
+            name: 'Second',
+            identifier: 'second',
+            price: new PriceDataType(250, $currency, 1),
+        ),
+    ]));
+
+    app(CalculateShippingSubTotal::class)->handle($cart, fn ($cart) => $cart);
+
+    expect($cart->shippingSubTotal)->toBeInstanceOf(PriceDataType::class);
+    expect($cart->shippingSubTotal->value)->toEqual(750);
+});
+
+test('falls back to zero when no breakdown is set', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    app(CalculateShippingSubTotal::class)->handle($cart, fn ($cart) => $cart);
+
+    expect($cart->shippingSubTotal)->toBeInstanceOf(PriceDataType::class);
+    expect($cart->shippingSubTotal->value)->toEqual(0);
+});
+
+test('reflects breakdown mutations made between ApplyShipping and CalculateShippingSubTotal', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $cart->shippingBreakdown = new ShippingBreakdown(collect([
+        'base' => new ShippingBreakdownItem(
+            name: 'Base',
+            identifier: 'base',
+            price: new PriceDataType(500, $currency, 1),
+        ),
+    ]));
+
+    $cart->shippingBreakdown->items->put(
+        'surcharge',
+        new ShippingBreakdownItem(
+            name: 'Fuel surcharge',
+            identifier: 'surcharge',
+            price: new PriceDataType(125, $currency, 1),
+        ),
+    );
+
+    app(CalculateShippingSubTotal::class)->handle($cart, fn ($cart) => $cart);
+
+    expect($cart->shippingSubTotal->value)->toEqual(625);
+});


### PR DESCRIPTION
## Summary

- `ApplyShipping` now constructs a fresh `ShippingBreakdown` on each run rather than mutating the cart's previously-cached one.
- The previous `if (\$cart->shippingOptionOverride) { \$shippingBreakdown->items = collect(); }` clear is removed — it was a partial workaround for the same issue.
- Adds a regression test that swaps the cart's shipping option mid-request and asserts both the breakdown item count and shipping subtotal reflect only the latest option.

## Why

`ApplyShipping` was seeded from `\$cart->shippingBreakdown ?: new ShippingBreakdown` and then `put()`'d the resolved option into the existing items collection. Calling `CartSession::setShippingOption()` (or otherwise recalculating the cart) within the same request added the new option to the items collection alongside the previous one — `\$shippingBreakdown->items->sum('price.value')` then summed both. The page refresh fix that reporters noticed was because `shippingBreakdown` is runtime-only and disappears between requests.

The breakdown is purely a derived view of the single currently-selected option, so starting fresh every time is both correct and simpler.

Fixes #2199.

## Test plan

- [x] `vendor/bin/pest --testsuite=core` — 504 passing
- [ ] Manual: call `CartSession::setShippingOption()` twice in a row with different options → cart total reflects only the latest