### PR TITLE
fix(attributes): fix hydrateState signature for Filament 4.11

### DIFF
--- a/packages/admin/src/Support/Forms/Components/Attributes.php
+++ b/packages/admin/src/Support/Forms/Components/Attributes.php
@@ -71,13 +71,13 @@ class Attributes extends Group
         $this->rawState($data);
     }
 
-    public function hydrateState(?array &$hydratedDefaultState, bool $shouldCallHydrationHooks = true): void
+    public function hydrateState(?array &$hydratedDefaultState, bool $shouldCallHydrationHooks = true, bool $shouldApplyStateCasts = true, array &$appliedStateCastPaths = []): void
     {
         if ($hydratedDefaultState === null) {
             $this->unwrapFieldTypeState();
         }
 
-        parent::hydrateState($hydratedDefaultState, $shouldCallHydrationHooks);
+        parent::hydrateState($hydratedDefaultState, $shouldCallHydrationHooks, $shouldApplyStateCasts, $appliedStateCastPaths);
     }
 
     public function hydrateStatePartially(array $statePaths, bool $shouldCallHydrationHooks = true): void

--- a/packages/admin/src/Support/Forms/Components/TextInputSelectAffix.php
+++ b/packages/admin/src/Support/Forms/Components/TextInputSelectAffix.php
@@ -63,11 +63,11 @@ class TextInputSelectAffix extends TextInput
         }
     }
 
-    public function hydrateState(?array &$hydratedDefaultState, bool $andCallHydrationHooks = true): void
+    public function hydrateState(?array &$hydratedDefaultState, bool $andCallHydrationHooks = true, bool $shouldApplyStateCasts = true, array &$appliedStateCastPaths = []): void
     {
-        parent::hydrateState($hydratedDefaultState, $andCallHydrationHooks);
+        parent::hydrateState($hydratedDefaultState, $andCallHydrationHooks, $shouldApplyStateCasts, $appliedStateCastPaths);
         if ($this->hasSelect()) {
-            $this->getSelectComponent()->hydrateState($hydratedDefaultState, $andCallHydrationHooks);
+            $this->getSelectComponent()->hydrateState($hydratedDefaultState, $andCallHydrationHooks, $shouldApplyStateCasts, $appliedStateCastPaths);
         }
     }
 


### PR DESCRIPTION
Filament 4.11 added `$shouldApplyStateCasts` and `$appliedStateCastPaths` parameters to `Component::hydrateState()`. Updates the override in `Attributes` to match, fixing a fatal error when viewing any resource that uses the Attributes component.

Introduced in: https://github.com/filamentphp/filament/pull/19911
