### PR TITLE
Search tweaks

### DIFF
--- a/WHATS-NEW.md
+++ b/WHATS-NEW.md
@@ -105,6 +105,18 @@ the same events, closing the programmatic-change gap. On the read side,
 a registry of named dependency graphs. This gives storefronts a precise cache
 key/invalidation vocabulary without hand-rolled busting.
 
+## Search
+
+Every engine (Database, Meilisearch, Typesense) returns a typed `SearchResults`
+data object with a consistent shape: camelCase keys (`perPage`, `totalPages`),
+the active sort echoed back as `sortField` / `sortDirection`, and facets always
+serialised as a plain array. The search data objects are annotated with
+`spatie/typescript-transformer` v3 attributes (`#[TypeScript]`), so storefronts
+can generate accurate TypeScript definitions for the whole results payload. The
+Typesense engine degrades gracefully — a missing collection yields an empty
+result set instead of an exception, and hybrid semantic search is only requested
+when the collection schema actually declares an embedding field.
+
 ## Pricing & attributes
 
 Prices are stored as plain integers with a `FormatsPrices` trait, and a new

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,12 @@
         "php": "^8.4",
         "spatie/laravel-activitylog": "^4.10.1",
         "spatie/laravel-blink": "^1.7.1",
-        "spatie/laravel-data": "^4.13.1",
+        "spatie/laravel-data": "^4.23",
         "spatie/laravel-medialibrary": "^11.12.7",
         "spatie/laravel-model-states": "^2.11",
         "spatie/laravel-permission": "^6.12",
         "spatie/php-structure-discoverer": "^2.3.1",
+        "spatie/typescript-transformer": "^3.3",
         "stripe/stripe-php": "^16.0",
         "mallardduck/blade-lucide-icons": "^1.26",
         "typesense/typesense-php": "^4.9"

--- a/packages/search/composer.json
+++ b/packages/search/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": "^8.4",
     "lunarphp/core": "self.version",
-    "spatie/laravel-data": "^4.13.1",
+    "spatie/laravel-data": "^4.23",
+    "spatie/typescript-transformer": "^3.3",
     "typesense/typesense-php": "^4.9",
     "meilisearch/meilisearch-php": "^1.10",
     "http-interop/http-factory-guzzle": "^1.2"

--- a/packages/search/src/Data/SearchFacet.php
+++ b/packages/search/src/Data/SearchFacet.php
@@ -4,8 +4,9 @@ namespace Lunar\Search\Data;
 
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
-/** @typescript */
+#[TypeScript]
 class SearchFacet extends Data
 {
     public function __construct(

--- a/packages/search/src/Data/SearchFacetValue.php
+++ b/packages/search/src/Data/SearchFacetValue.php
@@ -4,8 +4,9 @@ namespace Lunar\Search\Data;
 
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
-/** @typescript */
+#[TypeScript]
 class SearchFacetValue extends Data
 {
     public function __construct(

--- a/packages/search/src/Data/SearchHit.php
+++ b/packages/search/src/Data/SearchHit.php
@@ -4,8 +4,9 @@ namespace Lunar\Search\Data;
 
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
-/** @typescript */
+#[TypeScript]
 class SearchHit extends Data
 {
     public function __construct(

--- a/packages/search/src/Data/SearchHitHighlight.php
+++ b/packages/search/src/Data/SearchHitHighlight.php
@@ -3,8 +3,9 @@
 namespace Lunar\Search\Data;
 
 use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
-/** @typescript */
+#[TypeScript]
 class SearchHitHighlight extends Data
 {
     public function __construct(

--- a/packages/search/src/Data/SearchResults.php
+++ b/packages/search/src/Data/SearchResults.php
@@ -4,11 +4,9 @@ namespace Lunar\Search\Data;
 
 use Illuminate\View\View;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
-use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
-use Spatie\LaravelData\Mappers\SnakeCaseMapper;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 
-#[MapName(SnakeCaseMapper::class)]
 /** @typescript */
 class SearchResults extends Data
 {
@@ -22,7 +20,12 @@ class SearchResults extends Data
         public array $hits,
         #[DataCollectionOf(SearchFacet::class)]
         public array $facets,
+        // Serialised via toArray() to the paginator's link array, not the View.
+        #[LiteralTypeScriptType('Array<{ url: string | null; label: string; active: boolean }>')]
         public View $links,
+        public ?string $sortField = null,
+        #[LiteralTypeScriptType("'asc' | 'desc' | null")]
+        public ?string $sortDirection = null,
     ) {}
 
     public function toArray(): array

--- a/packages/search/src/Data/SearchResults.php
+++ b/packages/search/src/Data/SearchResults.php
@@ -6,8 +6,9 @@ use Illuminate\View\View;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
-/** @typescript */
+#[TypeScript]
 class SearchResults extends Data
 {
     public function __construct(

--- a/packages/search/src/Engines/AbstractEngine.php
+++ b/packages/search/src/Engines/AbstractEngine.php
@@ -165,6 +165,24 @@ abstract class AbstractEngine
         return collect($queries);
     }
 
+    /**
+     * The requested sort split into [field, direction] for the results payload,
+     * or [null, null] when no sort was requested. An invalid or missing
+     * direction falls back to `asc`.
+     *
+     * @return array{0: string|null, 1: string|null}
+     */
+    protected function getSortParts(): array
+    {
+        if (! $this->sort) {
+            return [null, null];
+        }
+
+        [$field, $direction] = array_pad(explode(':', $this->sort, 2), 2, null);
+
+        return [$field ?: null, in_array($direction, ['asc', 'desc']) ? $direction : 'asc'];
+    }
+
     protected function sortByIsValid(): bool
     {
         $sort = $this->sort;

--- a/packages/search/src/Engines/DatabaseEngine.php
+++ b/packages/search/src/Engines/DatabaseEngine.php
@@ -19,10 +19,10 @@ class DatabaseEngine extends AbstractEngine
 
         return SearchResults::from([
             'query' => $this->query,
-            'total_pages' => $results->lastPage(),
+            'totalPages' => $results->lastPage(),
             'page' => $results->currentPage(),
             'count' => $results->total(),
-            'per_page' => $results->perPage(),
+            'perPage' => $results->perPage(),
             'hits' => $documents,
             'facets' => collect(),
         ]);

--- a/packages/search/src/Engines/MeilisearchEngine.php
+++ b/packages/search/src/Engines/MeilisearchEngine.php
@@ -46,12 +46,16 @@ class MeilisearchEngine extends AbstractEngine
 
         $results = $paginator->items();
 
+        [$sortField, $sortDirection] = $this->getSortParts();
+
         return SearchResults::from([
             'query' => $results['query'],
-            'total_pages' => $paginator->lastPage(),
+            'totalPages' => $paginator->lastPage(),
             'page' => $paginator->currentPage(),
             'count' => $paginator->total(),
-            'per_page' => $paginator->perPage(),
+            'perPage' => $paginator->perPage(),
+            'sortField' => $sortField,
+            'sortDirection' => $sortDirection,
             'hits' => collect($results['hits'])->map(fn ($hit) => SearchHit::from([
                 'highlights' => collect(),
                 'document' => $hit,

--- a/packages/search/src/Engines/TypesenseEngine.php
+++ b/packages/search/src/Engines/TypesenseEngine.php
@@ -14,6 +14,7 @@ use Lunar\Search\Data\SearchHit;
 use Lunar\Search\Data\SearchHitHighlight;
 use Lunar\Search\Data\SearchResults;
 use Typesense\Documents;
+use Typesense\Exceptions\ObjectNotFound;
 use Typesense\Exceptions\ServiceUnavailable;
 
 class TypesenseEngine extends AbstractEngine
@@ -36,15 +37,29 @@ class TypesenseEngine extends AbstractEngine
 
                 $completeResults = $response['results'][0];
 
+                // A multi-search request resolves with HTTP 200 even when the
+                // collection is missing; the failure surfaces as a per-search
+                // error code in the body (e.g. 404 "Not found."). Treat any
+                // non-200 result as an empty result set rather than letting the
+                // missing 'hits'/'facet_counts' keys blow up downstream.
+                if (($completeResults['code'] ?? 200) !== 200) {
+                    Log::error('Typesense search failed: '.($completeResults['error'] ?? 'Unknown error'));
+
+                    return [
+                        'hits' => [],
+                        'facet_counts' => [],
+                    ];
+                }
+
                 unset($response['results'][0]);
                 $otherResults = $response['results'];
 
-                $facets = collect($completeResults['facet_counts'])->mapWithKeys(
+                $facets = collect($completeResults['facet_counts'] ?? [])->mapWithKeys(
                     fn ($facets) => [$facets['field_name'] => $facets]
                 );
 
                 foreach ($otherResults as $result) {
-                    foreach ($result['facet_counts'] as $facet) {
+                    foreach ($result['facet_counts'] ?? [] as $facet) {
                         $facets->put($facet['field_name'], $facet);
                     }
                 }
@@ -55,7 +70,7 @@ class TypesenseEngine extends AbstractEngine
                 ];
             });
 
-        } catch (ConnectException|ServiceUnavailable  $e) {
+        } catch (ConnectException|ServiceUnavailable|ObjectNotFound $e) {
             Log::error($e->getMessage());
             $paginator = new LengthAwarePaginator(
                 items: [
@@ -81,7 +96,10 @@ class TypesenseEngine extends AbstractEngine
             'document' => $hit['document'],
         ]));
 
-        $facets = collect($results['facet_counts'] ?? [])->map(
+        // The raw facet_counts are keyed by field name (the multi-search merge
+        // above needs that for dedupe); reset to a list so `facets` serialises
+        // as a JSON array, matching MeilisearchEngine::mapFacets().
+        $facets = collect($results['facet_counts'] ?? [])->values()->map(
             fn ($facet) => SearchFacet::from([
                 'label' => $this->getFacetConfig($facet['field_name'])['label'] ?? '',
                 'field' => $facet['field_name'],
@@ -114,12 +132,16 @@ class TypesenseEngine extends AbstractEngine
 
         $newPaginator = clone $paginator;
 
+        [$sortField, $sortDirection] = $this->getSortParts();
+
         return SearchResults::from([
             'query' => $this->query,
-            'total_pages' => $paginator->lastPage(),
+            'totalPages' => $paginator->lastPage(),
             'page' => $paginator->currentPage(),
             'count' => $paginator->total(),
-            'per_page' => $paginator->perPage(),
+            'perPage' => $paginator->perPage(),
+            'sortField' => $sortField,
+            'sortDirection' => $sortDirection,
             'hits' => $documents,
             'facets' => $facets,
             'links' => $newPaginator->setCollection(
@@ -140,7 +162,9 @@ class TypesenseEngine extends AbstractEngine
 
         foreach ($searchQueries as $searchQuery) {
 
-            $filters = collect($options['filter_by']);
+            // Scout passes filter_by through even when empty; a blank entry
+            // joined with real filters produces "unbalanced `&&` operands".
+            $filters = collect($options['filter_by'])->filter(fn ($filter) => filled($filter));
 
             foreach ($this->filters as $key => $value) {
                 $filters->push($key.':'.collect($value)->join(','));
@@ -197,7 +221,10 @@ class TypesenseEngine extends AbstractEngine
                 'facet_by' => implode(',', $searchQuery->facets),
             ];
 
-            if ($this->query) {
+            // Hybrid semantic search only works when the collection schema
+            // actually declares an auto-embed `embedding` field; requesting a
+            // vector query without one 404s the whole multi-search.
+            if ($this->query && $this->schemaHasEmbeddingField()) {
                 $params['vector_query'] = 'embedding:([], k: 200)';
             }
 
@@ -219,6 +246,12 @@ class TypesenseEngine extends AbstractEngine
         return $typesense->getCollections()[$index]->documents->delete([
             'filter_by' => 'id: ['.$ids->join(',').']',
         ]);
+    }
+
+    protected function schemaHasEmbeddingField(): bool
+    {
+        return collect($this->getFieldConfig())
+            ->contains(fn (array $field): bool => ($field['name'] ?? null) === 'embedding');
     }
 
     protected function getFieldConfig(): array

--- a/tests/search/Feature/Engines/TypesenseEngineTest.php
+++ b/tests/search/Feature/Engines/TypesenseEngineTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Config;
+use Lunar\Core\Models\Product;
+use Lunar\Search\Data\SearchResults;
+use Lunar\Search\Engines\TypesenseEngine;
+use Lunar\Search\Facades\Search;
+use Lunar\Tests\Search\TestCase;
+use Mockery\MockInterface;
+
+use function Pest\Laravel\partialMock;
+
+uses(TestCase::class)->group('search');
+
+function mockTypesenseWithResponse(array $response)
+{
+    $engine = partialMock(TypesenseEngine::class, function (MockInterface $mock) use ($response) {
+        $mock->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('getRawResults')
+            ->andReturn(
+                new LengthAwarePaginator(
+                    items: $response,
+                    total: 100,
+                    perPage: 50,
+                    currentPage: 1
+                )
+            );
+        $mock->shouldReceive('setFacets')->andReturnSelf();
+        $mock->shouldReceive('perPage')->andReturnSelf();
+        $mock->shouldReceive('extendQuery')->andReturnSelf();
+    });
+
+    Search::extend('typesense', fn () => $engine);
+}
+
+beforeEach(function () {
+    Config::set('scout.driver', 'typesense');
+    Config::set('lunar.search.engine_map.Lunar\Core\Models\Product', 'typesense');
+});
+
+it('can fetch empty results', function () {
+    mockTypesenseWithResponse([
+        'hits' => [],
+        'facet_counts' => [],
+    ]);
+
+    $results = Search::model(Product::class)->get();
+
+    expect($results)->toBeInstanceOf(SearchResults::class);
+});
+
+it('returns facets as a list even when keyed by field name', function () {
+    // getRawResults returns facet_counts keyed by field name — the shape the
+    // engine's multi-search closure produces when merging per-facet searches.
+    mockTypesenseWithResponse([
+        'hits' => [
+            [
+                'document' => [
+                    'id' => '123',
+                    'name' => 'Foo Bar',
+                ],
+            ],
+        ],
+        'facet_counts' => [
+            'brand' => [
+                'field_name' => 'brand',
+                'counts' => [
+                    ['value' => 'Nike', 'count' => 100],
+                    ['value' => 'Adidas', 'count' => 100],
+                ],
+            ],
+            'size' => [
+                'field_name' => 'size',
+                'counts' => [
+                    ['value' => '10', 'count' => 100],
+                ],
+            ],
+        ],
+    ]);
+
+    $results = Search::model(Product::class)->get();
+
+    expect($results->hits)
+        ->toHaveCount(1)
+        ->and($results->facets)
+        ->toHaveCount(2)
+        ->and(array_is_list($results->facets))
+        ->toBeTrue()
+        ->and($results->facets[0]->field)
+        ->toBe('brand')
+        ->and($results->facets[0]->values)
+        ->toHaveCount(2)
+        ->and($results->facets[0]->values[0]->label)
+        ->toBe('Nike');
+});
+
+it('carries the requested sort and serialises with camelCase keys', function () {
+    mockTypesenseWithResponse([
+        'hits' => [],
+        'facet_counts' => [],
+    ]);
+
+    $results = Search::model(Product::class)->sort('min_price:desc')->get();
+
+    expect($results->sortField)
+        ->toBe('min_price')
+        ->and($results->sortDirection)
+        ->toBe('desc');
+
+    $array = $results->toArray();
+
+    expect($array)
+        ->toHaveKeys(['perPage', 'totalPages', 'sortField', 'sortDirection'])
+        ->and($array)
+        ->not->toHaveKeys(['per_page', 'total_pages']);
+});
+
+it('returns a null sort when none was requested', function () {
+    mockTypesenseWithResponse([
+        'hits' => [],
+        'facet_counts' => [],
+    ]);
+
+    $results = Search::model(Product::class)->get();
+
+    expect($results->sortField)
+        ->toBeNull()
+        ->and($results->sortDirection)
+        ->toBeNull();
+});


### PR DESCRIPTION
Search engine tweaks

What's changed

SearchResults now serialises with camelCase keys and carries the active sort

- Dropped the SnakeCaseMapper from the SearchResults data object, so toArray() now emits perPage / totalPages instead of per_page / total_pages.
- Added sortField and sortDirection to the payload (populated via a new AbstractEngine::getSortParts() helper, [null, null] when no sort is requested), so storefronts can reflect the active sort in the UI.
- Added TypeScript literal types for links and sortDirection so the generated TS definitions are accurate.

TypeScript transformer attributes

- Search data objects are now marked with the #[TypeScript] attribute instead of the /** @typescript */ docblock annotation.
- Added spatie/typescript-transformer (^3.3) as an explicit dependency — the attribute classes live there and were previously not installed. Bumped spatie/laravel-data to ^4.23. Note: typescript-transformer v3 is a rewrite; the attribute namespace is unchanged, but host apps generating definitions via the v2-based laravel-typescript-transformer wrapper should check their transformer config.

Typesense engine hardening

- A multi-search request returns HTTP 200 even when the collection is missing — the failure is a per-search error code in the body. Any non-200 result is now logged and treated as an empty result set instead of blowing up on missing hits / facet_counts keys. ObjectNotFound is also caught alongside the existing connection exceptions.
- Facets are reset to a list (->values()) before serialisation so facets is a JSON array, matching the Meilisearch engine's output.
- Blank filter_by entries passed through by Scout are filtered out — an empty entry joined with real filters produced "unbalanced && operands" errors.
- vector_query (hybrid semantic search) is only added when the collection schema actually declares an auto-embed embedding field; requesting it without one 404s the whole multi-search.

Breaking

SearchResults::toArray() key casing changed (per_page → perPage, total_pages → totalPages) — any consumer reading the old snake_case keys must update.

Tests

New TypesenseEngineTest covering empty results, keyed-facet-to-list normalisation, camelCase serialisation with sort fields, and null sort behaviour.