### PR TITLE
Spec 0014 — Price calculator service

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,6 @@ Each item below should have a written spec in `specs/` (alongside this file in t
 
 ## Outstanding
 
-- Introduce `PriceCalculatorInterface` to consolidate money arithmetic (rounding, tax round-trip, fixed-value distribution, major↔minor conversion) — follow-up to spec 0012, lands after spec 0013 (spec 0014)
 - Ensure all service-layer classes are DI'd
 - Add `name` and `description` dedicated fields
 - Attributes remodel to simplify data and allow for re-use
@@ -54,3 +53,4 @@ Each item below should have a written spec in `specs/` (alongside this file in t
 - Support `Model::preventLazyLoading()`
 - Price data type / cast refactor — replace per-attribute `DataTypes\Price` cast with plain `integer` cast + `FormatsPrices` trait; new `PriceValue` data object for non-Eloquent currency-aware values (spec 0012)
 - `Base/` directory reorganisation — every class drained into a semantic home (`Casts/`, `Concerns/`, `Contracts/`, `DataObjects/`, `Enums/`, `FieldTypes/`, `Manifests/`, `Media/`, `Models/`, `Modifiers/`, `Orders/`, `Telemetry/`, `ValueObjects/`); `*Interface` suffix dropped on contracts; `BaseModel` renamed to `Models\Base`; `Base/` namespace deleted (spec 0013)
+- `PriceCalculatorInterface` consolidates money arithmetic — half-up `percentage`, strict-inverse `withTax`/`withoutTax`, largest-remainder `distribute`, bc-aware `toMinor`/`toMajor`; routed through every previously inline rounding site; new `PriceCalculator` facade (spec 0014)

--- a/packages/admin/src/Filament/Resources/DiscountResource/Pages/EditDiscount.php
+++ b/packages/admin/src/Filament/Resources/DiscountResource/Pages/EditDiscount.php
@@ -8,6 +8,7 @@ use Lunar\Admin\Base\LunarPanelDiscountInterface;
 use Lunar\Admin\Filament\Resources\DiscountResource;
 use Lunar\Admin\Support\Pages\BaseEditRecord;
 use Lunar\Core\DiscountTypes\BuyXGetY;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Currency;
 use Lunar\Filament\RelationManagers\Discount\CollectionConditionRelationManager;
 use Lunar\Filament\RelationManagers\Discount\ProductConditionRelationManager;
@@ -69,7 +70,7 @@ class EditDiscount extends BaseEditRecord
             if (! $currency) {
                 continue;
             }
-            $data['data']['min_prices'][$currencyCode] = (int) round($value * $currency->factor);
+            $data['data']['min_prices'][$currencyCode] = PriceCalculator::toMinor($value, $currency);
         }
 
         foreach ($fixedPrices as $currencyCode => $fixedPrice) {
@@ -80,7 +81,7 @@ class EditDiscount extends BaseEditRecord
             if (! $currency) {
                 continue;
             }
-            $data['data']['fixed_values'][$currencyCode] = (int) round($fixedPrice * $currency->factor);
+            $data['data']['fixed_values'][$currencyCode] = PriceCalculator::toMinor($fixedPrice, $currency);
         }
 
         return $data;

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductPricing.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductPricing.php
@@ -17,6 +17,7 @@ use Lunar\Admin\Filament\Resources\ProductResource;
 use Lunar\Admin\Support\Concerns\Products\ManagesProductPricing;
 use Lunar\Admin\Support\Pages\BaseEditRecord;
 use Lunar\Admin\Support\RelationManagers\PriceRelationManager;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Currency;
 use Lunar\Core\Models\Price;
 use Lunar\Filament\RelationManagers\Product\CustomerGroupPricingRelationManager;
@@ -121,7 +122,7 @@ class ManageProductPricing extends BaseEditRecord
                 CreateAction::make()->mutateDataUsing(function (array $data) {
                     $currencyModel = Currency::find($data['currency_id']);
 
-                    $data['price'] = (int) ($data['price'] * $currencyModel->factor);
+                    $data['price'] = PriceCalculator::toMinor((float) $data['price'], $currencyModel);
 
                     return $data;
                 }),
@@ -130,7 +131,7 @@ class ManageProductPricing extends BaseEditRecord
                 EditAction::make()->mutateDataUsing(function (array $data): array {
                     $currencyModel = Currency::find($data['currency_id']);
 
-                    $data['price'] = (int) ($data['price'] * $currencyModel->factor);
+                    $data['price'] = PriceCalculator::toMinor((float) $data['price'], $currencyModel);
 
                     return $data;
                 }),

--- a/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
+++ b/packages/admin/src/Support/Concerns/Products/ManagesProductPricing.php
@@ -11,6 +11,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Currency;
 use Lunar\Core\Models\Price;
 use Lunar\Filament\Schemas\ProductVariant\ProductVariantForm;
@@ -65,24 +66,32 @@ trait ManagesProductPricing
         unset($data['basePrices']);
         $variant->update($data);
 
+        $currencies = Currency::whereIn('id', $prices->pluck('currency_id')->filter()->unique())->get()->keyBy('id');
+
         $prices->filter(
             fn ($price) => ! ($price['id'] ?? null) && isset($price['value']) && isset($price['currency_id'])
-        )->each(fn ($price) => $variant->prices()->create([
-            'currency_id' => $price['currency_id'],
-            'price' => (int) round((float) ($price['value'] * ($price['factor'] ?? 1))),
-            'compare_price' => (int) round((float) (($price['compare_price'] ?? 0) * ($price['factor'] ?? 1))),
-            'min_quantity' => 1,
-            'customer_group_id' => null,
-        ])
-        );
+        )->each(function ($price) use ($variant, $currencies) {
+            $currency = $currencies->get($price['currency_id']);
+
+            $variant->prices()->create([
+                'currency_id' => $price['currency_id'],
+                'price' => PriceCalculator::toMinor((float) $price['value'], $currency),
+                'compare_price' => PriceCalculator::toMinor((float) ($price['compare_price'] ?? 0), $currency),
+                'min_quantity' => 1,
+                'customer_group_id' => null,
+            ]);
+        });
 
         $prices->filter(
             fn ($price) => ($price['id'] ?? null) && isset($price['value']) && ($price['value'] != $price['original_value'] || $price['compare_price'] != $price['original_compare_price'])
-        )->each(fn ($price) => Price::find($price['id'])->update([
-            'price' => (int) round((float) ($price['value'] * $price['factor'])),
-            'compare_price' => (int) round((float) ($price['compare_price'] * $price['factor'])),
-        ])
-        );
+        )->each(function ($price) use ($currencies) {
+            $currency = $currencies->get($price['currency_id']);
+
+            Price::find($price['id'])->update([
+                'price' => PriceCalculator::toMinor((float) $price['value'], $currency),
+                'compare_price' => PriceCalculator::toMinor((float) $price['compare_price'], $currency),
+            ]);
+        });
 
         $this->basePrices = $this->getBasePrices();
 

--- a/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/PriceRelationManager.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Events\ModelPricesUpdated;
 use Lunar\Core\Facades\DB;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Currency;
 use Lunar\Core\Models\CustomerGroup;
 use Lunar\Core\Models\Price;
@@ -164,7 +165,7 @@ class PriceRelationManager extends BaseRelationManager
                 CreateAction::make()->mutateDataUsing(function (array $data) {
                     $currencyModel = Currency::find($data['currency_id']);
 
-                    $data['price'] = (int) ($data['price'] * $currencyModel->factor);
+                    $data['price'] = PriceCalculator::toMinor((float) $data['price'], $currencyModel);
 
                     return $data;
                 })->label(
@@ -181,7 +182,7 @@ class PriceRelationManager extends BaseRelationManager
                     ->mutateDataUsing(function (array $data): array {
                         $currencyModel = Currency::find($data['currency_id']);
 
-                        $data['price'] = (int) ($data['price'] * $currencyModel->factor);
+                        $data['price'] = PriceCalculator::toMinor((float) $data['price'], $currencyModel);
 
                         return $data;
                     })->after(
@@ -207,7 +208,7 @@ class PriceRelationManager extends BaseRelationManager
                 continue;
             }
 
-            $data[$key] = ((int) $data[$key]) / $currency->factor;
+            $data[$key] = PriceCalculator::toMajor((int) $data[$key], $currency);
         }
 
         return $data;

--- a/packages/core/src/Actions/Orders/RefundOrder.php
+++ b/packages/core/src/Actions/Orders/RefundOrder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Lunar\Core\Actions\AbstractAction;
 use Lunar\Core\DataObjects\PaymentRefund;
 use Lunar\Core\Exceptions\OrderActionException;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Contracts\Order as OrderContract;
 use Lunar\Core\Models\Contracts\Transaction as TransactionContract;
 use Lunar\Core\Models\Order;
@@ -38,7 +39,7 @@ final class RefundOrder extends AbstractAction
             throw new OrderActionException('Transaction is not a successful capture and cannot be refunded.');
         }
 
-        $minorAmount = (int) bcmul((string) $amount, (string) $order->currency->factor);
+        $minorAmount = PriceCalculator::toMinor($amount, $order->currency);
 
         if ($minorAmount <= 0) {
             throw new OrderActionException('Refund amount must be greater than zero.');

--- a/packages/core/src/DiscountTypes/AmountOff.php
+++ b/packages/core/src/DiscountTypes/AmountOff.php
@@ -3,6 +3,7 @@
 namespace Lunar\Core\DiscountTypes;
 
 use Lunar\Core\DataObjects\PriceValue;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Cart;
 use Lunar\Core\Models\Collection;
 use Lunar\Core\Models\Contracts\Cart as CartContract;
@@ -49,10 +50,7 @@ class AmountOff extends AbstractDiscountType
     private function applyFixedValue(array $values, CartContract $cart): CartContract
     {
         $currency = $cart->currency;
-
-        $decimal = ($values[$currency->code] ?? 0) / $currency->factor;
-
-        $value = (int) bcmul($decimal, $currency->factor);
+        $value = (int) ($values[$currency->code] ?? 0);
 
         $lines = $this->getEligibleLines($cart);
 
@@ -64,19 +62,18 @@ class AmountOff extends AbstractDiscountType
             return $cart;
         }
 
-        $divisionalAmount = $value / $linesSubtotal;
+        $weights = $lines
+            ->mapWithKeys(fn ($line, $key) => [$key => ($line->subTotalDiscounted ?? $line->subTotal)->value])
+            ->all();
+
+        $allocations = PriceCalculator::distribute($value, $weights, $currency);
 
         $remaining = $value;
-
         $affectedLines = collect();
 
-        foreach ($lines as $line) {
+        foreach ($lines as $key => $line) {
             $subTotal = ($line->subTotalDiscounted ?? $line->subTotal)->value;
-            $amount = (int) floor($subTotal * $divisionalAmount);
-
-            if ($amount > $subTotal) {
-                $amount = $subTotal;
-            }
+            $amount = min($allocations[$key], $subTotal);
 
             // If this line already has a greater discount value
             // don't add this one as they already have a better deal.
@@ -86,9 +83,8 @@ class AmountOff extends AbstractDiscountType
 
             $remaining -= $amount;
 
-            $line->discountTotal = new PriceValue($amount, $cart->currency);
-
-            $line->subTotalDiscounted = new PriceValue($line->subTotal->value - $amount, $cart->currency);
+            $line->discountTotal = new PriceValue($amount, $currency);
+            $line->subTotalDiscounted = new PriceValue($line->subTotal->value - $amount, $currency);
 
             $affectedLines->push(new DiscountBreakdownLine(
                 line: $line,
@@ -96,14 +92,11 @@ class AmountOff extends AbstractDiscountType
             ));
         }
 
-        // Do we have an amount left over? if so, grab the first line that has
-        // enough left to apply the remaining too.
-        if ($remaining) {
-            // prioritise sharing the remaining over eligible lines
-            $lines->filter(function ($line) {
-                return $line->subTotalDiscounted->value > 0;
-            })
-                ->each(function ($line) use ($affectedLines, $cart, &$remaining) {
+        // Any leftover from caps or skipped lines is re-spread across lines
+        // that still have remaining subtotal.
+        if ($remaining > 0) {
+            $lines->filter(fn ($line) => $line->subTotalDiscounted->value > 0)
+                ->each(function ($line) use ($affectedLines, $currency, &$remaining) {
                     if ($remaining <= 0) {
                         return;
                     }
@@ -113,13 +106,10 @@ class AmountOff extends AbstractDiscountType
 
                     $newDiscountTotal = $line->discountTotal->value + $amountAvailable;
 
-                    $line->discountTotal = new PriceValue($newDiscountTotal, $cart->currency);
+                    $line->discountTotal = new PriceValue($newDiscountTotal, $currency);
+                    $line->subTotalDiscounted = new PriceValue($line->subTotal->value - $newDiscountTotal, $currency);
 
-                    $line->subTotalDiscounted = new PriceValue($line->subTotal->value - $newDiscountTotal, $cart->currency);
-
-                    if (! $affectedLines->first(function ($breakdownLine) use ($line) {
-                        return $breakdownLine->line == $line;
-                    })) {
+                    if (! $affectedLines->first(fn ($breakdownLine) => $breakdownLine->line == $line)) {
                         $affectedLines->push(new DiscountBreakdownLine(
                             line: $line,
                             quantity: $line->quantity
@@ -135,7 +125,7 @@ class AmountOff extends AbstractDiscountType
         $cart->discounts->push($this);
 
         $this->addDiscountBreakdown($cart, new DiscountBreakdown(
-            price: new PriceValue($value - $remaining, $cart->currency),
+            price: new PriceValue($value - $remaining, $currency),
             lines: $affectedLines,
             discount: $this->discount,
         ));
@@ -226,7 +216,7 @@ class AmountOff extends AbstractDiscountType
                 $subTotal = $subTotalDiscounted;
             }
 
-            $amount = (int) round($subTotal * ($value / 100));
+            $amount = PriceCalculator::percentage($subTotal, $value / 100, $cart->currency);
 
             // If this line already has a greater discount value
             // don't add this one as they already have a better deal.

--- a/packages/core/src/Drivers/SystemTaxDriver.php
+++ b/packages/core/src/Drivers/SystemTaxDriver.php
@@ -6,6 +6,7 @@ use Lunar\Core\Actions\Taxes\GetTaxZone;
 use Lunar\Core\Contracts\Addressable;
 use Lunar\Core\Contracts\Purchasable;
 use Lunar\Core\DataObjects\PriceValue;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Contracts\CartLine;
 use Lunar\Core\Models\Contracts\Currency;
 use Lunar\Core\Models\Contracts\TaxZone as TaxZoneContract;
@@ -120,55 +121,45 @@ class SystemTaxDriver implements TaxDriver
         });
 
         if (prices_inc_tax()) {
-            // Remove tax from price
-            $totalTaxPercentage = $taxAmounts->sum('percentage') / 100; // E.g. 0.2 for 20%
-            $priceExTax = round($subTotal / (1 + $totalTaxPercentage));
+            $totalTaxPercentage = (float) $taxAmounts->sum('percentage') / 100;
+            $priceExTax = PriceCalculator::withoutTax((int) $subTotal, $totalTaxPercentage, $this->currency);
 
-            // Check to see if the included tax uses the same tax zone
             if ($this->defaultTaxZone()->id === $taxZone->id) {
-                // Manually return the tax breakdown
+                $expectedTax = (int) $subTotal - $priceExTax;
+                $weights = $taxAmounts
+                    ->mapWithKeys(fn ($amount, $key) => [$key => (int) round((float) $amount->percentage * 10000)])
+                    ->all();
+
+                $allocations = PriceCalculator::distribute($expectedTax, $weights, $this->currency);
+
                 $breakdown = new TaxBreakdown;
 
-                $taxTally = 0;
-
                 foreach ($taxAmounts as $key => $amount) {
-                    if ($taxAmounts->keys()->last() == $key) {
-                        // Ensure the final tax amount adds up to the original price
-                        $result = $subTotal - $priceExTax - $taxTally;
-                    } else {
-                        $result = round($priceExTax * ($amount->percentage / 100));
-                    }
-
-                    $taxTally += $result;
-
-                    $amount = new TaxBreakdownAmount(
-                        price: new PriceValue((int) $result, $this->currency),
+                    $breakdown->addAmount(new TaxBreakdownAmount(
+                        price: new PriceValue($allocations[$key], $this->currency),
                         identifier: "tax_rate_{$amount->taxRate->id}",
                         description: $amount->taxRate->name,
-                        percentage: $amount->percentage
-                    );
-                    $breakdown->addAmount($amount);
+                        percentage: $amount->percentage,
+                    ));
                 }
 
                 return $breakdown;
             }
 
-            // Set subTotal to ex. tax price
             $subTotal = $priceExTax;
         }
 
         $breakdown = new TaxBreakdown;
 
         foreach ($taxAmounts as $amount) {
-            $result = round($subTotal * ($amount->percentage / 100));
+            $result = PriceCalculator::percentage((int) $subTotal, (float) $amount->percentage / 100, $this->currency);
 
-            $amount = new TaxBreakdownAmount(
-                price: new PriceValue((int) $result, $this->currency),
+            $breakdown->addAmount(new TaxBreakdownAmount(
+                price: new PriceValue($result, $this->currency),
                 identifier: "tax_rate_{$amount->taxRate->id}",
                 description: $amount->taxRate->name,
-                percentage: $amount->percentage
-            );
-            $breakdown->addAmount($amount);
+                percentage: $amount->percentage,
+            ));
         }
 
         return $breakdown;

--- a/packages/core/src/Facades/PriceCalculator.php
+++ b/packages/core/src/Facades/PriceCalculator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lunar\Core\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Lunar\Core\Pricing\PriceCalculatorInterface;
+
+/**
+ * @method static int percentage(int $value, float $rate, \Lunar\Core\Models\Contracts\Currency $currency)
+ * @method static int withTax(int $value, float $rate, \Lunar\Core\Models\Contracts\Currency $currency)
+ * @method static int withoutTax(int $value, float $rate, \Lunar\Core\Models\Contracts\Currency $currency)
+ * @method static array<int|string, int> distribute(int $total, array $weights, \Lunar\Core\Models\Contracts\Currency $currency)
+ * @method static int toMinor(int|float|string $major, \Lunar\Core\Models\Contracts\Currency $currency)
+ * @method static float toMajor(int $minor, \Lunar\Core\Models\Contracts\Currency $currency)
+ *
+ * @see PriceCalculatorInterface
+ */
+class PriceCalculator extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return PriceCalculatorInterface::class;
+    }
+}

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -95,7 +95,9 @@ use Lunar\Core\Observers\ProductVariantObserver;
 use Lunar\Core\Observers\TransactionObserver;
 use Lunar\Core\Observers\UrlObserver;
 use Lunar\Core\Orders\ReferenceGenerator as OrderReferenceGeneratorImpl;
+use Lunar\Core\Pricing\DefaultPriceCalculator;
 use Lunar\Core\Pricing\DefaultPriceFormatter;
+use Lunar\Core\Pricing\PriceCalculatorInterface;
 use Lunar\Core\Pricing\PriceFormatterInterface;
 use Lunar\Core\Telemetry\Insights as TelemetryInsights;
 use Lunar\Core\Telemetry\TelemetryService as TelemetryServiceImpl;
@@ -192,6 +194,8 @@ class LunarServiceProvider extends ServiceProvider
 
             return $app->make($concrete, $parameters);
         });
+
+        $this->app->singleton(PriceCalculatorInterface::class, DefaultPriceCalculator::class);
 
         $this->app->singleton(TaxManager::class, function ($app) {
             return $app->make(TaxManagerImpl::class);

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Lunar\Core\Contracts\HasCurrency;
 use Lunar\Core\Database\Factories\PriceFactory;
 use Lunar\Core\DataObjects\PriceValue;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Concerns\FormatsPrices;
 use Lunar\Core\Models\Concerns\HasMacros;
 use Lunar\Core\Models\Contracts\Currency as CurrencyContract;
@@ -140,12 +141,17 @@ class Price extends Base implements Contracts\Price, HasCurrency
     public function priceExTax(?TaxZoneContract $taxZone = null): PriceValue
     {
         $value = (int) $this->price;
+        $currency = $this->resolveCurrency();
 
         if (prices_inc_tax()) {
-            $value = (int) round($value / (1 + $this->getPriceableTaxRate($taxZone)));
+            $value = PriceCalculator::withoutTax(
+                $value,
+                (float) $this->getPriceableTaxRate($taxZone),
+                $currency,
+            );
         }
 
-        return new PriceValue($value, $this->resolveCurrency());
+        return new PriceValue($value, $currency);
     }
 
     /**
@@ -156,12 +162,17 @@ class Price extends Base implements Contracts\Price, HasCurrency
     public function priceIncTax(?TaxZoneContract $taxZone = null): PriceValue
     {
         $value = (int) $this->price;
+        $currency = $this->resolveCurrency();
 
         if (! prices_inc_tax()) {
-            $value = (int) round($value * (1 + $this->getPriceableTaxRate($taxZone)));
+            $value = PriceCalculator::withTax(
+                $value,
+                (float) $this->getPriceableTaxRate($taxZone),
+                $currency,
+            );
         }
 
-        return new PriceValue($value, $this->resolveCurrency());
+        return new PriceValue($value, $currency);
     }
 
     /**
@@ -172,12 +183,17 @@ class Price extends Base implements Contracts\Price, HasCurrency
     public function comparePriceIncTax(?TaxZoneContract $taxZone = null): PriceValue
     {
         $value = (int) $this->compare_price;
+        $currency = $this->resolveCurrency();
 
         if (! prices_inc_tax()) {
-            $value = (int) round($value * (1 + $this->getPriceableTaxRate($taxZone)));
+            $value = PriceCalculator::withTax(
+                $value,
+                (float) $this->getPriceableTaxRate($taxZone),
+                $currency,
+            );
         }
 
-        return new PriceValue($value, $this->resolveCurrency());
+        return new PriceValue($value, $currency);
     }
 
     /**

--- a/packages/core/src/Pricing/DefaultPriceCalculator.php
+++ b/packages/core/src/Pricing/DefaultPriceCalculator.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Lunar\Core\Pricing;
+
+use InvalidArgumentException;
+use Lunar\Core\Models\Contracts\Currency;
+
+class DefaultPriceCalculator implements PriceCalculatorInterface
+{
+    /**
+     * Decimal-places threshold at which {@see toMinor()} switches from
+     * float math to string math (bcmul). Subclass and override to change
+     * the cutover.
+     */
+    protected int $bcMathThreshold = 4;
+
+    public function percentage(int $value, float $rate, Currency $currency): int
+    {
+        return (int) round($value * $rate);
+    }
+
+    public function withTax(int $value, float $rate, Currency $currency): int
+    {
+        if ($rate === 0.0) {
+            return $value;
+        }
+
+        return (int) round($value * (1 + $rate));
+    }
+
+    public function withoutTax(int $value, float $rate, Currency $currency): int
+    {
+        if ($rate === 0.0) {
+            return $value;
+        }
+
+        $candidate = (int) round($value / (1 + $rate));
+
+        // Adjust so that withTax($candidate) is the largest result <= $value.
+        // For values reachable by withTax(), this guarantees the strict
+        // round-trip: withTax(withoutTax($v)) === $v.
+        while ($this->withTax($candidate, $rate, $currency) > $value) {
+            $candidate--;
+        }
+
+        while ($this->withTax($candidate + 1, $rate, $currency) <= $value) {
+            $candidate++;
+        }
+
+        return $candidate;
+    }
+
+    public function distribute(int $total, array $weights, Currency $currency): array
+    {
+        if ($weights === []) {
+            return [];
+        }
+
+        foreach ($weights as $weight) {
+            if ($weight < 0) {
+                throw new InvalidArgumentException('Negative weights are not allowed in distribute().');
+            }
+        }
+
+        $weightTotal = array_sum($weights);
+
+        if ($weightTotal === 0) {
+            return array_map(fn () => 0, $weights);
+        }
+
+        $allocations = [];
+        $remainders = [];
+
+        foreach ($weights as $key => $weight) {
+            $exact = $total * $weight / $weightTotal;
+            $floor = (int) floor($exact);
+            $allocations[$key] = $floor;
+            $remainders[$key] = $exact - $floor;
+        }
+
+        $remaining = $total - array_sum($allocations);
+
+        if ($remaining === 0) {
+            return $allocations;
+        }
+
+        $step = $remaining > 0 ? 1 : -1;
+        $remaining = abs($remaining);
+
+        arsort($remainders);
+
+        foreach (array_keys($remainders) as $key) {
+            if ($remaining === 0) {
+                break;
+            }
+
+            $allocations[$key] += $step;
+            $remaining--;
+        }
+
+        return $allocations;
+    }
+
+    public function toMinor(int|float|string $major, Currency $currency): int
+    {
+        if ($currency->decimal_places >= $this->bcMathThreshold) {
+            $scaled = bcmul((string) $major, (string) $currency->factor, 1);
+
+            return $this->bcRoundHalfUp($scaled);
+        }
+
+        return (int) round((float) $major * $currency->factor);
+    }
+
+    public function toMajor(int $minor, Currency $currency): float
+    {
+        return $minor / $currency->factor;
+    }
+
+    /**
+     * Round a bc-math string with one fractional digit to an int,
+     * half-away-from-zero (matching PHP's `round()` default).
+     */
+    protected function bcRoundHalfUp(string $value): int
+    {
+        if (bccomp($value, '0', 1) >= 0) {
+            return (int) bcadd($value, '0.5', 0);
+        }
+
+        return (int) bcsub($value, '0.5', 0);
+    }
+}

--- a/packages/core/src/Pricing/PriceCalculatorInterface.php
+++ b/packages/core/src/Pricing/PriceCalculatorInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Lunar\Core\Pricing;
+
+use Lunar\Core\Models\Contracts\Currency;
+
+/**
+ * Every operation takes a {@see Currency}, even when the default
+ * implementation doesn't read from it. This is the seam consumers
+ * subclass to apply currency-aware behaviour without changing the
+ * interface shape — e.g. banker's rounding only for JPY, sub-minor
+ * precision for currencies with `decimal_places >= 4`, or
+ * jurisdiction-specific tax rounding rules.
+ */
+interface PriceCalculatorInterface
+{
+    /**
+     * Multiply a minor-unit integer by a rate (e.g. 0.20 for 20%) and
+     * round to whole minor units. Used for tax and percentage-based
+     * discounts.
+     */
+    public function percentage(int $value, float $rate, Currency $currency): int;
+
+    /**
+     * Add tax to a tax-exclusive minor-unit value. `$rate` is a decimal
+     * (0.20 = 20%).
+     */
+    public function withTax(int $value, float $rate, Currency $currency): int;
+
+    /**
+     * Strip tax from a tax-inclusive minor-unit value. Inverse of
+     * {@see withTax()} to the minor unit:
+     * `withTax(withoutTax($v, $r), $r) === $v` is a guarantee.
+     */
+    public function withoutTax(int $value, float $rate, Currency $currency): int;
+
+    /**
+     * Distribute a total across N weighted parts so the parts sum back
+     * to the total exactly (no rounding drift). Used for fixed-value
+     * discount allocation and multi-rate tax breakdown balancing.
+     *
+     * Keys are preserved from `$weights` in the returned array.
+     *
+     * @param  array<int|string, int>  $weights  non-negative integer weights
+     * @return array<int|string, int> values that sum to `$total`
+     */
+    public function distribute(int $total, array $weights, Currency $currency): array;
+
+    /**
+     * Convert a major-unit decimal (e.g. `12.99`) to minor units using
+     * the currency's factor, rounding to whole minor units.
+     */
+    public function toMinor(int|float|string $major, Currency $currency): int;
+
+    /**
+     * Convert a minor-unit integer to a major-unit decimal.
+     */
+    public function toMajor(int $minor, Currency $currency): float;
+}

--- a/packages/table-rate-shipping/src/DiscountTypes/ShippingDiscount.php
+++ b/packages/table-rate-shipping/src/DiscountTypes/ShippingDiscount.php
@@ -10,6 +10,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Lunar\Admin\Base\LunarPanelDiscountInterface;
 use Lunar\Core\DataObjects\PriceValue;
 use Lunar\Core\DiscountTypes\AbstractDiscountType;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Contracts\Cart as CartContract;
 use Lunar\Core\Models\Currency;
 use Lunar\Core\ValueObjects\Cart\DiscountBreakdown;
@@ -81,8 +82,8 @@ class ShippingDiscount extends AbstractDiscountType implements LunarPanelDiscoun
 
             if ($type === 'percentage') {
                 $percentage = (float) ($rule['percentage'] ?? 0);
-                $discountedPrice = (int) round($item->price->value * (1 - $percentage / 100));
-                $discountedPrice = max(0, $discountedPrice);
+                $saving = PriceCalculator::percentage($item->price->value, $percentage / 100, $currency);
+                $discountedPrice = max(0, $item->price->value - $saving);
             } else {
                 if (! isset($rule['prices'][$currency->code])) {
                     $newTotal += $item->price->value;
@@ -210,7 +211,7 @@ class ShippingDiscount extends AbstractDiscountType implements LunarPanelDiscoun
         foreach ($currencies as $currency) {
             $minPrice = $data['data']['min_prices'][$currency->code] ?? null;
             if ($minPrice !== null) {
-                $data['data']['min_prices'][$currency->code] = (int) round($minPrice * $currency->factor);
+                $data['data']['min_prices'][$currency->code] = PriceCalculator::toMinor($minPrice, $currency);
             }
         }
 
@@ -221,7 +222,7 @@ class ShippingDiscount extends AbstractDiscountType implements LunarPanelDiscoun
             foreach ($currencies as $currency) {
                 $price = $method['prices'][$currency->code] ?? null;
                 if ($price !== null) {
-                    $data['data']['methods'][$i]['prices'][$currency->code] = (int) round($price * $currency->factor);
+                    $data['data']['methods'][$i]['prices'][$currency->code] = PriceCalculator::toMinor($price, $currency);
                 }
             }
         }

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource/Pages/ManageShippingRates.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource/Pages/ManageShippingRates.php
@@ -17,6 +17,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
+use Lunar\Core\Facades\PriceCalculator;
 use Lunar\Core\Models\Currency;
 use Lunar\Core\Models\CustomerGroup;
 use Lunar\Shipping\Filament\Resources\ShippingZoneResource;
@@ -242,7 +243,7 @@ class ManageShippingRates extends ManageRelatedRecords
             }
 
             $shippingRate->prices()->create([
-                'price' => (int) round($priceValue * $currency->factor),
+                'price' => PriceCalculator::toMinor($priceValue, $currency),
                 'currency_id' => $currency->id,
                 'customer_group_id' => null,
                 'min_quantity' => 1,
@@ -259,12 +260,12 @@ class ManageShippingRates extends ManageRelatedRecords
                 $currency = $currencies->first(fn ($currency) => $currency->id == $price['currency_id']);
 
                 if ($chargeBy == 'cart_total') {
-                    $price['min_quantity'] = (int) ($price['min_quantity'] * $currency->factor);
+                    $price['min_quantity'] = PriceCalculator::toMinor((float) $price['min_quantity'], $currency);
                 } else {
                     $price['min_quantity'] = (int) $price['min_quantity'];
                 }
 
-                $price['price'] = (int) ($price['price'] * $currency->factor);
+                $price['price'] = PriceCalculator::toMinor((float) $price['price'], $currency);
 
                 return $price;
             }

--- a/specs/completed/0014-price-calculator.md
+++ b/specs/completed/0014-price-calculator.md
@@ -1,6 +1,6 @@
 # 0014 — Price calculator service
 
-- Status: draft
+- Status: implemented
 - Author: Glenn Jacobs
 - Created: 2026-05-26
 - TODO item: (follow-up to 0012)

--- a/tests/core/Feature/Drivers/SystemTaxDriverTest.php
+++ b/tests/core/Feature/Drivers/SystemTaxDriverTest.php
@@ -120,7 +120,8 @@ test('can get breakdown price inc', function () {
         ->getBreakdown($subTotal);
 
     expect($breakdown)->toBeInstanceOf(TaxBreakdown::class);
-    expect($breakdown->amounts[0]->price->value)->toEqual(166);
+    // withoutTax(999, 0.20) = 832 (largest x where withTax(x) <= 999); tax = 999 - 832 = 167.
+    expect($breakdown->amounts[0]->price->value)->toEqual(167);
 });
 
 test('can set tax zone', function () {

--- a/tests/core/Unit/DiscountTypes/AmountOffTest.php
+++ b/tests/core/Unit/DiscountTypes/AmountOffTest.php
@@ -1694,11 +1694,14 @@ test('fixed amount discount distributes across cart lines with different values'
     expect($fourthLine->subTotalDiscounted->value)->toBeGreaterThanOrEqual(0);
     expect($lastLine->subTotalDiscounted->value)->toBeGreaterThanOrEqual(0);
 
-    expect($firstLine->discountTotal->value)->toEqual(150);
+    // Largest-remainder allocation: subtotals 150/200/400/400/360, total 1510,
+    // discount 1500. Floors 148/198/397/397/357 sum to 1497; +1 goes to the
+    // three lines with the largest fractional remainders (A, B, E).
+    expect($firstLine->discountTotal->value)->toEqual(149);
     expect($secondLine->discountTotal->value)->toEqual(199);
     expect($thirdLine->discountTotal->value)->toEqual(397);
     expect($fourthLine->discountTotal->value)->toEqual(397);
-    expect($lastLine->discountTotal->value)->toEqual(357);
+    expect($lastLine->discountTotal->value)->toEqual(358);
     expect($cart->discountTotal->value)->toEqual(1500);
 });
 

--- a/tests/core/Unit/Models/PriceTest.php
+++ b/tests/core/Unit/Models/PriceTest.php
@@ -192,7 +192,8 @@ test('can get a price ex tax', function () {
     ]);
 
     expect($price->priceExTax())->toBeInstanceOf(PriceValue::class);
-    expect($price->priceExTax()->value)->toEqual(833);
+    // Strict inverse: 832 is the largest x where withTax(x, 0.20) <= 999.
+    expect($price->priceExTax()->value)->toEqual(832);
 });
 
 test('can get a price inc tax', function () {

--- a/tests/core/Unit/Pricing/DefaultPriceCalculatorTest.php
+++ b/tests/core/Unit/Pricing/DefaultPriceCalculatorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use Lunar\Core\Models\Currency;
+use Lunar\Core\Pricing\DefaultPriceCalculator;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+function makeCurrency(int $decimals = 2): Currency
+{
+    $currency = new Currency;
+    $currency->code = 'TST';
+    $currency->name = 'Test';
+    $currency->decimal_places = $decimals;
+    $currency->factor = (int) (10 ** $decimals);
+    $currency->exchange_rate = 1;
+    $currency->enabled = true;
+    $currency->default = true;
+
+    return $currency;
+}
+
+test('percentage rounds half away from zero', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    expect($calc->percentage(100, 0.20, $currency))->toBe(20);
+    expect($calc->percentage(99, 0.20, $currency))->toBe(20); // 19.8 -> 20
+    expect($calc->percentage(1, 0.5, $currency))->toBe(1);    // 0.5 -> 1
+    expect($calc->percentage(0, 0.99, $currency))->toBe(0);
+});
+
+test('withTax applies the rate', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    expect($calc->withTax(1000, 0.20, $currency))->toBe(1200);
+    expect($calc->withTax(1000, 0.0, $currency))->toBe(1000);
+    expect($calc->withTax(99, 0.175, $currency))->toBe(116); // 116.325 -> 116
+});
+
+test('withoutTax is a strict inverse of withTax for all rates', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    $rates = [0.0, 0.05, 0.10, 0.175, 0.20, 0.2125, 0.25, 0.27];
+
+    foreach ($rates as $rate) {
+        for ($x = 0; $x < 500; $x++) {
+            $withTax = $calc->withTax($x, $rate, $currency);
+            $back = $calc->withoutTax($withTax, $rate, $currency);
+
+            // The result is the largest x' where withTax(x') <= withTax(x),
+            // so withTax(back) === withTax(x) is the strict round-trip.
+            expect($calc->withTax($back, $rate, $currency))->toBe($withTax);
+        }
+    }
+});
+
+test('withoutTax then withTax recovers the original value', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    foreach ([0.05, 0.10, 0.20, 0.175] as $rate) {
+        for ($v = 0; $v < 500; $v++) {
+            $withTax = $calc->withTax($v, $rate, $currency);
+            expect($calc->withTax($calc->withoutTax($withTax, $rate, $currency), $rate, $currency))
+                ->toBe($withTax);
+        }
+    }
+});
+
+test('distribute sums back to the total exactly', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    $result = $calc->distribute(100, [1, 1, 1], $currency);
+    expect(array_sum($result))->toBe(100);
+
+    $result = $calc->distribute(1000, [33, 33, 34], $currency);
+    expect(array_sum($result))->toBe(1000);
+
+    $result = $calc->distribute(7, [1, 1, 1], $currency);
+    expect(array_sum($result))->toBe(7);
+});
+
+test('distribute preserves keys and uses largest remainder', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    $result = $calc->distribute(10, ['a' => 1, 'b' => 1, 'c' => 1], $currency);
+
+    expect(array_keys($result))->toBe(['a', 'b', 'c']);
+    expect(array_sum($result))->toBe(10);
+    // Two lines get the +1, the third the floor.
+    expect(array_values($result))->toContain(3, 4);
+});
+
+test('distribute zero-weight lines get zero', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    $result = $calc->distribute(100, [50, 0, 50], $currency);
+
+    expect($result)->toBe([0 => 50, 1 => 0, 2 => 50]);
+});
+
+test('distribute all-zero weights returns zeros', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    expect($calc->distribute(100, [0, 0, 0], $currency))->toBe([0, 0, 0]);
+});
+
+test('distribute throws on negative weights', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    expect(fn () => $calc->distribute(100, [50, -1, 50], $currency))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('distribute empty weights returns empty', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency();
+
+    expect($calc->distribute(100, [], $currency))->toBe([]);
+});
+
+test('toMinor with 2 decimal places uses float math', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency(2);
+
+    expect($calc->toMinor(12.99, $currency))->toBe(1299);
+    expect($calc->toMinor('12.99', $currency))->toBe(1299);
+    expect($calc->toMinor(0, $currency))->toBe(0);
+});
+
+test('toMinor with 3 decimal places', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency(3);
+
+    expect($calc->toMinor(1.234, $currency))->toBe(1234);
+    expect($calc->toMinor('1.234', $currency))->toBe(1234);
+});
+
+test('toMinor with 4 decimal places uses bc math', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency(4);
+
+    expect($calc->toMinor('1.2345', $currency))->toBe(12345);
+    expect($calc->toMinor('1.99995', $currency))->toBe(20000); // half-up
+});
+
+test('toMajor inverts toMinor', function () {
+    $calc = new DefaultPriceCalculator;
+    $currency = makeCurrency(2);
+
+    expect($calc->toMajor(1299, $currency))->toBe(12.99);
+});


### PR DESCRIPTION
## Summary

Implements [spec 0014](./specs/completed/0014-price-calculator.md). Introduces `PriceCalculatorInterface` to consolidate money arithmetic that was previously scattered across the cart pipelines, tax driver, and discount types — and routes every previously inline rounding-sensitive site through the new `PriceCalculator` facade.

- New `Pricing\PriceCalculatorInterface` contract + `DefaultPriceCalculator` implementation: half-up `percentage` rounding; strict-inverse `withTax`/`withoutTax` with a search-based round-trip guarantee; largest-remainder `distribute`; bc-math `toMinor` for currencies with `decimal_places >= 4`.
- New `Facades\PriceCalculator` facade. Bound as a container singleton in `LunarServiceProvider` — swap via the container in your own `AppServiceProvider`, no config key.
- Migrated 12 call sites: `Price::priceExTax`/`priceIncTax`/`comparePriceIncTax`, `SystemTaxDriver::getBreakdown` (both inc/exc-tax branches, replacing the "subtract from last item" balancing with `distribute()`), `AmountOff::applyPercentage` + `applyFixedValue`, `ShippingDiscount::apply` + `lunarPanelOnSave`, `RefundOrder`, `ManagesProductPricing`, `ManageProductPricing`, `PriceRelationManager`, `ManageShippingRates`.

## Behavioural changes (spec-documented)

Two changes affect `prices_inc_tax` stores:

1. **`withoutTax` is now a strict inverse of `withTax`.** Previously it could drift by 1 minor unit on certain rates; now `withTax(withoutTax($v, $r), $r) === $v` is guaranteed for any value reachable from `withTax`. Affects displayed tax-exclusive prices on a small subset of catalogue prices.
2. **Fixed-amount discount allocation uses largest-remainder.** Previously the leftover from `floor()` was given to the first lines with capacity; now it goes to the lines with the largest fractional remainder. Cart totals are unchanged; per-line distribution may differ by 1 minor unit.

Test expectations updated to reflect both.

## Test plan

- [x] `vendor/bin/pint --dirty --format agent` — clean
- [x] `vendor/bin/phpstan analyse --no-progress` — 0 errors
- [x] `vendor/bin/pest --testsuite=core` — 595 pass / 1 skipped (1422 assertions in affected areas)
- [x] `vendor/bin/pest --testsuite=admin` — 188 pass
- [x] `vendor/bin/pest --testsuite=shipping` — 98 pass
- [x] 14 new `DefaultPriceCalculatorTest` cases covering rounding, the strict round-trip invariant, largest-remainder distribution, key preservation, and bc-math threshold (6026 assertions)
- [ ] Smoke-test the admin panel: create a product price (2/3/4 decimal currencies), apply a fixed-value discount across multiple lines, issue an order refund, save a table-rate-shipping rate

## Notes for reviewers

- A follow-up spec (0015) is in flight to add currency-aware arithmetic to `PriceValue` (`add`/`subtract`/`sum` with a `MismatchedCurrencyException` guard). That spec will land separately so it can be reviewed on its own.
- The `pricing.formatter` config key still uses the old "string in config" pattern. Worth a separate sweep to drop it in favour of container binding too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)