### PR TITLE
fix: make record URL resolvers config-cache safe

### DIFF
--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -9,11 +9,9 @@ use Illuminate\Support\ServiceProvider;
 use Lunar\Admin\Console\Commands\MakeLunarAdminCommand;
 use Lunar\Admin\Console\Commands\PublishAdminResourcesCommand;
 use Lunar\Admin\Events\CustomerUserEdited;
-use Lunar\Admin\Filament\Resources\CollectionResource;
-use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
-use Lunar\Admin\Filament\Resources\ProductVariantResource;
 use Lunar\Admin\Listeners\FilamentUpgradedListener;
 use Lunar\Admin\Support\ActivityLog\Manifest as ActivityLogManifest;
+use Lunar\Admin\Support\RecordUrlResolvers;
 
 class LunarPanelProvider extends ServiceProvider
 {
@@ -98,17 +96,9 @@ class LunarPanelProvider extends ServiceProvider
      */
     protected function registerBridgeRecordUrls(): void
     {
-        $this->app['config']->set('lunar.filament.record_urls.order',
-            fn ($record, array $context = []) => ManageOrder::getUrl([...$context, 'record' => $record]),
-        );
-
-        $this->app['config']->set('lunar.filament.record_urls.product_variant',
-            fn ($record, array $context = []) => ProductVariantResource::getUrl('edit', [...$context, 'record' => $record]),
-        );
-
-        $this->app['config']->set('lunar.filament.record_urls.collection_edit',
-            fn ($record, array $context = []) => CollectionResource::getUrl('edit', [...$context, 'record' => $record]),
-        );
+        $this->app['config']->set('lunar.filament.record_urls.order', [RecordUrlResolvers::class, 'order']);
+        $this->app['config']->set('lunar.filament.record_urls.product_variant', [RecordUrlResolvers::class, 'productVariant']);
+        $this->app['config']->set('lunar.filament.record_urls.collection_edit', [RecordUrlResolvers::class, 'collectionEdit']);
     }
 
     /**

--- a/packages/admin/src/Support/RecordUrlResolvers.php
+++ b/packages/admin/src/Support/RecordUrlResolvers.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lunar\Admin\Support;
+
+use Lunar\Admin\Filament\Resources\CollectionResource;
+use Lunar\Admin\Filament\Resources\OrderResource\Pages\ManageOrder;
+use Lunar\Admin\Filament\Resources\ProductVariantResource;
+
+class RecordUrlResolvers
+{
+    public static function order(mixed $record, array $context = []): string
+    {
+        return ManageOrder::getUrl([...$context, 'record' => $record]);
+    }
+
+    public static function productVariant(mixed $record, array $context = []): string
+    {
+        return ProductVariantResource::getUrl('edit', [...$context, 'record' => $record]);
+    }
+
+    public static function collectionEdit(mixed $record, array $context = []): string
+    {
+        return CollectionResource::getUrl('edit', [...$context, 'record' => $record]);
+    }
+}

--- a/tests/admin/Unit/LunarPanelProviderTest.php
+++ b/tests/admin/Unit/LunarPanelProviderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Lunar\Admin\Support\RecordUrlResolvers;
+use Lunar\Tests\Admin\Unit\Filament\TestCase;
+
+uses(TestCase::class)
+    ->group('lunar.admin');
+
+it('registers serializable record URL resolvers', function (): void {
+    $resolvers = [
+        'lunar.filament.record_urls.order' => [RecordUrlResolvers::class, 'order'],
+        'lunar.filament.record_urls.product_variant' => [RecordUrlResolvers::class, 'productVariant'],
+        'lunar.filament.record_urls.collection_edit' => [RecordUrlResolvers::class, 'collectionEdit'],
+    ];
+
+    foreach ($resolvers as $key => $resolver) {
+        expect(config($key))
+            ->toBe($resolver)
+            ->and(is_callable($resolver))->toBeTrue();
+    }
+});

--- a/tests/admin/Unit/LunarPanelProviderTest.php
+++ b/tests/admin/Unit/LunarPanelProviderTest.php
@@ -19,3 +19,23 @@ it('registers serializable record URL resolvers', function (): void {
             ->and(is_callable($resolver))->toBeTrue();
     }
 });
+
+it('can reload record URL resolver configuration after export', function (): void {
+    $cachedConfigurationPath = tempnam(sys_get_temp_dir(), 'lunar-config-');
+
+    if ($cachedConfigurationPath === false) {
+        throw new RuntimeException('Unable to create a cached configuration file.');
+    }
+
+    try {
+        file_put_contents(
+            $cachedConfigurationPath,
+            '<?php return '.var_export(config('lunar.filament.record_urls'), true).';',
+        );
+
+        expect(require $cachedConfigurationPath)
+            ->toBe(config('lunar.filament.record_urls'));
+    } finally {
+        unlink($cachedConfigurationPath);
+    }
+});


### PR DESCRIPTION
## Summary

- Replace the Lunar Admin record URL closures with serializable static callable arrays.
- Move the unchanged URL construction into `RecordUrlResolvers`.
- Add regression coverage for all three provider registrations.

## Why

`LunarPanelProvider` writes closures into Laravel configuration at boot. Laravel cannot reconstruct those values while caching configuration, so `php artisan config:cache` and `php artisan optimize` fail.

The callable arrays preserve all existing order, product-variant, and collection URL behaviour while allowing Laravel to export and reload configuration.

Fixes #2564.

## Verification

- `vendor/bin/pest tests/admin/Unit/LunarPanelProviderTest.php`
- `vendor/bin/pest --testsuite=admin` (236 passed, 793 assertions)
- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/phpstan analyse packages/admin/src tests/admin/Unit/LunarPanelProviderTest.php --memory-limit=1G`