### PR TITLE
fix(filament): filament bridge owns its own config, not admin's

### DIFF
--- a/packages/admin/config/admin.php
+++ b/packages/admin/config/admin.php
@@ -3,41 +3,6 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Enable Variants
-    |--------------------------------------------------------------------------
-    |
-    | When `true` this will show the Variants manager when editing a product. If your
-    | storefront doesn't support variants, set this to false.
-    |
-    */
-    'enable_variants' => true,
-
-    /*
-    |--------------------------------------------------------------------------
-    | PDF Streaming
-    |--------------------------------------------------------------------------
-    |
-    | When handling PDF's in the panel, you can decide whether to stream the PDF in
-    | a new tab or download the PDF to your hard drive.
-    |
-    | Available options are 'download' or 'stream'
-    |
-    */
-    'pdf_rendering' => 'download',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Enable Scout when searching on supported models.
-    |--------------------------------------------------------------------------
-    |
-    | Some models in the core have Scout implemented as a search driver, if you
-    | want to use Scout when possible on tables in the panel, enable it here.
-    |
-    */
-    'scout_enabled' => false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Navigation counts
     |--------------------------------------------------------------------------
     |

--- a/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductVariants.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Pages/ManageProductVariants.php
@@ -30,12 +30,12 @@ class ManageProductVariants extends BaseManageRelatedRecords
 
     public static function shouldRegisterNavigation(array $parameters = []): bool
     {
-        return config('lunar.admin.enable_variants', true);
+        return config('lunar.filament.enable_variants', true);
     }
 
     public static function canAccess(array $parameters = []): bool
     {
-        if (! config('lunar.admin.enable_variants', true)) {
+        if (! config('lunar.filament.enable_variants', true)) {
             return false;
         }
 

--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -255,7 +255,7 @@ class LunarPanelManager
             DispatchServingFilamentEvent::class,
         ];
 
-        if (config('lunar.admin.pdf_rendering', 'download') == 'stream') {
+        if (config('lunar.filament.pdf_rendering', 'download') == 'stream') {
             Route::get('lunar/pdf/download', DownloadPdfController::class)
                 ->name('lunar.pdf.download')->middleware($panelMiddleware);
         }

--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -98,15 +98,15 @@ class LunarPanelProvider extends ServiceProvider
      */
     protected function registerBridgeRecordUrls(): void
     {
-        $this->app['config']->set('lunar-filament.record_urls.order',
+        $this->app['config']->set('lunar.filament.record_urls.order',
             fn ($record, array $context = []) => ManageOrder::getUrl([...$context, 'record' => $record]),
         );
 
-        $this->app['config']->set('lunar-filament.record_urls.product_variant',
+        $this->app['config']->set('lunar.filament.record_urls.product_variant',
             fn ($record, array $context = []) => ProductVariantResource::getUrl('edit', [...$context, 'record' => $record]),
         );
 
-        $this->app['config']->set('lunar-filament.record_urls.collection_edit',
+        $this->app['config']->set('lunar.filament.record_urls.collection_edit',
             fn ($record, array $context = []) => CollectionResource::getUrl('edit', [...$context, 'record' => $record]),
         );
     }

--- a/packages/admin/src/Support/Pages/BaseListRecords.php
+++ b/packages/admin/src/Support/Pages/BaseListRecords.php
@@ -83,7 +83,7 @@ abstract class BaseListRecords extends ListRecords
 
     protected function applySearchToTableQuery(Builder $query): Builder
     {
-        $scoutEnabled = config('lunar.admin.scout_enabled', false);
+        $scoutEnabled = config('lunar.filament.scout_enabled', false);
         $isScoutSearchable = in_array(Searchable::class, class_uses_recursive(static::getModel()));
 
         $this->applyColumnSearchesToTableQuery($query);

--- a/packages/filament/CLAUDE.md
+++ b/packages/filament/CLAUDE.md
@@ -121,6 +121,6 @@ Three supported ways for consumers to bend bridge behaviour, in escalating order
 
 1. **Extension hooks** — `LunarFilament::extensions([SomeClass::class => new class { public function configureForm($form) { … } }])`. Additive, runtime, ideal for "add a field" / "tweak a label" / "wrap an action".
 2. **Subclass and rebind** — extend the bridge class, bind the subclass in the container; `::make()` calls resolve through the container. Use when behaviour changes are too structural for hooks.
-3. **Publish stubs** — `php artisan vendor:publish --tag=lunar-filament.schemas`. Copies into `app/Filament/…` (configurable via `lunar-filament.publish_path`). One-way door — the published copy no longer receives upstream improvements. Prefer the first two strategies unless the consumer genuinely owns the file.
+3. **Publish stubs** — `php artisan vendor:publish --tag=lunar-filament.schemas`. Copies into `app/Filament/…` (configurable via `lunar.filament.publish_path`). One-way door — the published copy no longer receives upstream improvements. Prefer the first two strategies unless the consumer genuinely owns the file.
 
 When designing a new public class, work through all three: hooks should fire at sensible points, the class should be subclass-friendly (final methods only when invariants demand it), and stub-publishable surfaces should be self-contained.

--- a/packages/filament/README.md
+++ b/packages/filament/README.md
@@ -178,7 +178,7 @@ use Lunar\Filament\Forms\Components\Support\RecordSearch;
 $results = RecordSearch::for(Product::class, $search)->take(20)->get();
 ```
 
-It prefers Laravel Scout when both `lunar.admin.scout_enabled` is true and the model uses Scout's `Searchable` trait, falls back to a translated-attribute DB search, and falls back again to a plain `name` column search for models that have neither.
+It prefers Laravel Scout when both `lunar.filament.scout_enabled` is true and the model uses Scout's `Searchable` trait, falls back to a translated-attribute DB search, and falls back again to a plain `name` column search for models that have neither.
 
 ---
 
@@ -375,7 +375,7 @@ class MyProductResource extends Resource
 }
 ```
 
-The trait forwards `getGloballySearchableAttributes`, `getGlobalSearchResultTitle`, `getGlobalSearchResultDetails`, and `getGlobalSearchEloquentQuery` to the descriptor, and routes the actual constraint-building through `RecordSearch` — the same Scout-vs-translated-attribute backend the entity selectors use. Scout is used when `lunar.admin.scout_enabled=true` and the model uses `Laravel\Scout\Searchable`; otherwise the query falls back to LIKE-matching across the resource's attribute list plus any searchable `TranslatedText` attributes.
+The trait forwards `getGloballySearchableAttributes`, `getGlobalSearchResultTitle`, `getGlobalSearchResultDetails`, and `getGlobalSearchEloquentQuery` to the descriptor, and routes the actual constraint-building through `RecordSearch` — the same Scout-vs-translated-attribute backend the entity selectors use. Scout is used when `lunar.filament.scout_enabled=true` and the model uses `Laravel\Scout\Searchable`; otherwise the query falls back to LIKE-matching across the resource's attribute list plus any searchable `TranslatedText` attributes.
 
 `getGlobalSearchResultUrl` stays on the resource — only the resource knows its own URL.
 
@@ -502,7 +502,7 @@ $this->app->bind(
 php artisan vendor:publish --tag=lunar-filament.schemas
 ```
 
-Copies every schema, table, infolist, and relation manager into `app/Filament/…` (configurable in `config/lunar-filament.php` → `publish_path`). The runtime resolver prefers your published copy when both exist.
+Copies every schema, table, infolist, and relation manager into `app/Filament/…` (configurable in `config/lunar/filament.php` → `publish_path`). The runtime resolver prefers your published copy when both exist.
 
 You can also publish:
 
@@ -516,12 +516,15 @@ php artisan vendor:publish --tag=lunar-filament.views     # blade views
 
 ## Configuration
 
-Publish and tweak `config/lunar-filament.php` to change:
+Publish and tweak `config/lunar/filament.php` to change:
 
 - `publish_path` — where stub publication writes files (default: `app/Filament`).
 - `resolver.prefer_published` — runtime preference between published and bridge classes.
 - `register_widgets_on_default_panel` — opt-in auto-registration of the dashboard widgets (off by default for downstream-panel installs).
 - `record_url_resolvers` — closures that map a record + key to a URL inside your panel.
+- `enable_variants` — whether the variants manager shows when editing a product (default: `true`).
+- `pdf_rendering` — `'download'` or `'stream'`, controlling how PDFs are handled when browsing the resource (default: `'download'`).
+- `scout_enabled` — whether to prefer Laravel Scout over the translated-attribute DB search on supported models (default: `false`).
 
 ---
 

--- a/packages/filament/config/filament.php
+++ b/packages/filament/config/filament.php
@@ -59,4 +59,39 @@ return [
         'order' => null,
         'product_variant' => null,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Variants
+    |--------------------------------------------------------------------------
+    |
+    | When `true` this will show the Variants manager when editing a product. If your
+    | storefront doesn't support variants, set this to false.
+    |
+    */
+    'enable_variants' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | PDF Streaming
+    |--------------------------------------------------------------------------
+    |
+    | When handling PDF's when browsing the resource, you can decide whether to stream the
+    | PDF in a new tab or download the PDF to your hard drive.
+    |
+    | Available options are 'download' or 'stream'
+    |
+    */
+    'pdf_rendering' => 'download',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Scout when searching on supported models.
+    |--------------------------------------------------------------------------
+    |
+    | Some models in the core have Scout implemented as a search driver, if you
+    | want to use Scout when possible when searching, enable it here.
+    |
+    */
+    'scout_enabled' => false,
 ];

--- a/packages/filament/src/Actions/Support/DownloadPdfAction.php
+++ b/packages/filament/src/Actions/Support/DownloadPdfAction.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\URL;
  * `Lunar\Filament\Actions\Orders\DownloadOrderPdfAction`) to pre-wire the
  * `pdfView` and filename for a specific resource.
  *
- * Honours `lunar.admin.pdf_rendering` — "stream" emits a temporary signed
+ * Honours `lunar.filament.pdf_rendering` — "stream" emits a temporary signed
  * URL handled by the existing PDF route; "download" streams the response
  * inline.
  */
@@ -41,7 +41,7 @@ class DownloadPdfAction extends Action
     {
         parent::setUp();
 
-        if (config('lunar.admin.pdf_rendering', 'download') === 'stream') {
+        if (config('lunar.filament.pdf_rendering', 'download') === 'stream') {
             $this->url(function ($record) {
                 return URL::temporarySignedRoute(
                     'lunar.pdf.download',

--- a/packages/filament/src/Forms/Components/Support/RecordSearch.php
+++ b/packages/filament/src/Forms/Components/Support/RecordSearch.php
@@ -16,7 +16,7 @@ use function Filament\Support\generate_search_term_expression;
 /**
  * Single search backend shared by every Lunar selector component.
  *
- * Prefers Scout when both `lunar.admin.scout_enabled` is true and the
+ * Prefers Scout when both `lunar.filament.scout_enabled` is true and the
  * model uses Laravel Scout's `Searchable` trait. Falls back to a
  * translated-attribute DB query across the model's searchable attributes.
  */
@@ -43,7 +43,7 @@ class RecordSearch
      */
     public static function shouldUseScout(string $model): bool
     {
-        if (! config('lunar.admin.scout_enabled', false)) {
+        if (! config('lunar.filament.scout_enabled', false)) {
             return false;
         }
 

--- a/packages/filament/src/LunarFilamentServiceProvider.php
+++ b/packages/filament/src/LunarFilamentServiceProvider.php
@@ -15,8 +15,8 @@ class LunarFilamentServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/lunar-filament.php',
-            'lunar-filament'
+            __DIR__.'/../config/filament.php',
+            'lunar.filament'
         );
 
         $this->app['config']->set('lunar.staff.model', Staff::class);
@@ -47,7 +47,7 @@ class LunarFilamentServiceProvider extends ServiceProvider
         );
 
         $this->publishes([
-            __DIR__.'/../config/lunar-filament.php' => config_path('lunar-filament.php'),
+            __DIR__.'/../config/filament.php' => config_path('lunar/filament.php'),
         ], 'lunar-filament.config');
 
         $this->publishes([
@@ -59,9 +59,9 @@ class LunarFilamentServiceProvider extends ServiceProvider
         ], 'lunar-filament.views');
 
         $this->publishes([
-            __DIR__.'/Schemas' => config('lunar-filament.publish_path', app_path('Filament')).'/Schemas',
-            __DIR__.'/Tables' => config('lunar-filament.publish_path', app_path('Filament')).'/Tables',
-            __DIR__.'/RelationManagers' => config('lunar-filament.publish_path', app_path('Filament')).'/RelationManagers',
+            __DIR__.'/Schemas' => config('lunar.filament.publish_path', app_path('Filament')).'/Schemas',
+            __DIR__.'/Tables' => config('lunar.filament.publish_path', app_path('Filament')).'/Tables',
+            __DIR__.'/RelationManagers' => config('lunar.filament.publish_path', app_path('Filament')).'/RelationManagers',
         ], 'lunar-filament.schemas');
 
         $this->registerSynthesizers();

--- a/packages/filament/src/LunarPlugin.php
+++ b/packages/filament/src/LunarPlugin.php
@@ -136,8 +136,8 @@ class LunarPlugin implements Plugin
         // from resources/pages. Toggles are persisted via config for downstream consumers that
         // want to gate UI affordances on whether the plugin enabled them.
         config([
-            'lunar-filament.plugin.global_search' => $this->globalSearch,
-            'lunar-filament.plugin.actions' => $this->actions,
+            'lunar.filament.plugin.global_search' => $this->globalSearch,
+            'lunar.filament.plugin.actions' => $this->actions,
         ]);
     }
 

--- a/packages/filament/src/Schemas/ProductType/ProductTypeForm.php
+++ b/packages/filament/src/Schemas/ProductType/ProductTypeForm.php
@@ -40,7 +40,7 @@ class ProductTypeForm
                                 ->label('')
                                 ->columnSpan(2),
                         ])->visible(
-                            config('lunar.admin.enable_variants', true)
+                            config('lunar.filament.enable_variants', true)
                         ),
                 ])->columnSpan(2),
             ]),

--- a/packages/filament/src/Support/RecordUrls.php
+++ b/packages/filament/src/Support/RecordUrls.php
@@ -7,7 +7,7 @@ namespace Lunar\Filament\Support;
  *
  * Bridge components link out to per-record pages that live in the consuming
  * panel — `lunarphp/admin` by default, or any Filament panel the consumer
- * builds. Each key under `lunar-filament.record_urls.{key}` is a closure
+ * builds. Each key under `lunar.filament.record_urls.{key}` is a closure
  * receiving the record and returning a URL, or null when the bridge should
  * skip the link.
  */
@@ -15,7 +15,7 @@ class RecordUrls
 {
     public static function for(string $key, mixed $record, array $context = []): ?string
     {
-        $resolver = config('lunar-filament.record_urls.'.$key);
+        $resolver = config('lunar.filament.record_urls.'.$key);
 
         if (! is_callable($resolver)) {
             return null;

--- a/packages/filament/src/Support/Resolver.php
+++ b/packages/filament/src/Support/Resolver.php
@@ -8,7 +8,7 @@ use Filament\Tables\Table;
 /**
  * Resolves the runtime class for a bridge schema, table, or relation manager.
  *
- * When `lunar-filament.resolver.prefer_published` is true (the default) and a
+ * When `lunar.filament.resolver.prefer_published` is true (the default) and a
  * subclass exists in the consumer app under the configured `app_namespace`,
  * the published copy is returned instead of the bridge class.
  *
@@ -59,11 +59,11 @@ class Resolver
      */
     public static function resolve(string $bridgeClass): string
     {
-        if (! config('lunar-filament.resolver.prefer_published', true)) {
+        if (! config('lunar.filament.resolver.prefer_published', true)) {
             return $bridgeClass;
         }
 
-        $appNamespace = (string) config('lunar-filament.resolver.app_namespace', 'App\\Filament');
+        $appNamespace = (string) config('lunar.filament.resolver.app_namespace', 'App\\Filament');
 
         $relative = static::relativePath($bridgeClass);
 

--- a/packages/filament/src/Tables/ProductType/ProductTypeTable.php
+++ b/packages/filament/src/Tables/ProductType/ProductTypeTable.php
@@ -55,7 +55,7 @@ class ProductTypeTable
                 )
                 ->label(__('lunar-filament::producttype.table.variant_attributes_count.label'))
                 ->visible(
-                    config('lunar.admin.enable_variants', true)
+                    config('lunar.filament.enable_variants', true)
                 ),
         ];
     }

--- a/tests/admin/Feature/Filament/Panel/GlobalSearch/GlobalSearchTest.php
+++ b/tests/admin/Feature/Filament/Panel/GlobalSearch/GlobalSearchTest.php
@@ -18,7 +18,7 @@ uses(TestCase::class)
     ->group('actions');
 
 beforeEach(function () {
-    Config::set('lunar.admin.scout_enabled', false);
+    Config::set('lunar.filament.scout_enabled', false);
 
     $this->asStaff(admin: true);
 });

--- a/tests/admin/Feature/Filament/Resources/BrandResource/Actions/SearchTest.php
+++ b/tests/admin/Feature/Filament/Resources/BrandResource/Actions/SearchTest.php
@@ -11,7 +11,7 @@ uses(TestCase::class)
 
 it('can search brand by name on brand list', function () {
 
-    Config::set('lunar.admin.scout_enabled', false);
+    Config::set('lunar.filament.scout_enabled', false);
 
     $this->asStaff(admin: true);
 

--- a/tests/filament/Unit/Forms/Components/Support/RecordSearchTest.php
+++ b/tests/filament/Unit/Forms/Components/Support/RecordSearchTest.php
@@ -10,20 +10,20 @@ use Lunar\Tests\Filament\TestCase;
 uses(TestCase::class);
 
 it('returns a database builder when scout is disabled', function () {
-    config()->set('lunar.admin.scout_enabled', false);
+    config()->set('lunar.filament.scout_enabled', false);
 
     expect(RecordSearch::for(Brand::class, 'acme'))->toBeInstanceOf(Builder::class);
 });
 
 it('reports scout usage based on config and trait', function () {
-    config()->set('lunar.admin.scout_enabled', true);
+    config()->set('lunar.filament.scout_enabled', true);
 
     expect(RecordSearch::shouldUseScout(Product::class))->toBeTrue()
         ->and(RecordSearch::shouldUseScout(Attribute::class))->toBeFalse();
 });
 
 it('does not use scout when disabled', function () {
-    config()->set('lunar.admin.scout_enabled', false);
+    config()->set('lunar.filament.scout_enabled', false);
 
     expect(RecordSearch::shouldUseScout(Product::class))->toBeFalse();
 });

--- a/tests/filament/Unit/ServiceProviderTest.php
+++ b/tests/filament/Unit/ServiceProviderTest.php
@@ -35,8 +35,14 @@ it('exposes the service provider via package discovery', function () {
 });
 
 it('exposes the lunar-filament config namespace', function () {
-    expect(config('lunar-filament'))->toBeArray()
-        ->and(config('lunar-filament.resolver.app_namespace'))->toBe('App\\Filament');
+    expect(config('lunar.filament'))->toBeArray()
+        ->and(config('lunar.filament.resolver.app_namespace'))->toBe('App\\Filament');
+});
+
+it('defaults the config keys relocated from lunar.admin', function () {
+    expect(config('lunar.filament.enable_variants'))->toBeTrue()
+        ->and(config('lunar.filament.pdf_rendering'))->toBe('download')
+        ->and(config('lunar.filament.scout_enabled'))->toBeFalse();
 });
 
 it('boots a LunarFilament facade backed by the registry', function () {

--- a/tests/filament/Unit/Support/RecordUrlsTest.php
+++ b/tests/filament/Unit/Support/RecordUrlsTest.php
@@ -6,13 +6,13 @@ use Lunar\Tests\Filament\TestCase;
 uses(TestCase::class);
 
 it('returns null when no resolver is configured', function () {
-    config()->set('lunar-filament.record_urls.order', null);
+    config()->set('lunar.filament.record_urls.order', null);
 
     expect(RecordUrls::for('order', (object) ['id' => 1]))->toBeNull();
 });
 
 it('invokes the configured callable resolver', function () {
-    config()->set('lunar-filament.record_urls.order',
+    config()->set('lunar.filament.record_urls.order',
         fn ($record) => 'https://example.test/orders/'.$record->id,
     );
 

--- a/tests/filament/Unit/Support/ResolverTest.php
+++ b/tests/filament/Unit/Support/ResolverTest.php
@@ -11,7 +11,7 @@ it('returns the bridge class when no published subclass exists', function () {
 });
 
 it('returns the bridge class when prefer_published is disabled', function () {
-    config()->set('lunar-filament.resolver.prefer_published', false);
+    config()->set('lunar.filament.resolver.prefer_published', false);
 
     expect(Resolver::resolve(BrandForm::class))->toBe(BrandForm::class);
 });


### PR DESCRIPTION
## Problem

`lunarphp/filament` is a standalone-installable Filament v5 bridge package — its own README says install `lunarphp/admin` for the turnkey panel, and admin depends on filament, not the other way around. But three of filament's own files read config keys (`enable_variants`, `pdf_rendering`, `scout_enabled`) from `lunar.admin.*`, a namespace only merged when `lunarphp/admin` happens to also be installed. A site running `lunarphp/filament` alone could never configure these — they silently fall back to hardcoded defaults with no way to override them.

This predates #2551 (the keys were `lunar.panel.*` before, owned by admin then too — that PR renamed the key while carrying the same cross-package coupling forward). Flagged during review of that PR.

## Fix

- `packages/filament/config/lunar-filament.php` → `packages/filament/config/filament.php`, merged under `lunar.filament` (was a flat top-level `lunar-filament` key), published to `config/lunar/filament.php` — now matches the `admin`/`panel`/`core` sibling-package convention.
- Moved `enable_variants`, `pdf_rendering`, `scout_enabled` out of `lunar.admin` config into filament's own config, since filament is the actual consumer of all three.
- Updated every call site (7 production reads across `admin`/`filament`, plus a config-writer in `LunarPlugin.php` for internal consistency) and every test referencing the old keys/namespace.

**Explicitly out of scope**: the `lunar-filament` translation namespace (~660 `__('lunar-filament::...')` calls), view namespace, the four `publishes()` tag names (`lunar-filament.config`/`.lang`/`.views`/`.schemas`), and the `lunar-filament.extensions` container alias — none of those changed.

## Breaking change

`lunar.admin.enable_variants` / `.pdf_rendering` / `.scout_enabled` move to `lunar.filament.*`. v2 is unreleased, so no published upgrade path is required (same precedent as #2551's `lunar.panel` → `lunar.admin` rename).

## Verification

`filament` suite 41/82 passing, `admin` suite 235/787 passing, PHPStan clean (level 0, no ignores/baseline), Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)