### PR TITLE
Fix DeleteCollection sweeping re-parented descendants

### DIFF
--- a/packages/core/src/Actions/Collections/DeleteCollection.php
+++ b/packages/core/src/Actions/Collections/DeleteCollection.php
@@ -33,6 +33,14 @@ class DeleteCollection implements DeletesCollection
                 }
             }
 
+            // Deleting a nested-set node sweeps its descendants by the node's
+            // in-memory _lft/_rgt. Those can be stale — after re-parenting above,
+            // or whenever the tree shifted since this model was loaded — and the
+            // package only auto-refreshes them when it has performed a node action
+            // this request. Reload so the sweep is bounded by the live position
+            // and can't catch descendants that have already moved away.
+            $collection->refresh();
+
             return (bool) $collection->delete();
         });
     }

--- a/tests/core/Unit/Actions/Collections/DeleteCollectionTest.php
+++ b/tests/core/Unit/Actions/Collections/DeleteCollectionTest.php
@@ -46,3 +46,28 @@ test('re-parents descendants when a target is provided', function () {
     expect(Collection::find($parent->id))->toBeNull();
     expect($child->fresh()->parent_id)->toBe($newHome->id);
 });
+
+// Deleting a nested-set node sweeps its descendants by the node's in-memory
+// bounds. If the collection handed to the action is stale — its subtree moved
+// elsewhere since it was loaded — those bounds still span the moved nodes, and
+// the descendant sweep destroys them. The package only auto-corrects the bounds
+// when it has performed a node action this request, so we zero that flag to model
+// a request where it hasn't and pin the action's correctness independently of it.
+test('does not sweep up descendants that moved out from under a stale collection', function () {
+    $parent = Collection::factory()->create(['collection_group_id' => $this->group->id]);
+    $child = Collection::factory()->create(['collection_group_id' => $this->group->id]);
+    $parent->appendNode($child);
+
+    $stale = $parent->fresh();
+
+    $newHome = Collection::factory()->create(['collection_group_id' => $this->group->id]);
+    $newHome->appendNode($child);
+
+    Collection::$actionsPerformed = 0;
+
+    app(DeleteCollection::class)->execute($stale);
+
+    expect(Collection::find($parent->id))->toBeNull();
+    expect($child->fresh()?->parent_id)->toBe($newHome->id);
+    expect(Collection::find($newHome->id))->not->toBeNull();
+});


### PR DESCRIPTION
## Problem

The `DeleteCollectionTest` "re-parents descendants when a target is provided" test fails intermittently with `Attempt to read property "parent_id" on null` — the re-parented child row gets destroyed during the delete.

`DeleteCollection` deletes the **same in-memory collection** whose nested-set bounds (`_lft`/`_rgt`) were captured *before* its children were moved out. Deleting a nested-set node sweeps its descendants by the node's in-memory bounds, so those stale bounds still span the moved child (and its new parent) and the sweep destroys them.

The only thing normally preventing this is kalnoy/nestedset's `refreshNode()` in the model's `deleting` hook — but that is gated behind a process-global heuristic (`$actionsPerformed !== 0`). The action was relying on a library performance optimization for correctness; when that guard reads 0 at the wrong moment, the stale bounds win.

## Fix

Reload the collection inside the transaction, immediately before deleting, so the descendant sweep is bounded by the **live** tree position rather than possibly-stale in-memory bounds — independent of the package's internal refresh heuristic.

## Test

Adds a deterministic regression test: a stale collection whose subtree was re-homed elsewhere, with the package's auto-refresh inactive. It fails without the fix (child destroyed) and passes with it.

Pint, PHPStan (level 0), and the full core suite (840 passing) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)