### PR TITLE
fix: trim whitespace from string attributes on BaseModel

### DIFF
--- a/packages/core/src/Base/BaseModel.php
+++ b/packages/core/src/Base/BaseModel.php
@@ -24,6 +24,11 @@ abstract class BaseModel extends Model
         }
     }
 
+    public function setAttribute($key, $value): mixed
+    {
+        return parent::setAttribute($key, is_string($value) ? trim($value) : $value);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/core/Unit/Base/BaseModelTest.php
+++ b/tests/core/Unit/Base/BaseModelTest.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use Lunar\Base\BaseModel;
 use Lunar\Base\Traits\HasModelExtending;
 use Lunar\Models\Collection as ModelsCollection;
+use Lunar\Models\CustomerGroup;
 use Lunar\Models\Product;
 use Lunar\Models\Url;
 use Lunar\Tests\Core\TestCase;
@@ -68,4 +69,12 @@ test('macros are scoped to the correct model', function () {
 test('base model includes trait', function () {
     $uses = class_uses_recursive(BaseModel::class);
     expect(in_array(HasModelExtending::class, $uses))->toBeTrue();
+});
+
+test('trims leading and trailing whitespace from string attributes', function () {
+    $group = CustomerGroup::factory()->create([
+        'handle' => '  my-group  ',
+    ]);
+
+    expect($group->handle)->toBe('my-group');
 });


### PR DESCRIPTION
Laravel's TrimStrings middleware is intentionally skipped for Livewire requests (Livewire\Mechanisms\HandleRequests\HandleRequests calls TrimStrings::skipWhen). This means leading/trailing whitespace entered via Livewire forms (e.g. the admin panel) is never stripped before reaching the model, allowing values like "  size  " to be persisted.

Override setAttribute() on BaseModel to trim all incoming string values before delegating to the parent. This covers every model in Lunar (handle, sku, slug, coupon, code, reference, postcode, etc.)

Fixes #1664