### PR TITLE
feat(panel): lazy-load collections tree

### DIFF
--- a/packages/panel/resources/js/components/CollectionTreeRow.test.ts
+++ b/packages/panel/resources/js/components/CollectionTreeRow.test.ts
@@ -32,6 +32,7 @@ const node = (overrides: Partial<CollectionTreeNode> = {}): CollectionTreeNode =
     descendants_count: 1,
     matched: true,
     edit_url: '/panel/collections/1/edit',
+    children_url: '/panel/collections/1/children',
     children: [],
     _actions: {},
     ...overrides,
@@ -39,13 +40,17 @@ const node = (overrides: Partial<CollectionTreeNode> = {}): CollectionTreeNode =
 
 const child = node({ id: 2, parent_id: 1, name: 'Raincoats', handle: 'raincoats', descendants_count: 0 });
 
-const mountRow = (collection: CollectionTreeNode, options: { expanded?: number[]; forceExpanded?: boolean } = {}) =>
+const mountRow = (
+    collection: CollectionTreeNode,
+    options: { expanded?: number[]; forceExpanded?: boolean; loading?: number[] } = {},
+) =>
     mount(CollectionTreeRow, {
         props: {
             collection,
             depth: 0,
             expandedIds: new Set(options.expanded ?? []),
             forceExpanded: options.forceExpanded ?? false,
+            loadingIds: new Set(options.loading ?? []),
             actions: [],
         },
     });
@@ -67,12 +72,21 @@ describe('CollectionTreeRow', () => {
         expect(mountRow(parent, { expanded: [1] }).text()).toContain('Raincoats');
     });
 
-    it('emits toggle from the chevron', async () => {
-        const wrapper = mountRow(node({ children: [child] }));
+    it('emits the node to toggle from the chevron', async () => {
+        const parent = node({ children: [child] });
+        const wrapper = mountRow(parent);
 
         await wrapper.find('button').trigger('click');
 
-        expect(wrapper.emitted('toggle')).toEqual([[1]]);
+        expect(wrapper.emitted('toggle')?.[0][0]).toMatchObject({ id: 1 });
+    });
+
+    it('shows a chevron for an unloaded subtree and a skeleton while it loads', () => {
+        // descendants_count > 0 with no loaded children: children fetch on expand.
+        const lazy = node({ children: [] });
+
+        expect(mountRow(lazy).find('button[aria-expanded]').exists()).toBe(true);
+        expect(mountRow(lazy, { expanded: [1], loading: [1] }).find('.animate-pulse').exists()).toBe(true);
     });
 
     it('force-expands and disables the chevron while filtering', () => {
@@ -83,7 +97,7 @@ describe('CollectionTreeRow', () => {
     });
 
     it('renders no chevron for leaves', () => {
-        const wrapper = mountRow(node());
+        const wrapper = mountRow(node({ descendants_count: 0 }));
 
         expect(wrapper.find('button[aria-expanded]').exists()).toBe(false);
     });

--- a/packages/panel/resources/js/components/CollectionTreeRow.vue
+++ b/packages/panel/resources/js/components/CollectionTreeRow.vue
@@ -20,6 +20,7 @@ export interface CollectionTreeNode {
     descendants_count: number;
     matched: boolean;
     edit_url: string;
+    children_url: string;
     children: CollectionTreeNode[];
     // Extension-contributed row-action URLs land here under their action key.
     _actions?: Record<string, string>;
@@ -32,15 +33,21 @@ const props = defineProps<{
     // While filtering every node is force-expanded and the chevron disabled,
     // so matches are never hidden behind a collapsed parent.
     forceExpanded: boolean;
+    // Nodes whose children are currently being fetched (browse mode).
+    loadingIds: Set<number>;
     actions: RowAction[];
 }>();
 
-const emit = defineEmits<{ toggle: [id: number] }>();
+const emit = defineEmits<{ toggle: [node: CollectionTreeNode] }>();
 
 const { t } = useI18n();
 
-const hasChildren = computed(() => props.collection.children.length > 0);
+// Nested-set bounds tell us a node has children before they are fetched, so
+// the chevron shows even while the subtree is still unloaded.
+const hasChildren = computed(() => props.collection.descendants_count > 0 || props.collection.children.length > 0);
 const isOpen = computed(() => props.forceExpanded || props.expandedIds.has(props.collection.id));
+const isLoading = computed(() => props.loadingIds.has(props.collection.id));
+const childPad = computed(() => ({ paddingLeft: `${12 + (props.depth + 1) * 22 + 20}px` }));
 
 const statusTone = (status: string): 'sage' | 'warn' | 'archived' =>
     status === 'published' ? 'sage' : status === 'draft' ? 'warn' : 'archived';
@@ -62,7 +69,7 @@ const rowPad = computed(() => ({ paddingLeft: `${12 + props.depth * 22}px` }));
                     class="w-5 h-5 grid place-items-center rounded-sm text-ink-400 hover:text-ink-700 hover:bg-surface-2 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage/35"
                     :aria-label="isOpen ? t('collections.row_collapse') : t('collections.row_expand')"
                     :aria-expanded="isOpen"
-                    @click="emit('toggle', collection.id)"
+                    @click="emit('toggle', collection)"
                 >
                     <span :class="['inline-flex transition-transform duration-150', isOpen ? 'rotate-90' : '']">
                         <Icon name="chevRight" cls="sm" />
@@ -118,7 +125,17 @@ const rowPad = computed(() => ({ paddingLeft: `${12 + props.depth * 22}px` }));
             </div>
         </div>
 
-        <template v-if="hasChildren && isOpen">
+        <template v-if="isOpen">
+            <!-- Subtree loading: pulsing placeholder until children arrive -->
+            <div
+                v-if="isLoading && collection.children.length === 0"
+                :style="childPad"
+                class="flex items-center gap-2.5 py-2.5 pr-2 border-b border-line"
+            >
+                <div class="w-7 h-7 rounded-md bg-surface-2 animate-pulse shrink-0" />
+                <div class="h-3 w-40 rounded bg-surface-2 animate-pulse" />
+            </div>
+
             <CollectionTreeRow
                 v-for="child in collection.children"
                 :key="child.id"
@@ -126,8 +143,9 @@ const rowPad = computed(() => ({ paddingLeft: `${12 + props.depth * 22}px` }));
                 :depth="depth + 1"
                 :expanded-ids="expandedIds"
                 :force-expanded="forceExpanded"
+                :loading-ids="loadingIds"
                 :actions="actions"
-                @toggle="(id) => emit('toggle', id)"
+                @toggle="(node) => emit('toggle', node)"
             />
         </template>
     </div>

--- a/packages/panel/resources/js/pages/collections/Index.vue
+++ b/packages/panel/resources/js/pages/collections/Index.vue
@@ -77,9 +77,8 @@ const clearFilters = (): void => {
     reload();
 };
 
-// Per-group open state persists across visits; per-row expansion is
-// in-memory with everything open by default (the payload nests children, so
-// arriving rows render expanded until toggled).
+// Per-group open state persists across visits; per-row expansion is in-memory
+// and collapsed by default, fetching each subtree on first open.
 const groupOpenKey = (id: number): string => `lunar_collgrp_${id}`;
 
 const initialGroupOpen = (id: number): boolean => {
@@ -121,38 +120,37 @@ const toggleGroup = (id: number): void => {
 
 const isGroupOpen = (id: number): boolean => props.filtering || groupOpen[id] !== false;
 
-const collectIds = (nodes: CollectionTreeNode[], into: number[] = []): number[] => {
-    nodes.forEach((node) => {
-        into.push(node.id);
-        collectIds(node.children, into);
-    });
+// Browse mode starts fully collapsed: only roots ship in the payload and each
+// subtree is fetched the first time its row opens, then cached on the node.
+const expandedIds = reactive(new Set<number>());
+const loadingIds = reactive(new Set<number>());
 
-    return into;
+const loadChildren = async (node: CollectionTreeNode): Promise<void> => {
+    loadingIds.add(node.id);
+
+    try {
+        const response = await fetch(node.children_url, { headers: { Accept: 'application/json' } });
+        const payload = (await response.json()) as { data: CollectionTreeNode[] };
+        node.children = payload.data;
+    } catch {
+        // Leave the node collapsed on failure so the next open retries.
+        expandedIds.delete(node.id);
+    } finally {
+        loadingIds.delete(node.id);
+    }
 };
 
-const expandedIds = reactive(new Set<number>(props.groups.flatMap((group) => collectIds(group.tree))));
-const closedIds = reactive(new Set<number>());
+const toggleRow = (node: CollectionTreeNode): void => {
+    if (expandedIds.has(node.id)) {
+        expandedIds.delete(node.id);
 
-watch(
-    () => props.groups,
-    (groups) => {
-        // New rows from a reload arrive expanded; collapsed state sticks for
-        // rows staff explicitly closed this visit.
-        groups.flatMap((group) => collectIds(group.tree)).forEach((id) => {
-            if (!closedIds.has(id)) {
-                expandedIds.add(id);
-            }
-        });
-    },
-);
+        return;
+    }
 
-const toggleRow = (id: number): void => {
-    if (expandedIds.has(id)) {
-        expandedIds.delete(id);
-        closedIds.add(id);
-    } else {
-        expandedIds.add(id);
-        closedIds.delete(id);
+    expandedIds.add(node.id);
+
+    if (node.children.length === 0 && node.descendants_count > 0) {
+        void loadChildren(node);
     }
 };
 
@@ -312,6 +310,7 @@ const groupHasVisibleRows = (group: CollectionGroupRow): boolean => group.tree.l
                                     :depth="0"
                                     :expanded-ids="expandedIds"
                                     :force-expanded="filtering"
+                                    :loading-ids="loadingIds"
                                     :actions="tableActions"
                                     @toggle="toggleRow"
                                 />

--- a/packages/panel/src/Http/Controllers/Collections/CollectionChildrenController.php
+++ b/packages/panel/src/Http/Controllers/Collections/CollectionChildrenController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Lunar\Panel\Http\Controllers\Collections;
+
+use Illuminate\Http\JsonResponse;
+use Lunar\Core\Models\Collection;
+use Lunar\Panel\Http\Controllers\Concerns\PresentsCollectionRows;
+use Lunar\Panel\Http\Controllers\Concerns\ResolvesTableExtensions;
+
+/**
+ * Serves one collection's immediate children as tree rows, letting the
+ * collections index lazy-load a subtree when its row is expanded rather than
+ * shipping the whole tree up front.
+ */
+class CollectionChildrenController
+{
+    use PresentsCollectionRows;
+    use ResolvesTableExtensions;
+
+    public function index(Collection $collection): JsonResponse
+    {
+        $resolver = $this->resolveTable('collections.index');
+
+        $children = $collection->children()
+            ->withCount('products')
+            ->with('thumbnail')
+            ->defaultOrder()
+            ->get()
+            ->map(fn (Collection $child) => $this->collectionRow($child, $resolver));
+
+        return response()->json(['data' => $children]);
+    }
+}

--- a/packages/panel/src/Http/Controllers/Collections/CollectionIndexController.php
+++ b/packages/panel/src/Http/Controllers/Collections/CollectionIndexController.php
@@ -11,10 +11,12 @@ use Lunar\Core\Models\CollectionGroup;
 use Lunar\Core\States\Collection\Archived;
 use Lunar\Core\States\Collection\Draft;
 use Lunar\Core\States\Collection\Published;
+use Lunar\Panel\Http\Controllers\Concerns\PresentsCollectionRows;
 use Lunar\Panel\Http\Controllers\Concerns\ResolvesTableExtensions;
 
 class CollectionIndexController
 {
+    use PresentsCollectionRows;
     use ResolvesTableExtensions;
 
     public function index(Request $request): Response
@@ -66,32 +68,19 @@ class CollectionIndexController
             $visibleIds = $visible;
         }
 
+        // Browse mode ships only root collections; each subtree is fetched on
+        // demand as rows are expanded. Filtering keeps the eager set (matches
+        // plus their ancestors) so deep matches stay reachable.
         $collections = Collection::query()
             ->withCount('products')
             ->with('thumbnail')
+            ->when(! $filtering, fn ($query) => $query->whereNull('parent_id'))
             ->when($visibleIds !== null, fn ($query) => $query->whereIn('id', array_keys($visibleIds)))
             ->orderBy('collection_group_id')
             ->orderBy('_lft')
             ->get();
 
-        $rows = $collections->map(fn (Collection $collection) => [
-            'id' => $collection->id,
-            'parent_id' => $collection->parent_id,
-            'group_id' => $collection->collection_group_id,
-            'name' => $collection->translate('name'),
-            'handle' => $collection->handle,
-            'thumbnail' => $collection->thumbnail?->getAvailableUrl(['small']),
-            'short_description' => $collection->translate('short_description'),
-            'status' => $collection->status->getValue(),
-            'status_label' => $collection->status->label(),
-            'products_count' => (int) $collection->getAttribute('products_count'),
-            // Nested-set bounds carry the subtree size without another query.
-            'descendants_count' => (int) (($collection->getRgt() - $collection->getLft() - 1) / 2),
-            'matched' => $matchedIds === null || $matchedIds->has($collection->id),
-            'edit_url' => route('panel.collections.edit', $collection),
-            '_actions' => $resolver->resolveRowActionUrls($collection),
-            'children' => [],
-        ]);
+        $rows = $collections->map(fn (Collection $collection) => $this->collectionRow($collection, $resolver, $matchedIds));
 
         $groups = CollectionGroup::query()
             ->withCount('collections')
@@ -111,12 +100,14 @@ class CollectionIndexController
             ])
             ->values();
 
+        $totalCount = Collection::count();
+
         return Inertia::render('collections/Index', [
             'groups' => $groups,
             'tableActions' => $resolver->getActions(),
             'filtering' => $filtering,
-            'matchedCount' => $filtering ? ($matchedIds?->count() ?? 0) : $collections->count(),
-            'totalCount' => Collection::count(),
+            'matchedCount' => $filtering ? ($matchedIds?->count() ?? 0) : $totalCount,
+            'totalCount' => $totalCount,
             'filters' => $request->only(['q', 'status']),
             'urls' => [
                 'index' => route('panel.collections.index'),
@@ -128,8 +119,8 @@ class CollectionIndexController
 
     /**
      * Nest the flat, _lft-ordered rows of one group into a children tree.
-     * Every row's parent is guaranteed present: unfiltered payloads carry the
-     * whole group, filtered ones include every match's ancestors.
+     * Every row's parent is guaranteed present: browse payloads carry only
+     * roots (nothing to nest), filtered ones include every match's ancestors.
      *
      * @param  SupportCollection<int, array<string, mixed>>  $rows
      * @return array<int, array<string, mixed>>

--- a/packages/panel/src/Http/Controllers/Concerns/PresentsCollectionRows.php
+++ b/packages/panel/src/Http/Controllers/Concerns/PresentsCollectionRows.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Lunar\Panel\Http\Controllers\Concerns;
+
+use Illuminate\Support\Collection as SupportCollection;
+use Lunar\Core\Models\Collection;
+use Lunar\Panel\Tables\Resolvers\TableExtensionResolver;
+
+/**
+ * Maps a loaded collection to the tree-row array shape shared by the index
+ * page and the lazy children endpoint, so both surfaces stay identical.
+ */
+trait PresentsCollectionRows
+{
+    /**
+     * $matchedIds is only set while filtering; a null value flags every row as
+     * matched. `children` starts empty — the panel fetches it from
+     * `children_url` when the row is expanded.
+     *
+     * @param  SupportCollection<int, int>|null  $matchedIds
+     * @return array<string, mixed>
+     */
+    protected function collectionRow(Collection $collection, TableExtensionResolver $resolver, ?SupportCollection $matchedIds = null): array
+    {
+        return [
+            'id' => $collection->id,
+            'parent_id' => $collection->parent_id,
+            'group_id' => $collection->collection_group_id,
+            'name' => $collection->translate('name'),
+            'handle' => $collection->handle,
+            'thumbnail' => $collection->thumbnail?->getAvailableUrl(['small']),
+            'short_description' => $collection->translate('short_description'),
+            'status' => $collection->status->getValue(),
+            'status_label' => $collection->status->label(),
+            'products_count' => (int) $collection->getAttribute('products_count'),
+            // Nested-set bounds carry the subtree size without another query.
+            'descendants_count' => (int) (($collection->getRgt() - $collection->getLft() - 1) / 2),
+            'matched' => $matchedIds === null || $matchedIds->has($collection->id),
+            'edit_url' => route('panel.collections.edit', $collection),
+            'children_url' => route('panel.collections.children', $collection),
+            '_actions' => $resolver->resolveRowActionUrls($collection),
+            'children' => [],
+        ];
+    }
+}

--- a/packages/panel/src/Sections/Catalog/CatalogSection.php
+++ b/packages/panel/src/Sections/Catalog/CatalogSection.php
@@ -14,6 +14,7 @@ use Lunar\Panel\Http\Controllers\Brands\BrandUrlController;
 use Lunar\Panel\Http\Controllers\Catalog\CollectionSearchController;
 use Lunar\Panel\Http\Controllers\Catalog\ProductOptionSearchController;
 use Lunar\Panel\Http\Controllers\Catalog\ProductSearchController;
+use Lunar\Panel\Http\Controllers\Collections\CollectionChildrenController;
 use Lunar\Panel\Http\Controllers\Collections\CollectionCreateController;
 use Lunar\Panel\Http\Controllers\Collections\CollectionEditController;
 use Lunar\Panel\Http\Controllers\Collections\CollectionGroupController;
@@ -271,6 +272,8 @@ class CatalogSection extends Section
                 Route::post('/groups', [CollectionGroupController::class, 'store'])->name('groups.store');
                 Route::put('/groups/{collectionGroup}', [CollectionGroupController::class, 'update'])->name('groups.update');
                 Route::delete('/groups/{collectionGroup}', [CollectionGroupController::class, 'destroy'])->name('groups.destroy');
+
+                Route::get('/{collection}/children', [CollectionChildrenController::class, 'index'])->name('children');
 
                 Route::get('/{collection}/edit', [CollectionEditController::class, 'edit'])->name('edit');
                 Route::put('/{collection}', [CollectionEditController::class, 'update'])->name('update');

--- a/tests/panel/Feature/Collections/CollectionIndexTest.php
+++ b/tests/panel/Feature/Collections/CollectionIndexTest.php
@@ -18,7 +18,7 @@ it('redirects guests to the login screen', function () {
     $this->get(route('panel.collections.index'))->assertRedirect(route('panel.login'));
 });
 
-it('renders the grouped collection tree', function () {
+it('renders only root collections, deferring children to lazy loading', function () {
     $this->actingAs(Staff::factory()->create(['admin' => true]), 'staff');
 
     $group = CollectionGroup::factory()->create(['name' => 'Navigation']);
@@ -33,17 +33,45 @@ it('renders the grouped collection tree', function () {
             ->has('groups', 1)
             ->where('groups.0.name', 'Navigation')
             ->where('groups.0.collections_count', 2)
+            // Only the root ships; its child is fetched on expand.
             ->has('groups.0.tree', 1)
             ->has('groups.0.tree.0', fn (Assert $row) => $row
-                ->hasAll(['id', 'name', 'handle', 'thumbnail', 'short_description', 'status', 'status_label', 'products_count', 'descendants_count', 'matched', 'edit_url', '_actions', 'children'])
+                ->hasAll(['id', 'name', 'handle', 'thumbnail', 'short_description', 'status', 'status_label', 'products_count', 'descendants_count', 'matched', 'edit_url', 'children_url', '_actions', 'children'])
                 ->where('id', $root->id)
                 ->where('descendants_count', 1)
-                ->has('children', 1)
+                ->has('children', 0)
                 ->etc()
             )
             ->has('tableActions')
             ->has('urls.create')
         );
+});
+
+it('lazy-loads a collection\'s immediate children', function () {
+    $this->actingAs(Staff::factory()->create(['admin' => true]), 'staff');
+
+    $group = CollectionGroup::factory()->create();
+    $root = Collection::factory()->create(['collection_group_id' => $group->id]);
+    $child = Collection::factory()->create(['collection_group_id' => $group->id]);
+    $grandchild = Collection::factory()->create(['collection_group_id' => $group->id]);
+    $root->appendNode($child);
+    $child->refresh()->appendNode($grandchild);
+
+    $this->getJson(route('panel.collections.children', $root))
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $child->id)
+        // The grandchild is a descendant but not an immediate child.
+        ->assertJsonPath('data.0.descendants_count', 1)
+        ->assertJsonPath('data.0.children', []);
+});
+
+it('gates the children endpoint behind the collections permission', function () {
+    $this->actingAs(Staff::factory()->create(['admin' => false]), 'staff');
+
+    $collection = Collection::factory()->create();
+
+    $this->getJson(route('panel.collections.children', $collection))->assertForbidden();
 });
 
 it('searches by name and includes ancestors for context', function () {


### PR DESCRIPTION
## Problem

The Collections index loaded **every** collection in a single unbounded `->get()` (plus all groups, plus a second full `parent_id` pluck when filtering), nested the whole tree in PHP, and serialised it into the Inertia payload on every visit. Row expansion was pure show/hide — nothing fetched on demand. This does not scale for stores with a large number of collections.

## Change

Split behaviour by mode:

- **Browse (unfiltered) — lazy.** The index ships only **root collections** per group. Each subtree is fetched the first time its row is expanded, via a new `GET /collections/{collection}/children` JSON endpoint, and cached client-side so re-expanding doesn't refetch. The expand chevron keys off `descendants_count` (derived from nested-set bounds), so it appears before children are loaded. A pulsing skeleton row shows while a subtree loads.
- **Search / status filter — unchanged.** Still eager-loads matches plus their ancestors and force-expands, since deep matches must stay reachable.

The tree-row array shape is now produced by a shared `PresentsCollectionRows` trait so the index and children endpoint stay identical.

## Notes

- New endpoint is gated behind the same collections permission as the index.
- Initial payload is now bounded to N roots regardless of catalog size; one query per expand.

## Tests

- `CollectionIndexTest`: updated the browse assertion (roots only, children deferred), added coverage for the children endpoint and its permission gate.
- `CollectionTreeRow.test.ts`: updated for the new chevron/toggle behaviour, added lazy-chevron + loading-skeleton cases.
- Green: Pint, PHPStan (level 0), panel PHP suite (684), vitest (211), type-check, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)