### PR TITLE
Translate product-variants widget labels

### DIFF
--- a/packages/admin/resources/lang/en/productoption.php
+++ b/packages/admin/resources/lang/en/productoption.php
@@ -49,6 +49,9 @@ return [
                 'save-options' => [
                     'label' => 'Save Options',
                 ],
+                'save-variants' => [
+                    'label' => 'Save Variants',
+                ],
                 'add-shared-option' => [
                     'label' => 'Add Shared Option',
                     'form' => [

--- a/packages/admin/resources/views/resources/product-resource/widgets/product-options.blade.php
+++ b/packages/admin/resources/views/resources/product-resource/widgets/product-options.blade.php
@@ -64,7 +64,7 @@
                 <div class="fi-ta-empty-state-icon-bg">
                   {{ \Filament\Support\generate_icon_html('lucide-shapes', size: \Filament\Support\Enums\IconSize::Large) }}
                 </div>
-                <h4 class="fi-ta-empty-state-heading">No Product Options Configured</h4>
+                <h4 class="fi-ta-empty-state-heading">{{ __('lunarpanel::productoption.widgets.product-options.options-list.empty.heading') }}</h4>
               </div>
             </div>
           @endif

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -59,6 +59,9 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
             ->get();
 
         return Action::make('addSharedOption')
+            ->label(
+                __('lunarpanel::productoption.widgets.product-options.actions.add-shared-option.label')
+            )
             ->schema([
                 Shout::make('no_shared_components')
                     ->content(
@@ -356,6 +359,9 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
     public function saveVariantsAction(): Action
     {
         return Action::make('saveVariants')
+            ->label(
+                __('lunarpanel::productoption.widgets.product-options.actions.save-variants.label')
+            )
             ->action(function () {
                 DB::beginTransaction();
 


### PR DESCRIPTION
Fixes #2554.

Three strings on the product **Variants** screen rendered in English regardless of locale:

- **"Add shared option"** and **"Save variants"** actions had no `->label()`, so Filament humanised the action names.
- **"No Product Options Configured"** was hardcoded in the Blade view, while the two sibling empty states on the same view already use translation keys.

## Changes
- `ProductOptionsWidget` — apply the existing `add-shared-option.label` key to the `addSharedOption` action, and a new `save-variants.label` key to the `saveVariants` action.
- `lang/en/productoption.php` — add the `save-variants.label` key (`Save Variants`). Other locales fall back to English until translated.
- `product-options.blade.php` — route the hardcoded empty-state heading through `options-list.empty.heading`.

No behaviour change beyond localisation; verified in a Turkish-locale panel that all three now translate.