### PR TITLE
Upgrade panel to Inertia.js v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "filament/spatie-laravel-media-library-plugin": "^5.0",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.2",
-        "inertiajs/inertia-laravel": "^2.0",
+        "inertiajs/inertia-laravel": "^3.0",
         "lunarphp/nestedset": "^1.0",
         "laravel/framework": "^12.0|^13.0",
         "laravel/scout": "^10.13.1",

--- a/packages/panel/composer.json
+++ b/packages/panel/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "lunarphp/core": "self.version",
         "bacon/bacon-qr-code": "^3.0",
-        "inertiajs/inertia-laravel": "^2.0",
+        "inertiajs/inertia-laravel": "^3.0",
         "pragmarx/google2fa": "^9.0"
     },
     "extra": {

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -10,7 +10,7 @@
         "test": "vitest run"
     },
     "devDependencies": {
-        "@inertiajs/vue3": "^2.0.0",
+        "@inertiajs/vue3": "^3.0.0",
         "@tailwindcss/vite": "^4.0.6",
         "@vitejs/plugin-vue": "^5.2.0",
         "@vue/test-utils": "^2.4.11",

--- a/packages/panel/resources/js/components/MediaManager.vue
+++ b/packages/panel/resources/js/components/MediaManager.vue
@@ -11,6 +11,10 @@ const props = defineProps<{
     items: MediaItem[];
     storeUrl: string;
     reorderUrl: string;
+    // Page-prop key holding this list (e.g. "media"). When set, a drop persists
+    // with an optimistic patch on that prop so the new order is authoritative
+    // while the request runs and rolls back automatically if it fails.
+    optimisticKey?: string;
 }>();
 
 const { t } = useI18n();
@@ -108,9 +112,21 @@ const onTileDragEnd = (): void => {
 
     const ids = ordered.value.map((item) => item.id);
 
-    if (ids.join(',') !== props.items.map((item) => item.id).join(',')) {
-        router.post(props.reorderUrl, { ids }, { preserveScroll: true });
+    if (ids.join(',') === props.items.map((item) => item.id).join(',')) {
+        return;
     }
+
+    // Snapshot the dropped order so the optimistic patch reflects exactly what
+    // the user sees; the watch on `props.items` re-syncs `ordered` on both the
+    // optimistic apply and an automatic rollback if the request fails.
+    const reordered = [...ordered.value];
+
+    router.post(props.reorderUrl, { ids }, {
+        preserveScroll: true,
+        ...(props.optimisticKey
+            ? { optimistic: () => ({ [props.optimisticKey as string]: reordered }) }
+            : {}),
+    });
 };
 
 const editing = ref<MediaItem | null>(null);

--- a/packages/panel/resources/js/components/NavLink.vue
+++ b/packages/panel/resources/js/components/NavLink.vue
@@ -59,7 +59,7 @@ function childCls(child: NavItemShape) {
 
 <template>
     <Tooltip :text="collapsed ? item.label : ''">
-        <Link :href="item.url ?? '#'" :class="itemCls" @click="closeDrawer">
+        <Link :href="item.url ?? '#'" :prefetch="!!item.url" :class="itemCls" @click="closeDrawer">
             <Icon v-if="item.icon" :name="item.icon" />
             <span v-if="!collapsed" class="truncate">{{ item.label }}</span>
             <span
@@ -74,6 +74,7 @@ function childCls(child: NavItemShape) {
             v-for="child in item.children"
             :key="child.key"
             :href="child.url ?? '#'"
+            :prefetch="!!child.url"
             :class="childCls(child)"
             @click="closeDrawer"
         >{{ child.label }}</Link>

--- a/packages/panel/resources/js/components/SettingsNavBody.vue
+++ b/packages/panel/resources/js/components/SettingsNavBody.vue
@@ -36,7 +36,7 @@ const backCls = computed(() => [
 
 <template>
     <Tooltip :text="collapsed ? t('common.back_to_main') : ''">
-        <Link :href="backToMainUrl" :class="backCls" @click="closeDrawer">
+        <Link :href="backToMainUrl" prefetch :class="backCls" @click="closeDrawer">
             <Icon name="arrowLeft" /> <span v-if="!collapsed">{{ t('common.back_to_main') }}</span>
         </Link>
     </Tooltip>

--- a/packages/panel/resources/js/pages/customers/Edit.vue
+++ b/packages/panel/resources/js/pages/customers/Edit.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { router, useForm } from '@inertiajs/vue3';
+import { Deferred, router, useForm } from '@inertiajs/vue3';
 import { useI18n } from 'vue-i18n';
 import Button from '../../components/Button.vue';
 import AddressCard from '../../components/AddressCard.vue';
@@ -106,7 +106,8 @@ const props = defineProps<{
         avgOrder: string | null;
         latestOrderAt: string | null;
     };
-    orderChart: {
+    // Deferred prop: absent on first paint, delivered by a follow-up request.
+    orderChart?: {
         range: string;
         buckets: ChartPoint[];
     };
@@ -483,7 +484,7 @@ const submitNotes = (): void => {
 
 // Order-value chart: the range switcher partial-reloads only the chart prop;
 // while data is in flight the previous render holds at reduced opacity.
-const chartRange = ref(props.orderChart.range);
+const chartRange = ref(props.orderChart?.range ?? '12m');
 const chartLoading = ref(false);
 
 const chartRangeOptions = computed<FilterOption[]>(() => [
@@ -506,7 +507,7 @@ const onChartRangeChange = (): void => {
     });
 };
 
-const chartHasData = computed(() => props.orderChart.buckets.some((bucket) => bucket.value > 0));
+const chartHasData = computed(() => (props.orderChart?.buckets ?? []).some((bucket) => bucket.value > 0));
 
 watch(chartRange, onChartRangeChange);
 
@@ -582,12 +583,17 @@ const tabDefs = computed(() => [
                                 <FilterDropdown v-model="chartRange" :label="t('customers.chart_range_12m')" :options="chartRangeOptions" default-value="12m" />
                             </div>
                             <div class="px-4 py-3.5 transition-opacity duration-150" :class="chartLoading ? 'opacity-60' : ''">
-                                <TimeSeriesChart
-                                    v-if="chartHasData"
-                                    :points="orderChart.buckets"
-                                    :ariaLabel="t('customers.chart_title')"
-                                />
-                                <p v-else class="m-0 py-6 text-center text-[12px] text-ink-500 italic">{{ t('customers.chart_empty') }}</p>
+                                <Deferred data="orderChart">
+                                    <template #fallback>
+                                        <div class="h-[168px] rounded-md bg-surface-2 animate-pulse" role="status" :aria-label="t('common.loading')" />
+                                    </template>
+                                    <TimeSeriesChart
+                                        v-if="chartHasData"
+                                        :points="orderChart?.buckets ?? []"
+                                        :ariaLabel="t('customers.chart_title')"
+                                    />
+                                    <p v-else class="m-0 py-6 text-center text-[12px] text-ink-500 italic">{{ t('customers.chart_empty') }}</p>
+                                </Deferred>
                             </div>
                         </div>
 

--- a/packages/panel/resources/js/pages/products/Edit.vue
+++ b/packages/panel/resources/js/pages/products/Edit.vue
@@ -430,6 +430,7 @@ const timelineEvents = computed(() =>
                             :items="media"
                             :store-url="urls.mediaStore"
                             :reorder-url="urls.mediaReorder"
+                            optimistic-key="media"
                         />
 
                         <AttributeFields

--- a/packages/panel/resources/js/pages/settings/activity-log/Index.vue
+++ b/packages/panel/resources/js/pages/settings/activity-log/Index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
-import { router } from '@inertiajs/vue3';
+import { router, usePoll } from '@inertiajs/vue3';
 import { useI18n } from 'vue-i18n';
 import BulkActionsToolbar, { type BulkAction } from '../../../components/BulkActionsToolbar.vue';
 import DataTable from '../../../components/DataTable.vue';
@@ -97,6 +97,11 @@ const reload = (): void => {
 
 watch([subjectType, event], reload);
 watch(extensionFilterValues, reload);
+
+// Live view: re-fetch only the paginated activities every 15s so new entries
+// surface without a manual refresh. Inertia suspends polling while the tab is
+// hidden and reloads preserve scroll/state and the current URL's filters/page.
+usePoll(15000, { only: ['activities'] });
 
 const eventTone = (row: ActivityRow): 'sage' | 'archived' | 'danger' => {
     if (row.event === 'created') return 'sage';

--- a/packages/panel/resources/js/runtime/pageResolver.ts
+++ b/packages/panel/resources/js/runtime/pageResolver.ts
@@ -19,8 +19,14 @@ export function createPageResolver(
             // Auto-apply the shell layout so add-on pages get the sidebar chrome
             // without wrapping it. First-party pages wrap their own layout in the
             // template, so this only touches add-on pages. `??=` leaves an add-on
-            // that set its own persistent layout alone.
-            addonPage.layout ??= runtime.getLayout('default');
+            // that set its own persistent layout alone. v3 tightened `layout`'s
+            // type from a bare `Component` to `LayoutCallbackReturn`, so narrow the
+            // registry's `Component | undefined` return once it is known present.
+            const defaultLayout = runtime.getLayout('default');
+
+            if (defaultLayout) {
+                addonPage.layout ??= defaultLayout as DefineComponent;
+            }
 
             return addonPage;
         }

--- a/packages/panel/resources/views/app.blade.php
+++ b/packages/panel/resources/views/app.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-        <title inertia>{{ config('lunar.panel.name', 'Lunar') }}</title>
+        <title data-inertia>{{ config('lunar.panel.name', 'Lunar') }}</title>
 
         <link rel="icon" type="image/svg+xml" href="{{ asset('vendor/lunar-panel/favicons/favicon.svg') }}" />
         <link rel="icon" type="image/x-icon" href="{{ asset('vendor/lunar-panel/favicons/favicon.ico') }}" sizes="any" />

--- a/packages/panel/src/Http/Controllers/Customers/CustomerEditController.php
+++ b/packages/panel/src/Http/Controllers/Customers/CustomerEditController.php
@@ -142,7 +142,10 @@ class CustomerEditController
             'activities' => $activities,
             'orders' => $orders,
             'stats' => $stats,
-            'orderChart' => $this->orderChart($request, $customer),
+            // Deferred: the heaviest query on the page (order value bucketed over
+            // up to 10 years). It loads in a follow-up request after first paint,
+            // and the range switcher reloads it the same way (only: ['orderChart']).
+            'orderChart' => Inertia::defer(fn () => $this->orderChart($request, $customer)),
             'draft' => $draft ? [
                 'data' => $draft->data,
                 'updated_at' => $draft->updated_at?->toJSON(),

--- a/tests/panel/Feature/Customers/CustomerEditTest.php
+++ b/tests/panel/Feature/Customers/CustomerEditTest.php
@@ -96,12 +96,15 @@ it('buckets placed order value into the order chart', function () {
 
     $this->get(route('panel.customers.edit', $customer))
         ->assertInertia(fn (Assert $page) => $page
-            ->where('orderChart.range', '12m')
-            ->has('orderChart.buckets', 12)
-            ->where('orderChart.buckets.10.value', 100)
-            ->where('orderChart.buckets.10.display', '£100.00')
-            ->where('orderChart.buckets.11.value', 50)
-            ->where('orderChart.buckets.0.value', 0)
+            ->component('customers/Edit')
+            ->loadDeferredProps(fn (Assert $chart) => $chart
+                ->where('orderChart.range', '12m')
+                ->has('orderChart.buckets', 12)
+                ->where('orderChart.buckets.10.value', 100)
+                ->where('orderChart.buckets.10.display', '£100.00')
+                ->where('orderChart.buckets.11.value', 50)
+                ->where('orderChart.buckets.0.value', 0)
+            )
         );
 });
 
@@ -116,10 +119,13 @@ it('zooms the order chart out to yearly buckets', function () {
 
     $this->get(route('panel.customers.edit', ['customer' => $customer, 'chart_range' => '10y']))
         ->assertInertia(fn (Assert $page) => $page
-            ->where('orderChart.range', '10y')
-            ->has('orderChart.buckets', 10)
-            ->where('orderChart.buckets.7.value', 200)
-            ->where('orderChart.buckets.9.value', 0)
+            ->component('customers/Edit')
+            ->loadDeferredProps(fn (Assert $chart) => $chart
+                ->where('orderChart.range', '10y')
+                ->has('orderChart.buckets', 10)
+                ->where('orderChart.buckets.7.value', 200)
+                ->where('orderChart.buckets.9.value', 0)
+            )
         );
 });
 
@@ -130,8 +136,11 @@ it('falls back to the default chart range for unknown values', function () {
 
     $this->get(route('panel.customers.edit', ['customer' => $customer, 'chart_range' => 'banana']))
         ->assertInertia(fn (Assert $page) => $page
-            ->where('orderChart.range', '12m')
-            ->has('orderChart.buckets', 12)
+            ->component('customers/Edit')
+            ->loadDeferredProps(fn (Assert $chart) => $chart
+                ->where('orderChart.range', '12m')
+                ->has('orderChart.buckets', 12)
+            )
         );
 });
 

--- a/tests/panel/Fixtures/AddonTestCase.php
+++ b/tests/panel/Fixtures/AddonTestCase.php
@@ -21,8 +21,8 @@ class AddonTestCase extends TestCase
 
         // The fixture add-on ships its own page component (Widgets/Index);
         // register its path alongside the panel's own for Inertia's testing finder.
-        $app['config']->set('inertia.testing.page_paths', [
-            ...$app['config']->get('inertia.testing.page_paths', []),
+        $app['config']->set('inertia.pages.paths', [
+            ...$app['config']->get('inertia.pages.paths', []),
             __DIR__.'/resources/js/pages',
         ]);
     }

--- a/tests/panel/Fixtures/ExampleAddonTestCase.php
+++ b/tests/panel/Fixtures/ExampleAddonTestCase.php
@@ -22,8 +22,8 @@ class ExampleAddonTestCase extends TestCase
         // The real reference add-on ships its own page component
         // (Widgets/Index); register its path alongside the panel's own
         // and the test fixtures' for Inertia's testing finder.
-        $app['config']->set('inertia.testing.page_paths', [
-            ...$app['config']->get('inertia.testing.page_paths', []),
+        $app['config']->set('inertia.pages.paths', [
+            ...$app['config']->get('inertia.pages.paths', []),
             dirname(__DIR__, 3).'/packages/panel-addon-example/resources/js/pages',
         ]);
     }

--- a/tests/panel/TestCase.php
+++ b/tests/panel/TestCase.php
@@ -53,8 +53,9 @@ class TestCase extends BaseTestCase
 
         // Inertia's testing component-exists check looks under the Testbench
         // skeleton's resource_path() by default; point it at the panel
-        // package's own page components instead.
-        $app['config']->set('inertia.testing.page_paths', [
+        // package's own page components instead. v3 moved this key from
+        // `inertia.testing.page_paths` to `inertia.pages.paths`.
+        $app['config']->set('inertia.pages.paths', [
             dirname(__DIR__, 2).'/packages/panel/resources/js/pages',
         ]);
     }


### PR DESCRIPTION
## Summary

Upgrades the Inertia panel to **Inertia.js v3** and adopts the v3 features that fit the panel's architecture.

- `inertiajs/inertia-laravel` `^2.0` → `^3.0` (v3.1.1)
- `@inertiajs/vue3` `^2` → `^3` (3.6.1) — drops axios/qs/lodash-es from the bundle

## Breaking changes handled

- `<title inertia>` → `<title data-inertia>` in the root view.
- Layout type tightened in `pageResolver.ts` (narrow `Component | undefined`).
- Config restructure `inertia.testing.page_paths` → `inertia.pages.paths` in the panel test case + add-on fixtures.

## v3 features adopted (best-fit)

- **Deferred props** — Customer Edit `orderChart` (heaviest query) loads in a follow-up request behind a `<Deferred>` skeleton; chart tests moved to `loadDeferredProps`.
- **Optimistic updates + rollback** — MediaManager reorder patches the `media` page prop optimistically (opt-in `optimistic-key`) and auto-reverts on failure (previously no rollback).
- **Prefetch** — hover-prefetch on main + settings nav links.
- **Polling** — `usePoll` live-refreshes the Activity Log every 15s (auto-pauses on hidden tab).

## Deliberately not adopted

- **`<Form>` refactor** — v3's `<Form>` is uncontrolled (serializes native named DOM inputs); the panel's inputs are controlled Vue components (`Combobox`/`TagsInput`/`RichTextEditor` render no serializable native control). `useForm` is retained — it is not deprecated in v3 and is the correct tool here.
- **useHttp** — a precognitive form hook, not a request client; the draft layer's 409/422 domain-error mapping (`lib/http`) stays.
- **Infinite scroll / merge-props** — numbered pagination is the better fit for admin index tables.

## Verification

Pint · PHPStan · panel PHP (682 passed) · vitest (210 passed) · type-check · panel build · example add-on build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)