### PR TITLE
Redesign panel activity feed and fix attribute list editing UX

### DIFF
--- a/packages/panel/resources/js/components/ActivityTimeline.vue
+++ b/packages/panel/resources/js/components/ActivityTimeline.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import Icon from './Icon.vue';
+import { computed, reactive } from 'vue';
 
 interface ActivityEvent {
     id?: string | number;
-    type?: string;
     label?: string;
     detail?: string;
     when?: string;
     actor?: string;
+    /** Gravatar (or other) avatar URL; falls back to an initials avatar when absent or unreachable. */
+    avatar?: string | null;
+    /** Changed column names for an update event; drives the "what changed" line. */
+    changes?: string[];
     /** spatie/activitylog shape — falls back to `label` when set. */
     description?: string;
     /** spatie/activitylog shape — falls back to `when` when set. */
@@ -22,84 +24,108 @@ const props = withDefaults(
         events: ActivityEvent[];
         // newest first by default; events come in ascending order from the data layer.
         reverse?: boolean;
+        // Shown as the actor when an event has no causer (system-generated).
+        systemLabel?: string;
     }>(),
-    { reverse: true },
+    { reverse: true, systemLabel: 'System' },
 );
-
-interface ToneMeta {
-    icon: string;
-    tone: 'neutral' | 'sage' | 'warn' | 'danger' | 'archived';
-}
-
-// type -> { icon, tone }
-const TYPE_META: Record<string, ToneMeta> = {
-    placed: { icon: 'cart', tone: 'neutral' },
-    payment_authorized: { icon: 'card', tone: 'neutral' },
-    payment_captured: { icon: 'check', tone: 'sage' },
-    payment_pending: { icon: 'clock', tone: 'warn' },
-    payment_failed: { icon: 'alert', tone: 'danger' },
-    dispatch_partial: { icon: 'truck', tone: 'warn' },
-    dispatch_full: { icon: 'truck', tone: 'sage' },
-    delivered: { icon: 'check', tone: 'sage' },
-    returned: { icon: 'undo', tone: 'danger' },
-    refund_issued: { icon: 'refund', tone: 'danger' },
-    cancelled: { icon: 'x', tone: 'danger' },
-    fulfilment_created: { icon: 'box', tone: 'neutral' },
-    fulfilment_split: { icon: 'split', tone: 'neutral' },
-    fulfilment_merged: { icon: 'merge', tone: 'neutral' },
-    fulfilment_dispatched: { icon: 'truck', tone: 'sage' },
-    fulfilment_delivered: { icon: 'check', tone: 'sage' },
-    fulfilment_cancelled: { icon: 'x', tone: 'archived' },
-    fulfilment_tracking_updated: { icon: 'truck', tone: 'neutral' },
-    shipment_change: { icon: 'truck', tone: 'neutral' },
-    return_created: { icon: 'undo', tone: 'warn' },
-    return_approved: { icon: 'check', tone: 'warn' },
-    return_received: { icon: 'truck', tone: 'sage' },
-    return_resolved: { icon: 'checkCircle', tone: 'sage' },
-    return_cancelled: { icon: 'x', tone: 'archived' },
-    // 'message' isn't in the panel's Icon.vue set — use 'fileText' so the (very common)
-    // untyped spatie/activitylog entry doesn't render a blank icon.
-    note_added: { icon: 'fileText', tone: 'neutral' },
-    comment: { icon: 'fileText', tone: 'neutral' },
-    tag_added: { icon: 'flag', tone: 'warn' },
-    email_sent: { icon: 'mail', tone: 'neutral' },
-    invoice_generated: { icon: 'receipt', tone: 'sage' },
-    invoice_downloaded: { icon: 'download', tone: 'neutral' },
-    proforma_sent: { icon: 'fileText', tone: 'neutral' },
-    credit_note_issued: { icon: 'refund', tone: 'sage' },
-    balance_collected: { icon: 'card', tone: 'sage' },
-    balance_refunded: { icon: 'refund', tone: 'sage' },
-    registered: { icon: 'userPlus', tone: 'sage' },
-    group_added: { icon: 'flag', tone: 'neutral' },
-    group_removed: { icon: 'flag', tone: 'neutral' },
-    address_added: { icon: 'pin', tone: 'neutral' },
-    user_invited: { icon: 'mail', tone: 'neutral' },
-    // spatie/activitylog model events plus the customer action events.
-    created: { icon: 'userPlus', tone: 'sage' },
-    updated: { icon: 'edit', tone: 'neutral' },
-    deleted: { icon: 'trash', tone: 'danger' },
-    address_created: { icon: 'fileText', tone: 'neutral' },
-    address_updated: { icon: 'edit', tone: 'neutral' },
-    address_deleted: { icon: 'trash', tone: 'archived' },
-    user_linked: { icon: 'userPlus', tone: 'sage' },
-    user_unlinked: { icon: 'x', tone: 'archived' },
-};
-
-// intentionally omits 'archived' to match the prototype — it falls back to TONE.neutral below.
-const TONE: Partial<Record<ToneMeta['tone'], string>> = {
-    neutral: 'bg-surface-2 border-line text-ink-700',
-    sage: 'bg-sage-soft border-sage-border text-sage-ink',
-    warn: 'bg-warn-soft border-warn-border text-warn-ink',
-    danger: 'bg-danger-soft border-danger-border text-danger',
-};
 
 const ordered = computed(() => (props.reverse ? [...props.events].reverse() : props.events));
 
-const meta = (type?: string): ToneMeta => TYPE_META[type ?? ''] ?? TYPE_META.note_added;
-
 const eventLabel = (ev: ActivityEvent): string => ev.label ?? ev.description ?? '';
-const eventWhen = (ev: ActivityEvent): string => ev.when ?? ev.created_at ?? '';
-const eventActor = (ev: ActivityEvent): string => ev.actor ?? ev.causer_name ?? '';
+const eventActor = (ev: ActivityEvent): string => (ev.actor ?? ev.causer_name ?? '') || props.systemLabel;
+const isSystem = (ev: ActivityEvent): boolean => !(ev.actor ?? ev.causer_name);
+
+// Avatar URLs that failed to load (e.g. Gravatar 404) fall back to initials.
+const failedAvatars = reactive(new Set<string>());
+const avatarUrl = (ev: ActivityEvent): string =>
+    ev.avatar && !failedAvatars.has(ev.avatar) ? ev.avatar : '';
+
+// Raw column names cleaned up for display. A handful read badly under the generic
+// rule, so they're spelled out; everything else is snake_case -> Title Case with a
+// trailing "_id" dropped (product_type_id -> "Product type").
+const FIELD_LABELS: Record<string, string> = {
+    attribute_data: 'Attributes',
+    sku: 'SKU',
+    ean: 'EAN',
+    gtin: 'GTIN',
+    mpn: 'MPN',
+};
+
+const humanizeField = (key: string): string =>
+    FIELD_LABELS[key] ??
+    key
+        .replace(/_id$/, '')
+        .replaceAll('_', ' ')
+        .replace(/^\w/, (c) => c.toUpperCase());
+
+const changedFields = (ev: ActivityEvent): string =>
+    (ev.changes ?? []).map(humanizeField).join(', ');
+
+const initials = (name: string): string => {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+        return '?';
+    }
+    if (parts.length === 1) {
+        return parts[0].slice(0, 2).toUpperCase();
+    }
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+// Deterministic hue from the name so a given person keeps the same avatar colour.
+const avatarStyle = (ev: ActivityEvent): Record<string, string> => {
+    if (isSystem(ev)) {
+        return { backgroundColor: 'hsl(220 9% 60%)' };
+    }
+    const name = eventActor(ev);
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+        hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+    }
+    return { backgroundColor: `hsl(${hash % 360} 52% 45%)` };
+};
+
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60],
+];
+
+const relativeTime = (ev: ActivityEvent): string => {
+    const raw = ev.when ?? ev.created_at;
+    if (!raw) {
+        return '';
+    }
+    const then = new Date(raw).getTime();
+    if (Number.isNaN(then)) {
+        return String(raw);
+    }
+    const diff = Math.round((then - Date.now()) / 1000);
+    const abs = Math.abs(diff);
+    if (abs < 60) {
+        return 'just now';
+    }
+    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto', style: 'narrow' });
+    for (const [unit, secs] of RELATIVE_UNITS) {
+        if (abs >= secs) {
+            return rtf.format(Math.round(diff / secs), unit);
+        }
+    }
+    return 'just now';
+};
+
+const absoluteTime = (ev: ActivityEvent): string => {
+    const raw = ev.when ?? ev.created_at;
+    if (!raw) {
+        return '';
+    }
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? String(raw) : date.toLocaleString();
+};
 </script>
 
 <template>
@@ -112,24 +138,35 @@ const eventActor = (ev: ActivityEvent): string => ev.actor ?? ev.causer_name ?? 
             <!-- Vertical connector (excluding last item) -->
             <span
                 v-if="i < ordered.length - 1"
-                class="absolute left-[15px] top-7 bottom-0 w-px bg-line"
+                class="absolute left-[15px] top-8 bottom-0 w-px bg-line"
                 aria-hidden="true"
             />
+            <img
+                v-if="avatarUrl(ev)"
+                :src="avatarUrl(ev)"
+                :alt="eventActor(ev)"
+                class="relative z-10 w-[30px] h-[30px] rounded-full shrink-0 object-cover bg-surface-2"
+                @error="ev.avatar && failedAvatars.add(ev.avatar)"
+            />
             <div
-                :class="[
-                    'relative z-10 w-[30px] h-[30px] rounded-full grid place-items-center border shrink-0',
-                    TONE[meta(ev.type).tone] || TONE.neutral,
-                ]"
+                v-else
+                class="relative z-10 w-[30px] h-[30px] rounded-full grid place-items-center shrink-0 text-[10px] font-semibold text-white select-none"
+                :style="avatarStyle(ev)"
+                :aria-label="eventActor(ev)"
             >
-                <Icon :name="meta(ev.type).icon" cls="sm" />
+                {{ initials(eventActor(ev)) }}
             </div>
-            <div class="flex-1 min-w-0 pt-1">
-                <div class="text-[13px] text-ink-900 font-medium">{{ eventLabel(ev) }}</div>
-                <div v-if="ev.detail" class="text-xs text-ink-700 mt-0.5">{{ ev.detail }}</div>
-                <div class="text-[11px] text-ink-500 mt-0.5">
-                    <span v-if="eventActor(ev)">{{ eventActor(ev) }}</span>
-                    <span v-if="eventActor(ev) && eventWhen(ev)" class="mx-1.5 text-ink-300">·</span>
-                    <span v-if="eventWhen(ev)">{{ eventWhen(ev) }}</span>
+            <div class="flex-1 min-w-0 pt-0.5">
+                <div class="text-[13px] leading-snug">
+                    <span class="font-semibold text-ink-900">{{ eventActor(ev) }}</span>
+                    <span v-if="eventLabel(ev)" class="text-ink-600">&nbsp;&middot;&nbsp;{{ eventLabel(ev) }}</span>
+                </div>
+                <div v-if="changedFields(ev)" class="text-xs text-ink-500 mt-1">
+                    {{ changedFields(ev) }}
+                </div>
+                <div v-else-if="ev.detail" class="text-xs text-ink-500 mt-1">{{ ev.detail }}</div>
+                <div class="text-[11px] text-ink-400 mt-1" :title="absoluteTime(ev)">
+                    {{ relativeTime(ev) }}
                 </div>
             </div>
         </li>

--- a/packages/panel/resources/js/components/AttributeFields.test.ts
+++ b/packages/panel/resources/js/components/AttributeFields.test.ts
@@ -57,7 +57,7 @@ describe('AttributeFields', () => {
         expect(values['attribute:cta']).toBe('New CTA');
     });
 
-    it('renders sequential list values as editable rows and appends new ones', async () => {
+    it('renders sequential list values as editable rows and appends via the trailing input', async () => {
         const values = reactive<Record<string, unknown>>({ 'attribute:tags': ['alpha'] });
 
         const wrapper = mountFields([field({ handle: 'tags', label: 'Tags', type: 'list' })], values);
@@ -70,10 +70,46 @@ describe('AttributeFields', () => {
 
         expect(values['attribute:tags']).toEqual(['alpha edited']);
 
+        // Typing in the always-present trailing input appends immediately, with
+        // no + button or Enter key needed.
         await wrapper.find('input[aria-label="Tags"]').setValue('beta');
-        await wrapper.find('input[aria-label="Tags"]').trigger('keydown.enter');
 
         expect(values['attribute:tags']).toEqual(['alpha edited', 'beta']);
+    });
+
+    it('appends to an empty plain list as soon as the user types', async () => {
+        const values = reactive<Record<string, unknown>>({ 'attribute:specs': [] });
+
+        const wrapper = mountFields([field({ handle: 'specs', label: 'Specs', type: 'list' })], values);
+
+        await wrapper.find('input[aria-label="Specs"]').setValue('200g');
+
+        expect(values['attribute:specs']).toEqual(['200g']);
+    });
+
+    it('prunes a plain row the user empties, on blur', async () => {
+        const values = reactive<Record<string, unknown>>({ 'attribute:tags': ['alpha', 'beta'] });
+
+        const wrapper = mountFields([field({ handle: 'tags', label: 'Tags', type: 'list' })], values);
+
+        const first = wrapper.find('input[aria-label="Tags 1"]');
+        await first.setValue('');
+        await first.trigger('blur');
+
+        expect(values['attribute:tags']).toEqual(['beta']);
+    });
+
+    it('auto-commits a complete keyed draft row on blur', async () => {
+        const values = reactive<Record<string, unknown>>({ 'attribute:specs': { width: '10cm' } });
+
+        const wrapper = mountFields([field({ handle: 'specs', label: 'Specs', type: 'list' })], values);
+
+        await wrapper.find('input[aria-label="Specs: attributes.list_key_placeholder"]').setValue('height');
+        const value = wrapper.find('input[aria-label="Specs"]');
+        await value.setValue('20cm');
+        await value.trigger('blur');
+
+        expect(values['attribute:specs']).toEqual({ width: '10cm', height: '20cm' });
     });
 
     it('reorders list rows by dragging the handle', async () => {

--- a/packages/panel/resources/js/components/AttributeFields.vue
+++ b/packages/panel/resources/js/components/AttributeFields.vue
@@ -125,6 +125,47 @@ const removeListRow = (field: AttributeField, index: number): void => {
     writeListRows(field, listRows(field).filter((_, i) => i !== index));
 };
 
+// Plain (sequential) lists render an always-present trailing input so typing
+// adds an entry inline (dirty-on-type), with no separate add step — an empty
+// list no longer looks inert. The trailing row is index === listRows().length.
+const plainDisplayRows = (field: AttributeField): ListRow[] =>
+    canAddListRow(field) ? [...listRows(field), { key: null, value: '' }] : listRows(field);
+
+const isTrailingRow = (field: AttributeField, index: number): boolean => index === listRows(field).length;
+
+const onPlainInput = (field: AttributeField, index: number, value: string): void => {
+    const rows = listRows(field);
+
+    if (index < rows.length) {
+        rows[index] = { key: null, value };
+        writeListRows(field, rows);
+    } else if (value !== '') {
+        // First keystroke in the trailing row promotes it to a real entry; the
+        // input keeps focus (rows are keyed by index) and a fresh blank appears.
+        writeListRows(field, [...rows, { key: null, value }]);
+    }
+};
+
+// Prune a row emptied by the user once they leave it; the trailing input keeps
+// the "add another" affordance, so nothing is silently lost.
+const onPlainBlur = (field: AttributeField, index: number): void => {
+    const rows = listRows(field);
+
+    if (index < rows.length && rows[index].value.trim() === '') {
+        writeListRows(field, rows.filter((_, i) => i !== index));
+    }
+};
+
+// Keyed lists auto-commit a complete draft row on blur, so a typed key + value
+// is never lost by clicking away or saving without pressing enter/plus.
+const commitListDraft = (field: AttributeField): void => {
+    const draft = listDraft(field);
+
+    if (draft.key.trim() && draft.value.trim()) {
+        addListRow(field);
+    }
+};
+
 const listDrafts = ref<Record<string, { key: string; value: string }>>({});
 
 const listDraft = (field: AttributeField): { key: string; value: string } =>
@@ -279,74 +320,110 @@ const embedUrl = (field: AttributeField): string | null => {
                         </div>
 
                         <div v-else-if="field.type === 'list'" class="border border-line-strong rounded-md bg-surface overflow-hidden">
-                            <div v-if="listRows(field).length" class="divide-y divide-line">
+                            <!-- Plain lists: inline editable rows plus an always-present
+                                 trailing input, so typing adds an entry with no extra step. -->
+                            <div v-if="!isKeyedList(field)" class="divide-y divide-line">
                                 <div
-                                    v-for="(row, index) in listRows(field)"
-                                    :key="row.key ?? index"
-                                    class="grid items-center gap-1.5 px-1.5 py-1"
+                                    v-for="(row, index) in plainDisplayRows(field)"
+                                    :key="index"
+                                    class="grid items-center gap-1.5 px-1.5 py-1 grid-cols-[auto_minmax(0,1fr)_auto]"
                                     :class="[
-                                        row.key !== null ? 'grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)_auto]' : 'grid-cols-[auto_minmax(0,1fr)_auto]',
+                                        isTrailingRow(field, index) ? 'bg-surface-2' : '',
                                         listDrag?.field === field.key && listDrag?.index === index ? 'opacity-60' : '',
                                     ]"
-                                    @dragover.prevent="onListRowDragOver(field, index)"
+                                    @dragover.prevent="isTrailingRow(field, index) ? undefined : onListRowDragOver(field, index)"
                                 >
                                     <button
                                         type="button"
                                         draggable="true"
                                         class="w-5 h-6 grid place-items-center text-ink-400 cursor-grab active:cursor-grabbing hover:text-ink-700"
+                                        :class="isTrailingRow(field, index) ? 'invisible pointer-events-none' : ''"
+                                        :tabindex="isTrailingRow(field, index) ? -1 : 0"
                                         :aria-label="t('attributes.reorder_item')"
                                         @dragstart="onListRowDragStart(field, index)"
                                         @dragend="onListRowDragEnd"
                                     ><Icon name="grip" cls="sm" /></button>
-                                    <span
-                                        v-if="row.key !== null"
-                                        class="px-1 text-[11.5px] font-mono text-ink-500 truncate"
-                                        :title="row.key"
-                                    >{{ row.key }}</span>
                                     <TextInput
                                         :model-value="row.value"
-                                        :aria-label="row.key !== null ? `${field.label}: ${row.key}` : `${field.label} ${index + 1}`"
-                                        @update:model-value="(value) => setListRowValue(field, index, value)"
+                                        :placeholder="isTrailingRow(field, index) ? t('attributes.list_placeholder') : ''"
+                                        :aria-label="isTrailingRow(field, index) ? field.label : `${field.label} ${index + 1}`"
+                                        @update:model-value="(value) => onPlainInput(field, index, value)"
+                                        @blur="onPlainBlur(field, index)"
                                     />
                                     <button
                                         type="button"
                                         class="w-6 h-6 rounded-md grid place-items-center text-ink-400 hover:bg-surface-2 hover:text-danger"
+                                        :class="isTrailingRow(field, index) ? 'invisible pointer-events-none' : ''"
+                                        :tabindex="isTrailingRow(field, index) ? -1 : 0"
                                         :aria-label="t('attributes.remove_item')"
                                         @click="removeListRow(field, index)"
                                     ><Icon name="x" cls="sm" /></button>
                                 </div>
                             </div>
 
-                            <div
-                                v-if="canAddListRow(field)"
-                                class="grid items-center gap-1.5 px-1.5 py-1 bg-surface-2"
-                                :class="[
-                                    isKeyedList(field) ? 'grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)_auto]' : 'grid-cols-[auto_minmax(0,1fr)_auto]',
-                                    listRows(field).length ? 'border-t border-line' : '',
-                                ]"
-                            >
-                                <span class="w-5" aria-hidden="true" />
-                                <TextInput
-                                    v-if="isKeyedList(field)"
-                                    v-model="listDraft(field).key"
-                                    mono
-                                    :placeholder="t('attributes.list_key_placeholder')"
-                                    :aria-label="`${field.label}: ${t('attributes.list_key_placeholder')}`"
-                                    @keydown.enter.prevent="addListRow(field)"
-                                />
-                                <TextInput
-                                    v-model="listDraft(field).value"
-                                    :placeholder="isKeyedList(field) ? t('attributes.list_value_placeholder') : t('attributes.list_placeholder')"
-                                    :aria-label="field.label"
-                                    @keydown.enter.prevent="addListRow(field)"
-                                />
-                                <button
-                                    type="button"
-                                    class="w-6 h-6 rounded-md grid place-items-center text-ink-500 hover:bg-surface hover:text-ink-900"
-                                    :aria-label="t('attributes.add_item')"
-                                    @click="addListRow(field)"
-                                ><Icon name="plus" cls="sm" /></button>
-                            </div>
+                            <!-- Keyed lists (Filament KeyValue shape): key + value rows with
+                                 an add row that auto-commits a complete draft on blur. -->
+                            <template v-else>
+                                <div class="divide-y divide-line">
+                                    <div
+                                        v-for="(row, index) in listRows(field)"
+                                        :key="row.key ?? index"
+                                        class="grid items-center gap-1.5 px-1.5 py-1 grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)_auto]"
+                                        :class="listDrag?.field === field.key && listDrag?.index === index ? 'opacity-60' : ''"
+                                        @dragover.prevent="onListRowDragOver(field, index)"
+                                    >
+                                        <button
+                                            type="button"
+                                            draggable="true"
+                                            class="w-5 h-6 grid place-items-center text-ink-400 cursor-grab active:cursor-grabbing hover:text-ink-700"
+                                            :aria-label="t('attributes.reorder_item')"
+                                            @dragstart="onListRowDragStart(field, index)"
+                                            @dragend="onListRowDragEnd"
+                                        ><Icon name="grip" cls="sm" /></button>
+                                        <span class="px-1 text-[11.5px] font-mono text-ink-500 truncate" :title="row.key ?? ''">{{ row.key }}</span>
+                                        <TextInput
+                                            :model-value="row.value"
+                                            :aria-label="`${field.label}: ${row.key}`"
+                                            @update:model-value="(value) => setListRowValue(field, index, value)"
+                                        />
+                                        <button
+                                            type="button"
+                                            class="w-6 h-6 rounded-md grid place-items-center text-ink-400 hover:bg-surface-2 hover:text-danger"
+                                            :aria-label="t('attributes.remove_item')"
+                                            @click="removeListRow(field, index)"
+                                        ><Icon name="x" cls="sm" /></button>
+                                    </div>
+                                </div>
+
+                                <div
+                                    v-if="canAddListRow(field)"
+                                    class="grid items-center gap-1.5 px-1.5 py-1 bg-surface-2 grid-cols-[auto_minmax(0,1fr)_minmax(0,2fr)_auto]"
+                                    :class="listRows(field).length ? 'border-t border-line' : ''"
+                                >
+                                    <span class="w-5" aria-hidden="true" />
+                                    <TextInput
+                                        v-model="listDraft(field).key"
+                                        mono
+                                        :placeholder="t('attributes.list_key_placeholder')"
+                                        :aria-label="`${field.label}: ${t('attributes.list_key_placeholder')}`"
+                                        @keydown.enter.prevent="addListRow(field)"
+                                        @blur="commitListDraft(field)"
+                                    />
+                                    <TextInput
+                                        v-model="listDraft(field).value"
+                                        :placeholder="t('attributes.list_value_placeholder')"
+                                        :aria-label="field.label"
+                                        @keydown.enter.prevent="addListRow(field)"
+                                        @blur="commitListDraft(field)"
+                                    />
+                                    <button
+                                        type="button"
+                                        class="w-6 h-6 rounded-md grid place-items-center text-ink-500 hover:bg-surface hover:text-ink-900"
+                                        :aria-label="t('attributes.add_item')"
+                                        @click="addListRow(field)"
+                                    ><Icon name="plus" cls="sm" /></button>
+                                </div>
+                            </template>
                         </div>
 
                         <div v-else-if="field.type === 'youtube' || field.type === 'vimeo'">

--- a/packages/panel/resources/js/components/UserMenu.vue
+++ b/packages/panel/resources/js/components/UserMenu.vue
@@ -23,7 +23,7 @@ import { useTheme, type ThemePreference } from '../composables/useTheme';
 
 withDefaults(defineProps<{ collapsed?: boolean }>(), { collapsed: false });
 
-type AuthUser = { name: string; email: string | null } | null;
+type AuthUser = { name: string; email: string | null; avatar?: string | null } | null;
 
 const { t } = useI18n();
 const { theme, setTheme } = useTheme();
@@ -32,6 +32,10 @@ const user = computed<AuthUser>(() => (usePage().props.auth as { user: AuthUser 
 const displayName = computed(() => user.value?.name || 'Account');
 const displayEmail = computed(() => user.value?.email ?? '');
 const initial = computed(() => displayName.value.charAt(0).toUpperCase() || 'U');
+
+// Gravatar with initial fallback when absent or unreachable (d=404).
+const avatarFailed = ref(false);
+const avatarUrl = computed(() => (user.value?.avatar && !avatarFailed.value ? user.value.avatar : ''));
 
 const themeModel = computed<ThemePreference>({
     get: () => theme.value,
@@ -112,7 +116,15 @@ const radioBase =
                 :aria-label="t('common.open_user_menu')"
             >
                 <Tooltip :text="collapsed ? displayName : ''">
+                    <img
+                        v-if="avatarUrl"
+                        :src="avatarUrl"
+                        :alt="displayName"
+                        class="w-7 h-7 rounded-full object-cover shrink-0 ring-1 ring-line bg-surface-2"
+                        @error="avatarFailed = true"
+                    />
                     <span
+                        v-else
                         class="w-7 h-7 rounded-full bg-ink-900 text-paper text-xs font-semibold grid place-items-center shrink-0 ring-1 ring-line"
                     >{{ initial }}</span>
                 </Tooltip>

--- a/packages/panel/resources/js/pages/brands/Edit.vue
+++ b/packages/panel/resources/js/pages/brands/Edit.vue
@@ -29,6 +29,8 @@ interface ActivityEntry {
     description: string;
     created_at: string;
     causer_name: string | null;
+    avatar: string | null;
+    changes: string[];
 }
 
 const props = defineProps<{
@@ -56,6 +58,7 @@ const props = defineProps<{
     activities: ActivityEntry[];
     urls: {
         index: string;
+        activityLog: string;
         update: string;
         destroy: string;
         draft: string;
@@ -151,10 +154,11 @@ const activityLabel = (description: string): string => {
 
 const timelineEvents = computed(() =>
     props.activities.map((activity) => ({
-        type: activity.description.replaceAll('-', '_'),
         label: activityLabel(activity.description),
-        when: new Date(activity.created_at).toLocaleString(),
+        when: activity.created_at,
         actor: activity.causer_name ?? '',
+        avatar: activity.avatar,
+        changes: activity.changes,
     })));
 </script>
 
@@ -296,6 +300,9 @@ const timelineEvents = computed(() =>
                             </SideCard>
 
                             <SideCard :title="t('brands.side_activity')">
+                                <template #actions>
+                                    <a :href="urls.activityLog" class="text-[11.5px] font-medium text-ink-500 hover:text-ink-900">{{ t('brands.side_activity_see_all') }}</a>
+                                </template>
                                 <ActivityTimeline v-if="activities.length" :events="timelineEvents" :reverse="false" />
                                 <div v-else class="text-[11.5px] text-ink-500">{{ t('brands.side_activity_empty') }}</div>
                             </SideCard>

--- a/packages/panel/resources/js/pages/collections/Edit.vue
+++ b/packages/panel/resources/js/pages/collections/Edit.vue
@@ -35,6 +35,8 @@ interface ActivityEntry {
     description: string;
     created_at: string;
     causer_name: string | null;
+    avatar: string | null;
+    changes: string[];
 }
 
 interface ProductRow {
@@ -92,6 +94,7 @@ const props = defineProps<{
     activities: ActivityEntry[];
     urls: {
         index: string;
+        activityLog: string;
         update: string;
         destroy: string;
         move: string;
@@ -317,10 +320,11 @@ const activityLabel = (description: string): string => {
 
 const timelineEvents = computed(() =>
     props.activities.map((activity) => ({
-        type: activity.description.replaceAll('-', '_'),
         label: activityLabel(activity.description),
-        when: new Date(activity.created_at).toLocaleString(),
+        when: activity.created_at,
         actor: activity.causer_name ?? '',
+        avatar: activity.avatar,
+        changes: activity.changes,
     })));
 </script>
 
@@ -567,6 +571,9 @@ const timelineEvents = computed(() =>
                             />
 
                             <SideCard :title="t('collections.side_activity')">
+                                <template #actions>
+                                    <a :href="urls.activityLog" class="text-[11.5px] font-medium text-ink-500 hover:text-ink-900">{{ t('collections.side_activity_see_all') }}</a>
+                                </template>
                                 <ActivityTimeline v-if="activities.length" :events="timelineEvents" :reverse="false" />
                                 <div v-else class="text-[11.5px] text-ink-500">{{ t('collections.side_activity_empty') }}</div>
                             </SideCard>

--- a/packages/panel/resources/js/pages/customers/Edit.vue
+++ b/packages/panel/resources/js/pages/customers/Edit.vue
@@ -68,6 +68,8 @@ interface ActivityEntry {
     description: string;
     created_at: string;
     causer_name: string | null;
+    avatar: string | null;
+    changes: string[];
 }
 
 interface OrderRow {
@@ -111,6 +113,7 @@ const props = defineProps<{
     draft: DraftState | null;
     urls: {
         index: string;
+        activityLog: string;
         update: string;
         destroy: string;
         addressesStore: string;
@@ -452,10 +455,11 @@ const activityLabel = (description: string): string => {
 
 const timelineEvents = computed(() =>
     props.activities.map((activity) => ({
-        type: activity.description.replaceAll('-', '_'),
         label: activityLabel(activity.description),
-        when: new Date(activity.created_at).toLocaleString(),
+        when: activity.created_at,
         actor: activity.causer_name ?? '',
+        avatar: activity.avatar,
+        changes: activity.changes,
     })));
 
 // Admin notes side card: view by default, pencil toggles an inline editor.
@@ -774,6 +778,9 @@ const tabDefs = computed(() => [
                                 </template>
 
                                 <template #activity>
+                                    <div v-if="activities.length" class="mb-3 flex justify-end">
+                                        <a :href="urls.activityLog" class="text-[11.5px] font-medium text-ink-500 hover:text-ink-900">{{ t('customers.activity_see_all') }}</a>
+                                    </div>
                                     <ActivityTimeline :events="timelineEvents" :reverse="false" />
                                     <PageEmpty v-if="!activities.length" :title="t('customers.activity_empty')" />
                                 </template>

--- a/packages/panel/resources/js/pages/product-types/Edit.vue
+++ b/packages/panel/resources/js/pages/product-types/Edit.vue
@@ -31,6 +31,8 @@ interface ActivityEntry {
     description: string;
     created_at: string;
     causer_name: string | null;
+    avatar: string | null;
+    changes: string[];
 }
 
 const props = defineProps<{
@@ -58,6 +60,7 @@ const props = defineProps<{
     activities: ActivityEntry[];
     urls: {
         index: string;
+        activityLog: string;
         update: string;
         destroy: string;
         draft: string;
@@ -151,10 +154,11 @@ const activityLabel = (description: string): string => {
 
 const timelineEvents = computed(() =>
     props.activities.map((activity) => ({
-        type: activity.description.replaceAll('-', '_'),
         label: activityLabel(activity.description),
-        when: new Date(activity.created_at).toLocaleString(),
+        when: activity.created_at,
         actor: activity.causer_name ?? '',
+        avatar: activity.avatar,
+        changes: activity.changes,
     })));
 </script>
 
@@ -285,6 +289,9 @@ const timelineEvents = computed(() =>
                             </SideCard>
 
                             <SideCard :title="t('product-types.side_activity')">
+                                <template #actions>
+                                    <a :href="urls.activityLog" class="text-[11.5px] font-medium text-ink-500 hover:text-ink-900">{{ t('product-types.side_activity_see_all') }}</a>
+                                </template>
                                 <ActivityTimeline v-if="activities.length" :events="timelineEvents" :reverse="false" />
                                 <div v-else class="text-[11.5px] text-ink-500">{{ t('product-types.side_activity_empty') }}</div>
                             </SideCard>

--- a/packages/panel/resources/js/pages/products/Edit.vue
+++ b/packages/panel/resources/js/pages/products/Edit.vue
@@ -40,6 +40,8 @@ interface ActivityEntry {
     description: string;
     created_at: string;
     causer_name: string | null;
+    avatar: string | null;
+    changes: string[];
 }
 
 interface AssociationEntry {
@@ -110,6 +112,7 @@ const props = defineProps<{
     activities: ActivityEntry[];
     urls: {
         index: string;
+        activityLog: string;
         update: string;
         destroy: string;
         draft: string;
@@ -337,10 +340,11 @@ const activityLabel = (description: string): string => {
 
 const timelineEvents = computed(() =>
     props.activities.map((activity) => ({
-        type: activity.description.replaceAll('-', '_'),
         label: activityLabel(activity.description),
-        when: new Date(activity.created_at).toLocaleString(),
+        when: activity.created_at,
         actor: activity.causer_name ?? '',
+        avatar: activity.avatar,
+        changes: activity.changes,
     })));
 </script>
 
@@ -640,6 +644,9 @@ const timelineEvents = computed(() =>
                             </SideCard>
 
                             <SideCard :title="t('products.side_activity')">
+                                <template #actions>
+                                    <a :href="urls.activityLog" class="text-[11.5px] font-medium text-ink-500 hover:text-ink-900">{{ t('products.side_activity_see_all') }}</a>
+                                </template>
                                 <ActivityTimeline v-if="activities.length" :events="timelineEvents" :reverse="false" />
                                 <div v-else class="text-[11.5px] text-ink-500">{{ t('products.side_activity_empty') }}</div>
                             </SideCard>

--- a/packages/panel/resources/js/pages/products/VariantEdit.vue
+++ b/packages/panel/resources/js/pages/products/VariantEdit.vue
@@ -30,6 +30,8 @@ interface ActivityEntry {
     description: string;
     created_at: string;
     causer_name: string | null;
+    avatar: string | null;
+    changes: string[];
 }
 
 const props = defineProps<{
@@ -62,6 +64,7 @@ const props = defineProps<{
     deleteBlockedReason: 'order_history' | 'last_variant' | null;
     urls: {
         productEdit: string;
+        activityLog: string;
         update: string;
         destroy: string;
         draft: string;
@@ -134,10 +137,11 @@ const activityLabel = (description: string): string => {
 
 const timelineEvents = computed(() =>
     props.activities.map((activity) => ({
-        type: activity.description.replaceAll('-', '_'),
         label: activityLabel(activity.description),
-        when: new Date(activity.created_at).toLocaleString(),
+        when: activity.created_at,
         actor: activity.causer_name ?? '',
+        avatar: activity.avatar,
+        changes: activity.changes,
     })));
 </script>
 
@@ -292,6 +296,9 @@ const timelineEvents = computed(() =>
                             </SideCard>
 
                             <SideCard :title="t('products.side_activity')">
+                                <template #actions>
+                                    <a :href="urls.activityLog" class="text-[11.5px] font-medium text-ink-500 hover:text-ink-900">{{ t('products.side_activity_see_all') }}</a>
+                                </template>
                                 <ActivityTimeline v-if="activities.length" :events="timelineEvents" :reverse="false" />
                                 <div v-else class="text-[11.5px] text-ink-500">{{ t('products.side_activity_empty') }}</div>
                             </SideCard>

--- a/packages/panel/resources/lang/ar/brands.php
+++ b/packages/panel/resources/lang/ar/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/ar/collections.php
+++ b/packages/panel/resources/lang/ar/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'تشكيلات فرعية متداخلة',
     'side_activity' => 'النشاط',
     'side_activity_empty' => 'لا يوجد نشاط مسجل بعد.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'آخر تحديث',
 
     'status_published' => 'منشورة',

--- a/packages/panel/resources/lang/ar/customers.php
+++ b/packages/panel/resources/lang/ar/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'لم يتم العثور على مستخدم بهذا البريد الإلكتروني.',
 
     'activity_empty' => 'لا يوجد نشاط مسجل بعد',
+    'activity_see_all' => 'See all',
     'activity_created' => 'تم إنشاء العميل',
     'activity_updated' => 'تم تحديث العميل',
     'activity_deleted' => 'تم حذف العميل',

--- a/packages/panel/resources/lang/ar/product-types.php
+++ b/packages/panel/resources/lang/ar/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/ar/products.php
+++ b/packages/panel/resources/lang/ar/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/bg/brands.php
+++ b/packages/panel/resources/lang/bg/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/bg/collections.php
+++ b/packages/panel/resources/lang/bg/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'вложени подколекции',
     'side_activity' => 'Активност',
     'side_activity_empty' => 'Все още няма записана активност.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Последна промяна',
 
     'status_published' => 'Публикувана',

--- a/packages/panel/resources/lang/bg/customers.php
+++ b/packages/panel/resources/lang/bg/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Не е намерен потребител с този имейл адрес.',
 
     'activity_empty' => 'Все още няма записана активност',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Клиентът е създаден',
     'activity_updated' => 'Клиентът е актуализиран',
     'activity_deleted' => 'Клиентът е изтрит',

--- a/packages/panel/resources/lang/bg/product-types.php
+++ b/packages/panel/resources/lang/bg/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/bg/products.php
+++ b/packages/panel/resources/lang/bg/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/de/brands.php
+++ b/packages/panel/resources/lang/de/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/de/collections.php
+++ b/packages/panel/resources/lang/de/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'verschachtelte Unterkollektionen',
     'side_activity' => 'Aktivität',
     'side_activity_empty' => 'Noch keine Aktivität aufgezeichnet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Zuletzt geändert',
 
     'status_published' => 'Veröffentlicht',

--- a/packages/panel/resources/lang/de/customers.php
+++ b/packages/panel/resources/lang/de/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Es wurde kein Benutzer mit dieser E-Mail-Adresse gefunden.',
 
     'activity_empty' => 'Noch keine Aktivität aufgezeichnet',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Kunde erstellt',
     'activity_updated' => 'Kunde aktualisiert',
     'activity_deleted' => 'Kunde gelöscht',

--- a/packages/panel/resources/lang/de/product-types.php
+++ b/packages/panel/resources/lang/de/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/de/products.php
+++ b/packages/panel/resources/lang/de/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/en/brands.php
+++ b/packages/panel/resources/lang/en/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/en/collections.php
+++ b/packages/panel/resources/lang/en/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'nested sub-collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'status_published' => 'Published',

--- a/packages/panel/resources/lang/en/customers.php
+++ b/packages/panel/resources/lang/en/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'No user was found with that email address.',
 
     'activity_empty' => 'No activity recorded yet',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Customer created',
     'activity_updated' => 'Customer updated',
     'activity_deleted' => 'Customer deleted',

--- a/packages/panel/resources/lang/en/product-types.php
+++ b/packages/panel/resources/lang/en/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/en/products.php
+++ b/packages/panel/resources/lang/en/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/es/brands.php
+++ b/packages/panel/resources/lang/es/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/es/collections.php
+++ b/packages/panel/resources/lang/es/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'subcolecciones anidadas',
     'side_activity' => 'Actividad',
     'side_activity_empty' => 'Aún no hay actividad registrada.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Última modificación',
 
     'status_published' => 'Publicada',

--- a/packages/panel/resources/lang/es/customers.php
+++ b/packages/panel/resources/lang/es/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'No se ha encontrado ningún usuario con esa dirección de correo electrónico.',
 
     'activity_empty' => 'Aún no hay actividad registrada',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Cliente creado',
     'activity_updated' => 'Cliente actualizado',
     'activity_deleted' => 'Cliente eliminado',

--- a/packages/panel/resources/lang/es/product-types.php
+++ b/packages/panel/resources/lang/es/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/es/products.php
+++ b/packages/panel/resources/lang/es/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/fa/brands.php
+++ b/packages/panel/resources/lang/fa/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/fa/collections.php
+++ b/packages/panel/resources/lang/fa/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'زیرمجموعه تو در تو',
     'side_activity' => 'فعالیت',
     'side_activity_empty' => 'هنوز فعالیتی ثبت نشده است.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'آخرین به‌روزرسانی',
 
     'status_published' => 'منتشرشده',

--- a/packages/panel/resources/lang/fa/customers.php
+++ b/packages/panel/resources/lang/fa/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'کاربری با این آدرس ایمیل یافت نشد.',
 
     'activity_empty' => 'هنوز فعالیتی ثبت نشده است',
+    'activity_see_all' => 'See all',
     'activity_created' => 'مشتری ایجاد شد',
     'activity_updated' => 'مشتری به‌روزرسانی شد',
     'activity_deleted' => 'مشتری حذف شد',

--- a/packages/panel/resources/lang/fa/product-types.php
+++ b/packages/panel/resources/lang/fa/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/fa/products.php
+++ b/packages/panel/resources/lang/fa/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/fr/brands.php
+++ b/packages/panel/resources/lang/fr/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/fr/collections.php
+++ b/packages/panel/resources/lang/fr/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'sous-collections imbriquées',
     'side_activity' => 'Activité',
     'side_activity_empty' => 'Aucune activité enregistrée pour le moment.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Dernière modification',
 
     'status_published' => 'Publiée',

--- a/packages/panel/resources/lang/fr/customers.php
+++ b/packages/panel/resources/lang/fr/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => "Aucun utilisateur n'a été trouvé avec cette adresse e-mail.",
 
     'activity_empty' => 'Aucune activité enregistrée pour le moment',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Client créé',
     'activity_updated' => 'Client mis à jour',
     'activity_deleted' => 'Client supprimé',

--- a/packages/panel/resources/lang/fr/product-types.php
+++ b/packages/panel/resources/lang/fr/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/fr/products.php
+++ b/packages/panel/resources/lang/fr/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/hr/brands.php
+++ b/packages/panel/resources/lang/hr/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/hr/collections.php
+++ b/packages/panel/resources/lang/hr/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'ugniježđenih podkolekcija',
     'side_activity' => 'Aktivnost',
     'side_activity_empty' => 'Još nema zabilježene aktivnosti.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Zadnja izmjena',
 
     'status_published' => 'Objavljena',

--- a/packages/panel/resources/lang/hr/customers.php
+++ b/packages/panel/resources/lang/hr/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Nije pronađen korisnik s tom e-poštom.',
 
     'activity_empty' => 'Još nema zabilježene aktivnosti',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Kupac je kreiran',
     'activity_updated' => 'Kupac je ažuriran',
     'activity_deleted' => 'Kupac je izbrisan',

--- a/packages/panel/resources/lang/hr/product-types.php
+++ b/packages/panel/resources/lang/hr/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/hr/products.php
+++ b/packages/panel/resources/lang/hr/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/hu/brands.php
+++ b/packages/panel/resources/lang/hu/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/hu/collections.php
+++ b/packages/panel/resources/lang/hu/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'beágyazott alkollekció',
     'side_activity' => 'Tevékenység',
     'side_activity_empty' => 'Még nincs rögzített tevékenység.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Utolsó módosítás',
 
     'status_published' => 'Közzétéve',

--- a/packages/panel/resources/lang/hu/customers.php
+++ b/packages/panel/resources/lang/hu/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Nem található felhasználó ezzel az e-mail címmel.',
 
     'activity_empty' => 'Még nincs rögzített tevékenység',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Az ügyfél létrehozva',
     'activity_updated' => 'Az ügyfél frissítve',
     'activity_deleted' => 'Az ügyfél törölve',

--- a/packages/panel/resources/lang/hu/product-types.php
+++ b/packages/panel/resources/lang/hu/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/hu/products.php
+++ b/packages/panel/resources/lang/hu/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/mn/brands.php
+++ b/packages/panel/resources/lang/mn/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/mn/collections.php
+++ b/packages/panel/resources/lang/mn/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'үүрлэсэн дэд цуглуулга',
     'side_activity' => 'Үйл ажиллагаа',
     'side_activity_empty' => 'Одоогоор бүртгэгдсэн үйл ажиллагаа алга.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Сүүлд шинэчилсэн',
 
     'status_published' => 'Нийтлэгдсэн',

--- a/packages/panel/resources/lang/mn/customers.php
+++ b/packages/panel/resources/lang/mn/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Энэ и-мэйл хаягтай хэрэглэгч олдсонгүй.',
 
     'activity_empty' => 'Одоогоор бүртгэгдсэн үйл ажиллагаа алга',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Харилцагч үүсгэгдлээ',
     'activity_updated' => 'Харилцагч шинэчлэгдлээ',
     'activity_deleted' => 'Харилцагч устгагдлаа',

--- a/packages/panel/resources/lang/mn/product-types.php
+++ b/packages/panel/resources/lang/mn/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/mn/products.php
+++ b/packages/panel/resources/lang/mn/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/nl/brands.php
+++ b/packages/panel/resources/lang/nl/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/nl/collections.php
+++ b/packages/panel/resources/lang/nl/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'geneste subcollecties',
     'side_activity' => 'Activiteit',
     'side_activity_empty' => 'Nog geen activiteit vastgelegd.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Laatst bijgewerkt',
 
     'status_published' => 'Gepubliceerd',

--- a/packages/panel/resources/lang/nl/customers.php
+++ b/packages/panel/resources/lang/nl/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Er is geen gebruiker gevonden met dat e-mailadres.',
 
     'activity_empty' => 'Nog geen activiteit geregistreerd',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Klant aangemaakt',
     'activity_updated' => 'Klant bijgewerkt',
     'activity_deleted' => 'Klant verwijderd',

--- a/packages/panel/resources/lang/nl/product-types.php
+++ b/packages/panel/resources/lang/nl/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/nl/products.php
+++ b/packages/panel/resources/lang/nl/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/pl/brands.php
+++ b/packages/panel/resources/lang/pl/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/pl/collections.php
+++ b/packages/panel/resources/lang/pl/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'zagnieżdżonych podkolekcji',
     'side_activity' => 'Aktywność',
     'side_activity_empty' => 'Brak zarejestrowanej aktywności.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Ostatnia zmiana',
 
     'status_published' => 'Opublikowana',

--- a/packages/panel/resources/lang/pl/customers.php
+++ b/packages/panel/resources/lang/pl/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Nie znaleziono użytkownika o tym adresie e-mail.',
 
     'activity_empty' => 'Brak zarejestrowanej aktywności',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Klient utworzony',
     'activity_updated' => 'Klient zaktualizowany',
     'activity_deleted' => 'Klient usunięty',

--- a/packages/panel/resources/lang/pl/product-types.php
+++ b/packages/panel/resources/lang/pl/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/pl/products.php
+++ b/packages/panel/resources/lang/pl/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/pt_BR/brands.php
+++ b/packages/panel/resources/lang/pt_BR/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/pt_BR/collections.php
+++ b/packages/panel/resources/lang/pt_BR/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'subcoleções aninhadas',
     'side_activity' => 'Atividade',
     'side_activity_empty' => 'Nenhuma atividade registrada ainda.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Última atualização',
 
     'status_published' => 'Publicada',

--- a/packages/panel/resources/lang/pt_BR/customers.php
+++ b/packages/panel/resources/lang/pt_BR/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Nenhum usuário foi encontrado com esse endereço de e-mail.',
 
     'activity_empty' => 'Nenhuma atividade registrada ainda',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Cliente criado',
     'activity_updated' => 'Cliente atualizado',
     'activity_deleted' => 'Cliente excluído',

--- a/packages/panel/resources/lang/pt_BR/product-types.php
+++ b/packages/panel/resources/lang/pt_BR/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/pt_BR/products.php
+++ b/packages/panel/resources/lang/pt_BR/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/ro/brands.php
+++ b/packages/panel/resources/lang/ro/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/ro/collections.php
+++ b/packages/panel/resources/lang/ro/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'subcolecții imbricate',
     'side_activity' => 'Activitate',
     'side_activity_empty' => 'Nicio activitate înregistrată încă.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Ultima actualizare',
 
     'status_published' => 'Publicată',

--- a/packages/panel/resources/lang/ro/customers.php
+++ b/packages/panel/resources/lang/ro/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Niciun utilizator nu a fost găsit cu această adresă de e-mail.',
 
     'activity_empty' => 'Nicio activitate înregistrată încă',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Client creat',
     'activity_updated' => 'Client actualizat',
     'activity_deleted' => 'Client șters',

--- a/packages/panel/resources/lang/ro/product-types.php
+++ b/packages/panel/resources/lang/ro/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/ro/products.php
+++ b/packages/panel/resources/lang/ro/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/tr/brands.php
+++ b/packages/panel/resources/lang/tr/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/tr/collections.php
+++ b/packages/panel/resources/lang/tr/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'iç içe alt koleksiyon',
     'side_activity' => 'Etkinlik',
     'side_activity_empty' => 'Henüz kayıtlı etkinlik yok.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Son güncelleme',
 
     'status_published' => 'Yayında',

--- a/packages/panel/resources/lang/tr/customers.php
+++ b/packages/panel/resources/lang/tr/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Bu e-posta adresine sahip bir kullanıcı bulunamadı.',
 
     'activity_empty' => 'Henüz kaydedilmiş etkinlik yok',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Müşteri oluşturuldu',
     'activity_updated' => 'Müşteri güncellendi',
     'activity_deleted' => 'Müşteri silindi',

--- a/packages/panel/resources/lang/tr/product-types.php
+++ b/packages/panel/resources/lang/tr/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/tr/products.php
+++ b/packages/panel/resources/lang/tr/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/resources/lang/vi/brands.php
+++ b/packages/panel/resources/lang/vi/brands.php
@@ -63,6 +63,7 @@ return [
     'side_usage_collections' => 'collections feature it',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_brand' => 'Delete this brand? Products keep their data but lose the brand link.',

--- a/packages/panel/resources/lang/vi/collections.php
+++ b/packages/panel/resources/lang/vi/collections.php
@@ -91,6 +91,7 @@ return [
     'side_usage_descendants' => 'bộ sưu tập con lồng nhau',
     'side_activity' => 'Hoạt động',
     'side_activity_empty' => 'Chưa có hoạt động nào được ghi lại.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Cập nhật gần nhất',
 
     'status_published' => 'Đã xuất bản',

--- a/packages/panel/resources/lang/vi/customers.php
+++ b/packages/panel/resources/lang/vi/customers.php
@@ -105,6 +105,7 @@ return [
     'link_user_not_found' => 'Không tìm thấy người dùng nào với địa chỉ email đó.',
 
     'activity_empty' => 'Chưa có hoạt động nào được ghi lại',
+    'activity_see_all' => 'See all',
     'activity_created' => 'Đã tạo khách hàng',
     'activity_updated' => 'Đã cập nhật khách hàng',
     'activity_deleted' => 'Đã xóa khách hàng',

--- a/packages/panel/resources/lang/vi/product-types.php
+++ b/packages/panel/resources/lang/vi/product-types.php
@@ -67,6 +67,7 @@ return [
     'side_defaults' => 'Defaults',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'last_updated' => 'Last updated',
 
     'confirm_delete_title' => 'Delete product type?',

--- a/packages/panel/resources/lang/vi/products.php
+++ b/packages/panel/resources/lang/vi/products.php
@@ -106,6 +106,7 @@ return [
     'side_collections' => 'Collections',
     'side_activity' => 'Activity',
     'side_activity_empty' => 'No activity recorded yet.',
+    'side_activity_see_all' => 'See all',
     'status_archived_help' => 'Hidden everywhere. Kept for records and re-publishing.',
     'action_duplicate' => 'Duplicate',
     'confirm_duplicate' => 'Duplicate this product? Variants, prices, option links and attribute values are copied; the copy starts as a draft.',

--- a/packages/panel/src/Http/Controllers/Brands/BrandEditController.php
+++ b/packages/panel/src/Http/Controllers/Brands/BrandEditController.php
@@ -16,6 +16,7 @@ use Lunar\Panel\Contracts\DraftManager;
 use Lunar\Panel\Http\Requests\Brands\BrandRequest;
 use Lunar\Panel\PanelManager;
 use Lunar\Panel\Support\AttributeSchema;
+use Lunar\Panel\Support\TimelineActivity;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -61,11 +62,7 @@ class BrandEditController
             ->latest()
             ->limit(25)
             ->get()
-            ->map(fn (Activity $activity) => [
-                'description' => $activity->description,
-                'created_at' => $activity->created_at,
-                'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
-            ]);
+            ->map(fn (Activity $activity) => TimelineActivity::toArray($activity));
 
         return Inertia::render('brands/Edit', [
             'brand' => [
@@ -102,6 +99,7 @@ class BrandEditController
             'activities' => $activities,
             'urls' => [
                 'index' => route('panel.brands.index'),
+                'activityLog' => route('panel.settings.activity-log.index', ['subject_type' => $brand->getMorphClass()]),
                 'update' => route('panel.brands.update', $brand),
                 'destroy' => route('panel.brands.destroy', $brand),
                 'draft' => route('panel.brands.draft.update', $brand),

--- a/packages/panel/src/Http/Controllers/Collections/CollectionEditController.php
+++ b/packages/panel/src/Http/Controllers/Collections/CollectionEditController.php
@@ -19,6 +19,7 @@ use Lunar\Panel\Http\Requests\Collections\CollectionRequest;
 use Lunar\Panel\PanelManager;
 use Lunar\Panel\Support\AttributeSchema;
 use Lunar\Panel\Support\AvailabilitySchema;
+use Lunar\Panel\Support\TimelineActivity;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -70,11 +71,7 @@ class CollectionEditController
             ->latest()
             ->limit(25)
             ->get()
-            ->map(fn (Activity $activity) => [
-                'description' => $activity->description,
-                'created_at' => $activity->created_at,
-                'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
-            ]);
+            ->map(fn (Activity $activity) => TimelineActivity::toArray($activity));
 
         /** @var ?Collection $parent */
         $parent = $collection->parent;
@@ -139,6 +136,7 @@ class CollectionEditController
             'activities' => $activities,
             'urls' => [
                 'index' => route('panel.collections.index'),
+                'activityLog' => route('panel.settings.activity-log.index', ['subject_type' => $collection->getMorphClass()]),
                 'update' => route('panel.collections.update', $collection),
                 'destroy' => route('panel.collections.destroy', $collection),
                 'move' => route('panel.collections.move', $collection),

--- a/packages/panel/src/Http/Controllers/Customers/CustomerEditController.php
+++ b/packages/panel/src/Http/Controllers/Customers/CustomerEditController.php
@@ -19,6 +19,7 @@ use Lunar\Core\Models\Order;
 use Lunar\Panel\Contracts\DraftManager;
 use Lunar\Panel\Http\Requests\Customers\CustomerRequest;
 use Lunar\Panel\PanelManager;
+use Lunar\Panel\Support\TimelineActivity;
 use Spatie\Activitylog\Models\Activity;
 
 class CustomerEditController
@@ -80,11 +81,7 @@ class CustomerEditController
             ->latest()
             ->limit(25)
             ->get()
-            ->map(fn (Activity $activity) => [
-                'description' => $activity->description,
-                'created_at' => $activity->created_at,
-                'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
-            ]);
+            ->map(fn (Activity $activity) => TimelineActivity::toArray($activity));
 
         $placedOrders = $customer->orders()->whereNotNull('placed_at');
 
@@ -152,6 +149,7 @@ class CustomerEditController
             ] : null,
             'urls' => [
                 'index' => route('panel.customers.index'),
+                'activityLog' => route('panel.settings.activity-log.index', ['subject_type' => $customer->getMorphClass()]),
                 'update' => route('panel.customers.update', $customer),
                 'destroy' => route('panel.customers.destroy', $customer),
                 'addressesStore' => route('panel.customers.addresses.store', $customer),

--- a/packages/panel/src/Http/Controllers/ProductTypes/ProductTypeEditController.php
+++ b/packages/panel/src/Http/Controllers/ProductTypes/ProductTypeEditController.php
@@ -18,6 +18,7 @@ use Lunar\Panel\Contracts\DraftManager;
 use Lunar\Panel\Http\Requests\ProductTypes\ProductTypeRequest;
 use Lunar\Panel\PanelManager;
 use Lunar\Panel\Support\AttributeSchema;
+use Lunar\Panel\Support\TimelineActivity;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
@@ -48,11 +49,7 @@ class ProductTypeEditController
             ->latest()
             ->limit(25)
             ->get()
-            ->map(fn (Activity $activity) => [
-                'description' => $activity->description,
-                'created_at' => $activity->created_at,
-                'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
-            ]);
+            ->map(fn (Activity $activity) => TimelineActivity::toArray($activity));
 
         // Mapped ids pluck through the filtered relations (allRelatedIds()
         // queries the pivot directly and would skip the morph filter); the
@@ -90,6 +87,7 @@ class ProductTypeEditController
             'activities' => $activities,
             'urls' => [
                 'index' => route('panel.product-types.index'),
+                'activityLog' => route('panel.settings.activity-log.index', ['subject_type' => $productType->getMorphClass()]),
                 'update' => route('panel.product-types.update', $productType),
                 'destroy' => route('panel.product-types.destroy', $productType),
                 'draft' => route('panel.product-types.draft.update', $productType),

--- a/packages/panel/src/Http/Controllers/Products/ProductEditController.php
+++ b/packages/panel/src/Http/Controllers/Products/ProductEditController.php
@@ -32,6 +32,7 @@ use Lunar\Panel\PanelManager;
 use Lunar\Panel\Sections\Catalog\ProductDraftResource;
 use Lunar\Panel\Support\AttributeSchema;
 use Lunar\Panel\Support\AvailabilitySchema;
+use Lunar\Panel\Support\TimelineActivity;
 use Lunar\Panel\Support\VariantFields;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -107,11 +108,7 @@ class ProductEditController
             ->latest()
             ->limit(25)
             ->get()
-            ->map(fn (Activity $activity) => [
-                'description' => $activity->description,
-                'created_at' => $activity->created_at,
-                'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
-            ]);
+            ->map(fn (Activity $activity) => TimelineActivity::toArray($activity));
 
         $associations = $product->associations()
             ->with(['target.thumbnail', 'target.variants:id,product_id,sku', 'target.brand:id,name'])
@@ -260,6 +257,7 @@ class ProductEditController
             'activities' => $activities,
             'urls' => [
                 'index' => route('panel.products.index'),
+                'activityLog' => route('panel.settings.activity-log.index', ['subject_type' => $product->getMorphClass()]),
                 'update' => route('panel.products.update', $product),
                 'destroy' => route('panel.products.destroy', $product),
                 'draft' => route('panel.products.draft.update', $product),

--- a/packages/panel/src/Http/Controllers/Products/ProductVariantController.php
+++ b/packages/panel/src/Http/Controllers/Products/ProductVariantController.php
@@ -23,6 +23,7 @@ use Lunar\Panel\Contracts\DraftManager;
 use Lunar\Panel\Http\Requests\Products\ProductVariantRequest;
 use Lunar\Panel\PanelManager;
 use Lunar\Panel\Support\AttributeSchema;
+use Lunar\Panel\Support\TimelineActivity;
 use Lunar\Panel\Support\VariantFields;
 use Spatie\Activitylog\Models\Activity;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
@@ -69,11 +70,7 @@ class ProductVariantController
             ->latest()
             ->limit(25)
             ->get()
-            ->map(fn (Activity $activity) => [
-                'description' => $activity->description,
-                'created_at' => $activity->created_at,
-                'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
-            ]);
+            ->map(fn (Activity $activity) => TimelineActivity::toArray($activity));
 
         $measurements = Converter::getMeasurements();
 
@@ -173,6 +170,7 @@ class ProductVariantController
             },
             'urls' => [
                 'productEdit' => route('panel.products.edit', $product),
+                'activityLog' => route('panel.settings.activity-log.index', ['subject_type' => $productVariant->getMorphClass()]),
                 'update' => route('panel.products.variants.update', [$product, $productVariant]),
                 'destroy' => route('panel.products.variants.destroy', [$product, $productVariant]),
                 'draft' => route('panel.products.variants.draft.update', [$product, $productVariant]),

--- a/packages/panel/src/Http/Middleware/HandlePanelInertiaRequests.php
+++ b/packages/panel/src/Http/Middleware/HandlePanelInertiaRequests.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Lunar\Panel\PanelManager;
+use Lunar\Panel\Support\Gravatar;
 
 class HandlePanelInertiaRequests extends Middleware
 {
@@ -70,7 +71,7 @@ class HandlePanelInertiaRequests extends Middleware
         return null;
     }
 
-    /** @return array{id: mixed, name: string, email: string|null, admin: bool} */
+    /** @return array{id: mixed, name: string, email: string|null, avatar: string|null, admin: bool} */
     protected function serializeUser(Authenticatable $user): array
     {
         $name = trim(($user->first_name ?? '').' '.($user->last_name ?? ''));
@@ -79,6 +80,7 @@ class HandlePanelInertiaRequests extends Middleware
             'id' => $user->getAuthIdentifier(),
             'name' => $name !== '' ? $name : (string) ($user->email ?? ''),
             'email' => $user->email ?? null,
+            'avatar' => Gravatar::url($user->email ?? null),
             'admin' => (bool) ($user->admin ?? false),
         ];
     }

--- a/packages/panel/src/Support/Gravatar.php
+++ b/packages/panel/src/Support/Gravatar.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lunar\Panel\Support;
+
+class Gravatar
+{
+    /**
+     * Gravatar URL for an email. `d=404` so a missing Gravatar 404s and the
+     * frontend can fall back to an initials avatar rather than a placeholder.
+     */
+    public static function url(?string $email, int $size = 64): ?string
+    {
+        if (! $email) {
+            return null;
+        }
+
+        return 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email)))."?d=404&s={$size}";
+    }
+}

--- a/packages/panel/src/Support/TimelineActivity.php
+++ b/packages/panel/src/Support/TimelineActivity.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Lunar\Panel\Support;
+
+use Illuminate\Support\Carbon;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Serialises an activity-log entry for the sidebar activity timeline shared by
+ * the record edit pages (products, variants, brands, collections, ...).
+ */
+class TimelineActivity
+{
+    /**
+     * @return array{description: string, created_at: ?Carbon, causer_name: ?string, avatar: ?string, changes: list<string>}
+     */
+    public static function toArray(Activity $activity): array
+    {
+        return [
+            'description' => (string) $activity->description,
+            'created_at' => $activity->created_at,
+            'causer_name' => $activity->causer?->full_name ?? $activity->causer?->name ?? null,
+            'avatar' => Gravatar::url($activity->causer?->email),
+            'changes' => static::changedKeys($activity),
+        ];
+    }
+
+    /**
+     * Changed attribute names for an update; empty for create/delete where the
+     * full attribute set carries no "what changed" signal.
+     *
+     * Comparison is empty-aware: logOnlyDirty flags cast/state columns (status)
+     * and JSON columns as dirty even when nothing meaningful changed, and empty
+     * shapes serialise inconsistently ([] vs {} vs {"specs":[]}). Values that
+     * normalise to the same thing are treated as unchanged. The attribute_data
+     * JSON is diffed per attribute handle so the feed names the actual
+     * attributes that changed rather than a vague "attribute_data".
+     *
+     * @return list<string>
+     */
+    protected static function changedKeys(Activity $activity): array
+    {
+        if ($activity->description !== 'updated') {
+            return [];
+        }
+
+        $attributes = (array) $activity->properties->get('attributes', []);
+        $old = (array) $activity->properties->get('old', []);
+
+        $changes = [];
+
+        foreach ($attributes as $key => $newValue) {
+            if ($key === 'updated_at') {
+                continue;
+            }
+
+            $oldValue = $old[$key] ?? null;
+
+            if ($key === 'attribute_data') {
+                $handles = static::changedHandles($oldValue, $newValue);
+
+                if ($handles !== []) {
+                    array_push($changes, ...$handles);
+                } elseif (! static::valuesEqual($oldValue, $newValue)) {
+                    $changes[] = $key;
+                }
+
+                continue;
+            }
+
+            if (! static::valuesEqual($oldValue, $newValue)) {
+                $changes[] = $key;
+            }
+        }
+
+        return array_values(array_unique($changes));
+    }
+
+    /**
+     * Attribute handles whose value changed between two attribute_data payloads.
+     *
+     * @return list<string>
+     */
+    protected static function changedHandles(mixed $old, mixed $new): array
+    {
+        $old = is_array($old) ? $old : [];
+        $new = is_array($new) ? $new : [];
+
+        $handles = array_unique([...array_keys($old), ...array_keys($new)]);
+
+        $changed = [];
+
+        foreach ($handles as $handle) {
+            if (! static::valuesEqual($old[$handle] ?? null, $new[$handle] ?? null)) {
+                $changed[] = (string) $handle;
+            }
+        }
+
+        return $changed;
+    }
+
+    /**
+     * Two values are equal once empties are normalised away, so [], {},
+     * {"specs":[]}, "" and null all compare as the same empty value.
+     */
+    protected static function valuesEqual(mixed $a, mixed $b): bool
+    {
+        return static::normalize($a) == static::normalize($b);
+    }
+
+    /**
+     * Recursively drop empty entries; anything empty (empty array/string/null)
+     * collapses to null so all empty shapes compare equal.
+     */
+    protected static function normalize(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            $normalized = [];
+
+            foreach ($value as $key => $item) {
+                $item = static::normalize($item);
+
+                if ($item !== null) {
+                    $normalized[$key] = $item;
+                }
+            }
+
+            return $normalized === [] ? null : $normalized;
+        }
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/tests/panel/Unit/Support/TimelineActivityTest.php
+++ b/tests/panel/Unit/Support/TimelineActivityTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Lunar\Panel\Support\TimelineActivity;
+use Lunar\Tests\Panel\TestCase;
+use Spatie\Activitylog\Models\Activity;
+
+uses(TestCase::class);
+
+/**
+ * @param  array<string, mixed>  $properties
+ */
+function makeActivity(string $description, array $properties): Activity
+{
+    $activity = new Activity;
+    $activity->description = $description;
+    $activity->event = $description;
+    $activity->properties = $properties;
+
+    return $activity;
+}
+
+it('reports only fields whose value actually changed', function () {
+    // status is unchanged (logOnlyDirty false positive) and empty attribute_data
+    // scaffolding ([] -> {"specs":[]}) is not a real edit; both are dropped.
+    $activity = makeActivity('updated', [
+        'old' => ['status' => 'published', 'attribute_data' => [], 'short_description' => ['en' => 'a']],
+        'attributes' => ['status' => 'published', 'attribute_data' => ['specs' => []], 'short_description' => ['en' => 'b']],
+    ]);
+
+    expect(TimelineActivity::toArray($activity)['changes'])->toBe(['short_description']);
+});
+
+it('names the specific attribute handles that changed', function () {
+    $activity = makeActivity('updated', [
+        'old' => ['attribute_data' => ['specs' => [], 'material' => 'cotton']],
+        'attributes' => ['attribute_data' => ['specs' => ['weight' => '200g'], 'material' => 'linen']],
+    ]);
+
+    expect(TimelineActivity::toArray($activity)['changes'])->toBe(['specs', 'material']);
+});
+
+it('treats empty attribute_data shapes as unchanged', function () {
+    $activity = makeActivity('updated', [
+        'old' => ['attribute_data' => []],
+        'attributes' => ['attribute_data' => ['specs' => [], 'meta' => ['en' => '']]],
+    ]);
+
+    expect(TimelineActivity::toArray($activity)['changes'])->toBe([]);
+});
+
+it('ignores the updated_at timestamp', function () {
+    $activity = makeActivity('updated', [
+        'old' => ['updated_at' => '2020-01-01', 'name' => 'a'],
+        'attributes' => ['updated_at' => '2021-01-01', 'name' => 'b'],
+    ]);
+
+    expect(TimelineActivity::toArray($activity)['changes'])->toBe(['name']);
+});
+
+it('reports no changed fields for create and delete events', function () {
+    $created = makeActivity('created', ['attributes' => ['id' => 1, 'name' => 'x']]);
+    $deleted = makeActivity('deleted', ['old' => ['id' => 1, 'name' => 'x']]);
+
+    expect(TimelineActivity::toArray($created)['changes'])->toBe([])
+        ->and(TimelineActivity::toArray($deleted)['changes'])->toBe([]);
+});


### PR DESCRIPTION
Panel UI tweaks to the record edit pages (products, variants, brands, product types, collections, customers).

## Activity timeline
- Per-user **avatars** (Gravatar, with a colour-keyed initials fallback) replace the event-type icons; rows lead with the actor, show relative time, and a **See all** link to the filtered activity log.
- "What changed" is now accurate:
  - Empty-aware comparison drops `logOnlyDirty` false positives (e.g. an unchanged `status` cast) and empty JSON shapes (`[]` vs `{"specs":[]}`).
  - `attribute_data` is diffed **per attribute handle**, so the feed names the attributes that actually changed instead of a vague "Attributes".
- The activity→array mapping is centralised in a new `TimelineActivity` support class (was duplicated across six controllers).

## Gravatar
- Shared `Gravatar` helper (`d=404` so a missing Gravatar falls back to initials rather than a placeholder image).
- Also applied to the logged-in user in the **profile menu**; the avatar URL now rides the shared auth prop.

## Attribute list field
- **Plain lists** render an always-present trailing input: typing adds an entry inline (dirty-on-type), no `+` button; empty rows are pruned on blur. This removes the empty-list "I typed but nothing saved" trap.
- **Keyed lists** auto-commit a complete key+value draft on blur (Enter / `+` still work).

## i18n
- Adds `side_activity_see_all` / `activity_see_all` across all 16 locales.

## Tests
- New `TimelineActivityTest` (change detection) and additional `AttributeFields` cases (empty-list append, blur prune, keyed auto-commit).
- Verified locally: Pint, PHPStan, `vue-tsc`, `npm run build`, 210 vitest, 680 panel PHP tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)