### PR TITLE
Add delete customer action

### DIFF
--- a/packages/admin/src/Filament/Resources/CustomerResource/Pages/EditCustomer.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/Pages/EditCustomer.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Resources\CustomerResource\Pages;
 
+use Filament\Actions\DeleteAction;
 use Lunar\Admin\Filament\Resources\CustomerResource;
 use Lunar\Admin\Support\Pages\BaseEditRecord;
 
@@ -12,6 +13,7 @@ class EditCustomer extends BaseEditRecord
     protected function getDefaultHeaderActions(): array
     {
         return [
+            DeleteAction::make(),
         ];
     }
 

--- a/packages/admin/src/Filament/Resources/CustomerResource/Pages/ViewCustomer.php
+++ b/packages/admin/src/Filament/Resources/CustomerResource/Pages/ViewCustomer.php
@@ -2,6 +2,7 @@
 
 namespace Lunar\Admin\Filament\Resources\CustomerResource\Pages;
 
+use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Lunar\Admin\Filament\Resources\CustomerResource;
 use Lunar\Admin\Support\Pages\BaseViewRecord;
@@ -24,6 +25,7 @@ class ViewCustomer extends BaseViewRecord
     protected function getDefaultHeaderActions(): array
     {
         return [
+            DeleteAction::make(),
             EditAction::make(),
         ];
     }

--- a/packages/filament/src/Tables/Customer/CustomerTable.php
+++ b/packages/filament/src/Tables/Customer/CustomerTable.php
@@ -3,6 +3,7 @@
 namespace Lunar\Filament\Tables\Customer;
 
 use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -38,6 +39,7 @@ class CustomerTable
                 ])
                 ->recordActions([
                     ViewAction::make(),
+                    DeleteAction::make(),
                 ])
                 ->toolbarActions([
                     BulkActionGroup::make([

--- a/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/EditCustomerTest.php
+++ b/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/EditCustomerTest.php
@@ -89,3 +89,15 @@ it('can save attributes', function () {
 
     expect($record->refresh()->attr('name'))->toBe('New Customer Name');
 });
+
+it('can delete a customer from the edit page', function () {
+    $customer = Customer::factory()->create();
+
+    Livewire::actingAs($this->makeStaff(admin: true), 'staff')
+        ->test(EditCustomer::class, [
+            'record' => $customer->getRouteKey(),
+        ])
+        ->callAction('delete');
+
+    $this->assertModelMissing($customer);
+});

--- a/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/ListCustomersTest.php
+++ b/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/ListCustomersTest.php
@@ -24,3 +24,25 @@ it('can list customers', function () {
         ->assertCountTableRecords(5)
         ->assertCanSeeTableRecords($customers);
 });
+
+it('can delete a customer from the table', function () {
+    $customer = Customer::factory()->create();
+
+    Livewire::actingAs($this->makeStaff(admin: true), 'staff')
+        ->test(ListCustomers::class)
+        ->callTableAction('delete', $customer);
+
+    $this->assertModelMissing($customer);
+});
+
+it('can bulk delete customers', function () {
+    $customers = Customer::factory(3)->create();
+
+    Livewire::actingAs($this->makeStaff(admin: true), 'staff')
+        ->test(ListCustomers::class)
+        ->callTableBulkAction('delete', $customers);
+
+    foreach ($customers as $customer) {
+        $this->assertModelMissing($customer);
+    }
+});

--- a/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/ViewCustomerTest.php
+++ b/tests/admin/Feature/Filament/Resources/CustomerResource/Pages/ViewCustomerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Livewire\Livewire;
+use Lunar\Admin\Filament\Resources\CustomerResource;
+use Lunar\Admin\Filament\Resources\CustomerResource\Pages\ViewCustomer;
+use Lunar\Core\Models\Customer;
+use Lunar\Tests\Admin\Feature\Filament\TestCase;
+
+uses(TestCase::class)
+    ->group('resource.customer');
+
+it('can render customer view page', function () {
+    $this->asStaff(admin: true)
+        ->get(CustomerResource::getUrl('view', ['record' => Customer::factory()->create()]))
+        ->assertSuccessful();
+});
+
+it('can delete a customer from the view page', function () {
+    $customer = Customer::factory()->create();
+
+    Livewire::actingAs($this->makeStaff(admin: true), 'staff')
+        ->test(ViewCustomer::class, [
+            'record' => $customer->getRouteKey(),
+        ])
+        ->callAction('delete');
+
+    $this->assertModelMissing($customer);
+});


### PR DESCRIPTION
## Summary

Adds the ability to delete customers from the admin panel, addressing #2502.

- `DeleteAction` on the customer edit page header
- `DeleteAction` on the customer view page header
- `DeleteAction` as a row action in the customers table (the bulk delete action already existed)

## Tests

- Delete from the edit page
- Delete from the view page (plus a new `ViewCustomerTest` covering rendering)
- Delete a single row and bulk delete from the customers table

🤖 Generated with [Claude Code](https://claude.com/claude-code)