### PR TITLE
fix(panel): stop sidebar prefetch triggering the unsaved-changes prompt

### DIFF
--- a/packages/panel/resources/js/composables/useEditDraft.test.ts
+++ b/packages/panel/resources/js/composables/useEditDraft.test.ts
@@ -236,12 +236,12 @@ describe('useEditDraft', () => {
 
     describe('navigation guard', () => {
         type BeforeHandler = (event: {
-            detail: { visit: { url: URL; method: string } };
+            detail: { visit: { url: URL; method: string; prefetch: boolean } };
             preventDefault: () => void;
         }) => void;
 
-        const guardEvent = (path: string, method = 'get') => ({
-            detail: { visit: { url: new URL(path, window.location.origin), method } },
+        const guardEvent = (path: string, method = 'get', prefetch = false) => ({
+            detail: { visit: { url: new URL(path, window.location.origin), method, prefetch } },
             preventDefault: vi.fn(),
         });
 
@@ -289,6 +289,18 @@ describe('useEditDraft', () => {
 
             lastGuard()(guardEvent(window.location.pathname));
             lastGuard()(guardEvent('/somewhere-else', 'post'));
+
+            expect(confirmMock).not.toHaveBeenCalled();
+        });
+
+        it('never prompts for prefetch visits (sidebar link hover)', () => {
+            const confirmMock = vi.fn();
+            vi.stubGlobal('confirm', confirmMock);
+
+            const form = useEditDraft({ initial: { first_name: 'Original' }, draft: null, urls });
+            form.values.first_name = 'Changed';
+
+            lastGuard()(guardEvent('/somewhere-else', 'get', true));
 
             expect(confirmMock).not.toHaveBeenCalled();
         });

--- a/packages/panel/resources/js/composables/useEditDraft.ts
+++ b/packages/panel/resources/js/composables/useEditDraft.ts
@@ -120,9 +120,11 @@ export function useEditDraft<T extends Record<string, unknown>>(options: EditDra
     const t = getCurrentInstance() ? useI18n().t : (key: string): string => key;
 
     const unlistenNavigationGuard = router.on('before', (event) => {
-        const { url, method } = event.detail.visit;
+        const { url, method, prefetch } = event.detail.visit;
 
-        if (!isDirty.value || method !== 'get' || url.pathname === window.location.pathname) {
+        // Prefetch visits (sidebar <Link prefetch> on hover) fire the same
+        // 'before' event but never leave the page, so they must not prompt.
+        if (!isDirty.value || prefetch || method !== 'get' || url.pathname === window.location.pathname) {
             return;
         }
 


### PR DESCRIPTION
## Problem

Editing a product shows a "You have unsaved changes. Leave this page? Your edits will be kept as a draft." confirm when navigating away. The prompt also fired spuriously when simply **hovering** a sidebar link — no navigation had occurred.

## Cause

The edit-draft navigation guard (`useEditDraft.ts`) listens on Inertia's global `before` event. Inertia fires that same event for **prefetch** requests, and the sidebar's `<Link prefetch>` items prefetch on hover. A prefetch is a GET to a different pathname, so it passed straight through the guard's early-return filter (`!isDirty || method !== 'get' || samePath`) and popped the confirm dialog — despite being a background cache fill, not a navigation.

## Fix

The Inertia `Visit` object carries a `prefetch: boolean` flag. The guard now skips prefetch visits. Genuine navigations (real clicks, tab close, refresh) still prompt as before.

## Tests

Added a case to the navigation-guard suite asserting a prefetch visit never prompts. All 16 `useEditDraft` tests pass; `npm run type-check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)