### PR TITLE
fix(pricing): correct formatterStyle parameter type from string to int

### DIFF
--- a/packages/core/src/Pricing/DefaultPriceFormatter.php
+++ b/packages/core/src/Pricing/DefaultPriceFormatter.php
@@ -33,17 +33,17 @@ class DefaultPriceFormatter implements PriceFormatterInterface
         return $rounding ? round($convertedValue, $this->currency->decimal_places) : $convertedValue;
     }
 
-    public function formatted(?string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, ?int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    public function formatted(?string $locale = null, int $formatterStyle = NumberFormatter::CURRENCY, ?int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
     {
         return $this->formatValue($this->decimal(false), $locale, $formatterStyle, $decimalPlaces, $trimTrailingZeros);
     }
 
-    public function unitFormatted(?string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, ?int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    public function unitFormatted(?string $locale = null, int $formatterStyle = NumberFormatter::CURRENCY, ?int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
     {
         return $this->formatValue($this->unitDecimal(false), $locale, $formatterStyle, $decimalPlaces, $trimTrailingZeros);
     }
 
-    protected function formatValue(int|float $value, ?string $locale = null, string $formatterStyle = NumberFormatter::CURRENCY, ?int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
+    protected function formatValue(int|float $value, ?string $locale = null, int $formatterStyle = NumberFormatter::CURRENCY, ?int $decimalPlaces = null, bool $trimTrailingZeros = true): mixed
     {
         if (! $locale) {
             $locale = App::currentLocale();


### PR DESCRIPTION
The `NumberFormatter::CURRENCY` constant is an `int`, so the type hint was incorrect. This fixes strict type compatibility when passing formatter style constants.
