### PR TITLE
fix(panel): render country/language flags as SVG (flag-icons)

### DIFF
--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -27,6 +27,7 @@
     },
     "dependencies": {
         "@tiptap/starter-kit": "^3.28.0",
-        "@tiptap/vue-3": "^3.28.0"
+        "@tiptap/vue-3": "^3.28.0",
+        "flag-icons": "^7.5.0"
     }
 }

--- a/packages/panel/resources/css/app.css
+++ b/packages/panel/resources/css/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'flag-icons/css/flag-icons.min.css';
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/packages/panel/resources/js/components/Combobox.vue
+++ b/packages/panel/resources/js/components/Combobox.vue
@@ -12,9 +12,10 @@ import {
     ComboboxViewport,
 } from 'reka-ui';
 import { useI18n } from 'vue-i18n';
+import Flag from './Flag.vue';
 import Icon from './Icon.vue';
 
-type ComboboxOption = { value: string | number; label: string };
+type ComboboxOption = { value: string | number; label: string; flag?: string | null };
 
 const props = withDefaults(
     defineProps<{
@@ -115,6 +116,7 @@ const inputCls = computed(() => [
                             cls="sm"
                             :class="opt.value === modelValue ? 'text-ink-900' : 'invisible'"
                         />
+                        <Flag v-if="opt.flag" :code="opt.flag" class="shrink-0 text-[13px]" />
                         <span class="truncate">{{ opt.label }}</span>
                     </ComboboxItem>
                 </ComboboxViewport>

--- a/packages/panel/resources/js/components/Flag.vue
+++ b/packages/panel/resources/js/components/Flag.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+// Renders a country/region flag from an ISO 3166-1 alpha-2 code via flag-icons
+// (SVG, so it renders identically on every OS -- unlike emoji flags, which
+// Windows has no glyphs for). Unknown or malformed codes render nothing.
+const props = withDefaults(
+    defineProps<{
+        code?: string | null;
+        label?: string;
+        squared?: boolean;
+    }>(),
+    { code: null, label: undefined, squared: false },
+);
+
+const normalized = computed(() => (props.code ?? '').trim().toLowerCase());
+const valid = computed(() => /^[a-z]{2}$/.test(normalized.value));
+</script>
+
+<template>
+    <span
+        v-if="valid"
+        :class="['fi', squared ? 'fis' : '', `fi-${normalized}`, 'rounded-[2px] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.08)]']"
+        role="img"
+        :aria-label="label ?? normalized.toUpperCase()"
+    />
+</template>

--- a/packages/panel/resources/js/components/UrlSlugs.vue
+++ b/packages/panel/resources/js/components/UrlSlugs.vue
@@ -2,12 +2,13 @@
 import { computed, reactive, ref, watch } from 'vue';
 import { router } from '@inertiajs/vue3';
 import { useI18n } from 'vue-i18n';
-import { flagForLanguage } from '../lib/flags';
+import { regionForLanguage } from '../lib/flags';
 import Button from './Button.vue';
 import Checkbox from './Checkbox.vue';
 import ConfirmDialog from './ConfirmDialog.vue';
 import Dialog from './Dialog.vue';
 import FieldLabel from './FieldLabel.vue';
+import Flag from './Flag.vue';
 import Icon from './Icon.vue';
 import Section from './Section.vue';
 import Select from './Select.vue';
@@ -196,7 +197,7 @@ const previewHref = (url: UrlRow): string | null => {
                     <tr v-for="url in urls" :key="url.id" class="last:[&_td]:border-b-0">
                         <td class="pl-4 whitespace-nowrap align-top pt-3.5 pb-2.5 px-3 border-b border-line">
                             <span class="inline-flex items-center gap-1.5">
-                                <span v-if="flagForLanguage(url.language_code)" class="text-sm leading-none">{{ flagForLanguage(url.language_code) }}</span>
+                                <Flag :code="regionForLanguage(url.language_code)" class="text-[13px]" />
                                 <span class="font-mono text-[11.5px] text-ink-700">{{ url.language_code }}</span>
                             </span>
                         </td>
@@ -263,7 +264,7 @@ const previewHref = (url: UrlRow): string | null => {
                     <FieldLabel for="url-language">{{ t('urls.column_language') }}</FieldLabel>
                     <Select id="url-language" v-model="addLanguageId" :invalid="!!addErrors.language_id">
                         <option v-for="language in languages" :key="language.id" :value="language.id">
-                            {{ [flagForLanguage(language.code), language.name ?? language.code].filter(Boolean).join(' ') }}
+                            {{ language.name ?? language.code }}
                         </option>
                     </Select>
                     <div v-if="addErrors.language_id" class="mt-1 text-[11px] text-danger">{{ addErrors.language_id }}</div>

--- a/packages/panel/resources/js/lib/flags.test.ts
+++ b/packages/panel/resources/js/lib/flags.test.ts
@@ -1,23 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { flagForLanguage } from './flags';
+import { regionForLanguage } from './flags';
 
-const flag = (region: string): string =>
-    String.fromCodePoint(...[...region].map((char) => char.charCodeAt(0) - 0x61 + 0x1f1e6));
-
-describe('flagForLanguage', () => {
+describe('regionForLanguage', () => {
     it('uses the region subtag when present', () => {
-        expect(flagForLanguage('en-GB')).toBe(flag('gb'));
-        expect(flagForLanguage('pt_BR')).toBe(flag('br'));
+        expect(regionForLanguage('en-GB')).toBe('gb');
+        expect(regionForLanguage('pt_BR')).toBe('br');
     });
 
     it('maps bare language codes to a representative region', () => {
-        expect(flagForLanguage('en')).toBe(flag('gb'));
-        expect(flagForLanguage('de')).toBe(flag('de'));
-        expect(flagForLanguage('vi')).toBe(flag('vn'));
+        expect(regionForLanguage('en')).toBe('gb');
+        expect(regionForLanguage('de')).toBe('de');
+        expect(regionForLanguage('vi')).toBe('vn');
     });
 
     it('returns an empty string for unknown shapes', () => {
-        expect(flagForLanguage('eng')).toBe('');
-        expect(flagForLanguage('')).toBe('');
+        expect(regionForLanguage('eng')).toBe('');
+        expect(regionForLanguage('')).toBe('');
     });
 });

--- a/packages/panel/resources/js/lib/flags.ts
+++ b/packages/panel/resources/js/lib/flags.ts
@@ -1,9 +1,8 @@
-// Emoji flag for a language code, built from regional-indicator code points
-// (keeps the source ASCII-only). Locale codes with a region subtag (en-GB,
-// pt_BR) use the region; bare language codes fall back to a representative
-// region, defaulting to the language code itself, which matches for most
-// European languages (de, fr, nl, ...). Unknown codes return '' and callers
-// render nothing.
+// ISO 3166-1 alpha-2 region code for a language code, for feeding <Flag>.
+// Locale codes with a region subtag (en-GB, pt_BR) use the region; bare
+// language codes fall back to a representative region, defaulting to the
+// language code itself, which matches for most European languages (de, fr,
+// nl, ...). Unknown codes return '' and callers render nothing.
 const LANGUAGE_REGIONS: Record<string, string> = {
     ar: 'sa',
     cs: 'cz',
@@ -21,18 +20,10 @@ const LANGUAGE_REGIONS: Record<string, string> = {
     zh: 'cn',
 };
 
-export function flagForLanguage(code: string): string {
+export function regionForLanguage(code: string): string {
     const [language, region] = code.toLowerCase().replace('_', '-').split('-');
 
     const target = region ?? LANGUAGE_REGIONS[language] ?? language;
 
-    if (!/^[a-z]{2}$/.test(target)) {
-        return '';
-    }
-
-    const REGIONAL_INDICATOR_OFFSET = 0x1f1e6 - 0x61; // 'a' maps onto the regional indicator block
-
-    return String.fromCodePoint(
-        ...[...target].map((char) => char.charCodeAt(0) + REGIONAL_INDICATOR_OFFSET),
-    );
+    return /^[a-z]{2}$/.test(target) ? target : '';
 }

--- a/packages/panel/resources/js/pages/settings/countries/Index.vue
+++ b/packages/panel/resources/js/pages/settings/countries/Index.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n';
 import BulkActionsToolbar, { type BulkAction } from '../../../components/BulkActionsToolbar.vue';
 import DataTable from '../../../components/DataTable.vue';
 import FilterDropdown, { type FilterOption } from '../../../components/FilterDropdown.vue';
+import Flag from '../../../components/Flag.vue';
 import { type RowAction } from '../../../components/RowActions.vue';
 import PageEmpty from '../../../components/PageEmpty.vue';
 import Pagination from '../../../components/Pagination.vue';
@@ -134,7 +135,10 @@ const rowTo = (row: Record<string, unknown>): string => (row as unknown as Count
                 <span class="font-mono text-xs text-ink-500">{{ (row as unknown as Country).iso3 }}</span>
             </template>
             <template #cell-name="{ row }">
-                <span class="text-[12.5px] text-ink-900">{{ (row as unknown as Country).emoji }} {{ (row as unknown as Country).name }}</span>
+                <span class="inline-flex items-center gap-2 text-[12.5px] text-ink-900">
+                    <Flag :code="(row as unknown as Country).iso2" />
+                    {{ (row as unknown as Country).name }}
+                </span>
             </template>
             <template #cell-states_count="{ row }">
                 <span class="text-xs text-ink-700 [font-variant-numeric:tabular-nums]">{{ (row as unknown as Country).states_count }}</span>

--- a/packages/panel/resources/js/pages/settings/regions/Edit.vue
+++ b/packages/panel/resources/js/pages/settings/regions/Edit.vue
@@ -7,6 +7,7 @@ import Button from '../../../components/Button.vue';
 import Combobox from '../../../components/Combobox.vue';
 import ConfirmDialog from '../../../components/ConfirmDialog.vue';
 import FieldLabel from '../../../components/FieldLabel.vue';
+import Flag from '../../../components/Flag.vue';
 import Section from '../../../components/Section.vue';
 import Select from '../../../components/Select.vue';
 import TextInput from '../../../components/TextInput.vue';
@@ -28,7 +29,7 @@ type Region = {
 };
 
 type NamedOption = { id: number; name: string };
-type CountryOption = { id: number; name: string; emoji: string };
+type CountryOption = { id: number; name: string; iso2: string | null };
 
 const props = defineProps<{
     region: Region;
@@ -69,13 +70,10 @@ const submit = (): void => {
     })).put(props.urls.update, { preserveScroll: true });
 };
 
-const countryName = (id: number): string => {
-    const country = props.countries.find((c) => c.id === id);
-    return country ? `${country.emoji} ${country.name}` : String(id);
-};
+const countryFor = (id: number): CountryOption | undefined => props.countries.find((c) => c.id === id);
 
 const availableCountries = computed(() =>
-    props.countries.filter((c) => !form.countries.includes(c.id)).map((c) => ({ value: c.id, label: `${c.emoji} ${c.name}` })));
+    props.countries.filter((c) => !form.countries.includes(c.id)).map((c) => ({ value: c.id, label: c.name, flag: c.iso2 })));
 
 const addCountry = (id: string | number): void => {
     form.countries.push(Number(id));
@@ -161,7 +159,8 @@ const confirmDestroy = (): void => {
                     :key="id"
                     class="inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full bg-surface-2 border border-line text-xs text-ink-900"
                 >
-                    {{ countryName(id) }}
+                    <Flag v-if="countryFor(id)?.iso2" :code="countryFor(id)!.iso2" class="text-[13px]" />
+                    {{ countryFor(id)?.name ?? id }}
                     <button
                         type="button"
                         class="w-4 h-4 inline-flex items-center justify-center rounded-full text-ink-500 hover:text-danger"

--- a/packages/panel/resources/js/pages/settings/tax-zones/Edit.vue
+++ b/packages/panel/resources/js/pages/settings/tax-zones/Edit.vue
@@ -7,6 +7,7 @@ import Button from '../../../components/Button.vue';
 import Combobox from '../../../components/Combobox.vue';
 import ConfirmDialog from '../../../components/ConfirmDialog.vue';
 import FieldLabel from '../../../components/FieldLabel.vue';
+import Flag from '../../../components/Flag.vue';
 import Section from '../../../components/Section.vue';
 import Select from '../../../components/Select.vue';
 import TextInput from '../../../components/TextInput.vue';
@@ -31,7 +32,7 @@ type ZoneRate = {
     amounts: Record<number, number>;
 };
 
-type CountryOption = { id: number; name: string; iso2: string | null; emoji: string };
+type CountryOption = { id: number; name: string; iso2: string | null };
 type StateOption = { id: number; name: string; code: string; country: string | null };
 type NamedOption = { id: number; name: string };
 
@@ -77,10 +78,7 @@ const submit = (): void => {
 
 // --- Coverage pickers -------------------------------------------------------
 
-const countryName = (id: number): string => {
-    const country = props.countries.find((c) => c.id === id);
-    return country ? `${country.emoji} ${country.name}` : String(id);
-};
+const countryFor = (id: number): CountryOption | undefined => props.countries.find((c) => c.id === id);
 
 const stateName = (id: number): string => {
     const state = props.states.find((s) => s.id === id);
@@ -90,7 +88,7 @@ const stateName = (id: number): string => {
 const groupName = (id: number): string => props.customerGroups.find((g) => g.id === id)?.name ?? String(id);
 
 const availableCountries = computed(() =>
-    props.countries.filter((c) => !form.countries.includes(c.id)).map((c) => ({ value: c.id, label: `${c.emoji} ${c.name}` })));
+    props.countries.filter((c) => !form.countries.includes(c.id)).map((c) => ({ value: c.id, label: c.name, flag: c.iso2 })));
 
 const availableStates = computed(() =>
     props.states.filter((s) => !form.states.includes(s.id)).map((s) => ({ value: s.id, label: `${s.name}${s.country ? ` (${s.country})` : ''}` })));
@@ -112,7 +110,7 @@ const addGroup = (id: string | number): void => {
 
 const newPostcode = ref<{ country_id: number | null; postcode: string }>({ country_id: null, postcode: '' });
 
-const countryOptions = computed(() => props.countries.map((c) => ({ value: c.id, label: `${c.emoji} ${c.name}` })));
+const countryOptions = computed(() => props.countries.map((c) => ({ value: c.id, label: c.name, flag: c.iso2 })));
 
 const addPostcode = (): void => {
     if (!newPostcode.value.country_id || !newPostcode.value.postcode.trim()) return;
@@ -210,7 +208,8 @@ const confirmDestroy = (): void => {
                     :key="id"
                     class="inline-flex items-center gap-1.5 pl-2.5 pr-1.5 py-1 rounded-full bg-surface-2 border border-line text-xs text-ink-900"
                 >
-                    {{ countryName(id) }}
+                    <Flag v-if="countryFor(id)?.iso2" :code="countryFor(id)!.iso2" class="text-[13px]" />
+                    {{ countryFor(id)?.name ?? id }}
                     <button
                         type="button"
                         class="w-4 h-4 inline-flex items-center justify-center rounded-full text-ink-500 hover:text-danger"
@@ -264,7 +263,10 @@ const confirmDestroy = (): void => {
                     :key="`${row.country_id}-${row.postcode}`"
                     class="flex items-center gap-3 px-3 py-1.5 rounded-md border border-line bg-surface text-xs"
                 >
-                    <span class="text-ink-900">{{ countryName(row.country_id) }}</span>
+                    <span class="inline-flex items-center gap-1.5 text-ink-900">
+                        <Flag v-if="countryFor(row.country_id)?.iso2" :code="countryFor(row.country_id)!.iso2" class="text-[13px]" />
+                        {{ countryFor(row.country_id)?.name ?? row.country_id }}
+                    </span>
                     <span class="font-mono text-ink-700">{{ row.postcode }}</span>
                     <button
                         type="button"

--- a/packages/panel/src/Http/Controllers/Settings/RegionEditController.php
+++ b/packages/panel/src/Http/Controllers/Settings/RegionEditController.php
@@ -38,7 +38,7 @@ class RegionEditController
             'currencies' => Currency::query()->orderBy('code')->get(['id', 'code', 'name']),
             'languages' => Language::query()->orderBy('code')->get(['id', 'code', 'name']),
             'taxZones' => TaxZone::query()->orderBy('name')->get(['id', 'name']),
-            'countries' => Country::query()->orderBy('name')->get(['id', 'name', 'emoji']),
+            'countries' => Country::query()->orderBy('name')->get(['id', 'name', 'iso2']),
             'hasOrderHistory' => Order::query()->where('region_id', $region->id)->exists(),
             'urls' => [
                 'update' => route('panel.settings.regions.update', $region),

--- a/packages/panel/vite.config.ts
+++ b/packages/panel/vite.config.ts
@@ -3,7 +3,13 @@ import tailwindcss from '@tailwindcss/vite';
 import laravel from 'laravel-vite-plugin';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
+// The panel's built assets are served from public/vendor/lunar-panel/build
+// (symlinked from public/build; see PanelServiceProvider + `lunar:panel:link`),
+// but buildDirectory 'build' would bake a `/build/` base into asset urls() --
+// so bundled CSS assets like flag-icons SVGs 404. Pin the build-time base to the
+// real serve path so every bundled url() resolves; dev keeps the plugin default.
+export default defineConfig(({ command }) => ({
+    base: command === 'build' ? '/vendor/lunar-panel/build/' : undefined,
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.ts'],
@@ -14,4 +20,4 @@ export default defineConfig({
         vue(),
         tailwindcss(),
     ],
-});
+}));


### PR DESCRIPTION
## Problem

A contributor reported the country flags on the new Inertia panel didn't render — they showed as broken glyphs instead of flags.

The flags are emoji flag characters (regional-indicator pairs, e.g. `U+1F1EC U+1F1E7` for 🇬🇧). **Windows ships no flag glyphs** in its emoji font, so every browser on Windows falls back to a replacement/boxed glyph. macOS/iOS render them, which is why it looked fine in development.

## Fix

Render flags as SVG instead of relying on the OS emoji font, via a `<Flag>` component backed by [`flag-icons`](https://github.com/lipis/flag-icons) — keyed by the ISO-2 codes already in the data, so they render identically on every OS.

Wired into every flag surface:
- Countries table (the reported screen)
- URL slugs language column
- Regions & tax-zones country chips and pickers (`Combobox` options gained an optional per-option `flag`)

`flagForLanguage()` (returned an emoji string) becomes `regionForLanguage()` (returns an ISO-2 region code). The one native `<select>` that showed an emoji in its option text (add-URL language picker) drops it — a native `<option>` can't hold an SVG, and plain text beats a broken glyph.

## Vite base-path fix (why the SVGs still 404'd at first)

flag-icons is the first dependency to ship bundled CSS `url()` assets. They 404'd because the panel serves its assets from `/vendor/lunar-panel/build/`, but `buildDirectory: 'build'` baked a `/build/` base into `url()` references. Entry CSS/JS were unaffected only because Laravel's `@vite` rewrites those from the manifest — **CSS-internal `url()` can't be rewritten**.

Pinned the build-time Vite `base` to the real serve path (dev untouched). This hardens the panel for any bundled `url()` asset going forward, not just flags.

## Notes for reviewers

- Adds one runtime dependency: `flag-icons@^7.5.0`.
- `<Flag>` is intentionally **not** added to the public `ui.ts` add-on barrel — kept internal for now.
- Requires `npm install` + `npm run build` in `packages/panel` after checkout.

## Verification

- vitest: 211 passed · type-check: clean · build: OK (flag SVGs emit as assets, load on demand)
- Pint: passed · panel Pest suite: 684 passed
- Confirmed rebuilt CSS references `/vendor/lunar-panel/build/assets/…svg` and the SVG is reachable through the asset symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)