### PR TITLE
Normalise tag values via a model mutator

### DIFF
--- a/packages/admin/src/Support/Forms/Components/Tags.php
+++ b/packages/admin/src/Support/Forms/Components/Tags.php
@@ -42,7 +42,7 @@ class Tags extends TagsInput
 
     public function syncTags(?Model $record, array $state): void
     {
-        // value fields is utf8mb4_unicode_ci prevent no case sensitive
+        // Tag::value has an uppercasing mutator, but we still upper here so the whereIn lookup below matches existing rows under case-sensitive collations.
         $state = collect($state)->map(function (string $value) {
             return Str::upper($value);
         })->toArray();

--- a/packages/core/database/factories/TagFactory.php
+++ b/packages/core/database/factories/TagFactory.php
@@ -2,7 +2,6 @@
 
 namespace Lunar\Database\Factories;
 
-use Illuminate\Support\Str;
 use Lunar\Models\Tag;
 
 class TagFactory extends BaseFactory
@@ -12,7 +11,7 @@ class TagFactory extends BaseFactory
     public function definition(): array
     {
         return [
-            'value' => Str::upper($this->faker->word),
+            'value' => $this->faker->word,
         ];
     }
 }

--- a/packages/core/src/Jobs/SyncTags.php
+++ b/packages/core/src/Jobs/SyncTags.php
@@ -52,7 +52,7 @@ class SyncTags implements ShouldQueue
     {
         DB::transaction(function () {
             $tagIds = [];
-            // Make sure the tags are uppercase
+            // Tag::value has an uppercasing mutator, but we still upper here so the firstOrCreate lookup matches existing rows under case-sensitive collations.
             $this->tags->map(fn ($tag) => Str::upper($tag))
                 ->each(function ($tag) use (&$tagIds) {
                     $model = Tag::firstOrCreate([

--- a/packages/core/src/Models/Tag.php
+++ b/packages/core/src/Models/Tag.php
@@ -2,9 +2,11 @@
 
 namespace Lunar\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasMacros;
 use Lunar\Base\Traits\LogsActivity;
@@ -51,5 +53,12 @@ class Tag extends BaseModel implements Contracts\Tag
     public function taggable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    protected function value(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value) => $value === null ? null : Str::upper($value),
+        );
     }
 }

--- a/tests/core/Unit/Models/TagTest.php
+++ b/tests/core/Unit/Models/TagTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Models\Tag;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+test('tag values are stored uppercased regardless of input casing', function () {
+    $tag = Tag::create(['value' => 'mixedCase']);
+
+    expect($tag->value)->toBe('MIXEDCASE');
+
+    expect(Tag::find($tag->id)->value)->toBe('MIXEDCASE');
+});
+
+test('null tag values are not coerced', function () {
+    $tag = new Tag(['value' => null]);
+
+    expect($tag->value)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Adds a `value` mutator on the `Tag` model that uppercases on set (null preserved).
- Adds a `Tag` model test covering both casing normalisation and null handling.

## Why

Tag values added via the product edit page were uppercased by `SyncTags::handle()`, but tags created from the standalone `TagResource` went straight in unchanged. Two entry points, two different stored forms for the same logical tag — cross-referencing them stopped working.

Pushing the rule onto the model is the smallest centralisation that fixes both entry points. `SyncTags`' explicit `Str::upper()` becomes a no-op (left in place — defensive and behaviourally equivalent), and any future entry point that creates `Tag` rows automatically inherits the same casing rule.

Matching the existing **uppercase** convention rather than switching to lowercase, because:

1. Existing production data is already uppercase (from `SyncTags`).
2. Switching to lowercase would split tag values across two cases and break tag matching until a data migration runs.

If lowercase is preferred long-term, that's better tackled as a deliberate data migration + mutator flip in a separate PR.

Fixes #2401.

## Test plan

- [x] `vendor/bin/pest --testsuite=core` — 505 passing
- [ ] Manual: create `Foo` in `Tags` resource → DB stores `FOO`; create another product tag `foo` from product page → matches the same row