### PR TITLE
fix(core): ensure generated time values are correct type.

### DIFF
--- a/packages/core/src/Base/Traits/HasCustomerGroups.php
+++ b/packages/core/src/Base/Traits/HasCustomerGroups.php
@@ -141,11 +141,11 @@ trait HasCustomerGroups
         }
 
         if (! $startsAt) {
-            $startsAt = now();
+            $startsAt = now()->toDateTime();
         }
 
         if (! $endsAt) {
-            $endsAt = now()->addSecond();
+            $endsAt = now()->addSecond()->toDateTime();
         }
 
         return $this->applyCustomerGroupScope($query, $groupIds, $startsAt, $endsAt);


### PR DESCRIPTION
Fix for #2524. CustomerGroup query scope contained a type mismatch when default values are generated. See: `HasCustomerGroups::applyCustomerGroupScope`.