### PR TITLE
fix(core): support PostgreSQL with deterministic ordering

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -214,7 +214,7 @@ class Cart extends BaseModel implements Contracts\Cart
 
     public function lines(): HasMany
     {
-        return $this->hasMany(CartLine::modelClass(), 'cart_id', 'id');
+        return $this->hasMany(CartLine::modelClass(), 'cart_id', 'id')->orderBy('id');
     }
 
     public function currency(): BelongsTo

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -98,7 +98,7 @@ class Order extends BaseModel implements Contracts\Order
 
     public function lines(): HasMany
     {
-        return $this->hasMany(OrderLine::modelClass());
+        return $this->hasMany(OrderLine::modelClass())->orderBy('id');
     }
 
     public function physicalLines(): HasMany

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -106,7 +106,9 @@ class ProductVariant extends BaseModel implements Contracts\ProductVariant, HasT
             "{$prefix}product_option_value_product_variant",
             'variant_id',
             'value_id'
-        )->withTimestamps();
+        )->withTimestamps()
+            ->orderBy('position')
+            ->orderByPivot('id');
     }
 
     public function getPrices(): Collection

--- a/tests/core/Unit/Models/CartTest.php
+++ b/tests/core/Unit/Models/CartTest.php
@@ -1330,3 +1330,33 @@ test('cart session manager prefers the latest unmerged cart for an authenticated
         ->and($foundCart->id)->not->toBe($mergedCart->id)
         ->and($foundCart->merged_id)->toBeNull();
 });
+
+test('orders cart lines by id', function () {
+    $cart = Cart::factory()->create();
+
+    // Cart::lines() must carry an explicit ordering contract. Without an
+    // ORDER BY, row order is undefined by the SQL standard: MySQL/InnoDB
+    // returns clustered primary-key order by coincidence, but PostgreSQL
+    // returns heap order, which changes after an UPDATE. Lunar relies on a
+    // stable line sequence (e.g. GenerateFingerprint reduces $cart->lines in
+    // iteration order), so it must be deterministic across engines.
+    expect($cart->lines()->toBase()->orders)
+        ->toBe([['column' => 'id', 'direction' => 'asc']]);
+});
+
+test('can retrieve cart lines in ascending id order', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $lines = CartLine::factory()
+        ->count(5)
+        ->create(['cart_id' => $cart->id]);
+
+    $expectedOrder = $lines->pluck('id')->sort()->values()->all();
+
+    expect($cart->load('lines')->lines->pluck('id')->all())
+        ->toBe($expectedOrder);
+});

--- a/tests/core/Unit/Models/OrderTest.php
+++ b/tests/core/Unit/Models/OrderTest.php
@@ -300,3 +300,26 @@ test('can delete an order', function () {
         'id' => $order->id,
     ]);
 });
+
+test('orders order lines by id', function () {
+    $order = Order::factory()->create();
+
+    // Order::lines() must carry an explicit ordering contract so line order is
+    // deterministic across database engines. PostgreSQL does not return rows in
+    // insertion order without an ORDER BY, which shifts invoice/history display.
+    expect($order->lines()->toBase()->orders)
+        ->toBe([['column' => 'id', 'direction' => 'asc']]);
+});
+
+test('can retrieve order lines in ascending id order', function () {
+    $order = Order::factory()->create();
+
+    $lines = OrderLine::factory()
+        ->count(5)
+        ->create(['order_id' => $order->id]);
+
+    $expectedOrder = $lines->pluck('id')->sort()->values()->all();
+
+    expect($order->load('lines')->lines->pluck('id')->all())
+        ->toBe($expectedOrder);
+});

--- a/tests/core/Unit/Models/ProductVariantTest.php
+++ b/tests/core/Unit/Models/ProductVariantTest.php
@@ -8,6 +8,8 @@ use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
 use Lunar\Models\Price;
 use Lunar\Models\Product;
+use Lunar\Models\ProductOption;
+use Lunar\Models\ProductOptionValue;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRate;
@@ -276,4 +278,23 @@ test('reports unpurchasable when the parent product is soft-deleted', function (
     $product->delete();
 
     expect($variant->fresh()->isPurchasable())->toBeFalse();
+});
+
+test('returns variant option values ordered by position', function () {
+    $variant = ProductVariant::factory()->create();
+    $option = ProductOption::factory()->create();
+
+    // Attached deliberately out of position order. Without an explicit ORDER BY
+    // the pivot rows would come back in attachment order ([3, 1, 2]); the
+    // relationship must order by the option value's position so getOption()
+    // (snapshotted onto order lines) is deterministic across database engines.
+    $values = collect([3, 1, 2])->map(fn ($position) => ProductOptionValue::factory()->create([
+        'product_option_id' => $option->id,
+        'position' => $position,
+    ]));
+
+    $variant->values()->attach($values->pluck('id')->all());
+
+    expect($variant->load('values')->values->pluck('position')->all())
+        ->toBe([1, 2, 3]);
 });


### PR DESCRIPTION
### What & why

Several core relationships had no explicit `ORDER BY`, so row order depended on the database engine. MySQL/InnoDB returns clustered primary-key order by coincidence, but PostgreSQL — which is officially supported — returns heap order, which changes after an `UPDATE`. Running on PostgreSQL surfaces this as user-visible instability.

### Changes

- **`Cart::lines()`** and **`Order::lines()`** now order by `id`. Lunar relies on a stable line sequence: `GenerateFingerprint` reduces `$cart->lines` *in iteration order*, so an unstable order can change a cart's fingerprint after an unrelated update, not just shift the displayed order. Ordering `Order::lines()` also stabilizes the derived `physicalLines`/`digitalLines`/`shippingLines`/`productLines`.
- **`ProductVariant::values()`** now orders by `position`, with the pivot `id` as a deterministic tie-break across options. `getOption()` joins these values into the variant option label, which is snapshotted onto order lines in `CreateOrderLines`, so the persisted value must be deterministic across engines.

This follows the relationship-level ordering convention already used by `Order::transactions()`, `ProductOption::values()`, and `AttributeGroup::attributes()`.

### Tests

New coverage in `CartTest`, `OrderTest`, and `ProductVariantTest`. Each ordering test fails on the current code and passes with the fix. The full `tests/core` suite passes (561 passed, 1 skipped); Pint is clean.

> Note: the test database is SQLite, which returns rows in insertion order, so a behavioural heap-reorder cannot be reproduced there directly. The cart/order tests therefore assert the ordering contract on the relationship itself; the variant test asserts position ordering against a deliberately out-of-order attachment, which fails without the fix on any engine.

Fixes #2517