### PR TITLE
ci(panel): build and commit compiled assets on push to 2.x

### DIFF
--- a/.github/workflows/build_panel_assets.yml
+++ b/.github/workflows/build_panel_assets.yml
@@ -1,0 +1,67 @@
+name: build-panel-assets
+
+# The panel ships PREBUILT assets: PanelServiceProvider publishes
+# public/build -> public/vendor/lunar-panel/build, so consumers never run Vite.
+# But the monorepo-split action (split_packages.yml) only carries git-tracked
+# files into lunarphp/panel, and packages/panel/public/build is gitignored --
+# so a plain split would produce a package with no compiled assets.
+#
+# Build the bundle on every push to 2.x and commit it back (force-added, since
+# it's gitignored) so any tag cut from 2.x already contains fresh assets and the
+# split -- and therefore composer installs -- ship a working panel.
+
+on:
+  push:
+    branches: [2.x]
+    # public/build is deliberately absent here: the commit this workflow makes
+    # touches only that dir, so it can't retrigger itself.
+    paths:
+      - "packages/panel/resources/**"
+      - "packages/panel/vite.config.ts"
+      - "packages/panel/package.json"
+      - ".github/workflows/build_panel_assets.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-panel-assets-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # npm install, not ci: the repo gitignores package-lock.json (see
+      # tests.yml). Two installs -- the workspace root links the publishable
+      # packages, packages/panel has its own tree.
+      - name: Install workspace dependencies
+        run: npm install
+
+      - name: Install panel dependencies
+        run: npm install
+        working-directory: packages/panel
+
+      # Only the servable bundle -- not `npm run build`, which also runs vue-tsc
+      # to emit the @lunarphp/panel npm types (the publish_npm path's concern).
+      # Keeping asset shipping decoupled from typecheck means a type error can't
+      # block a fresh bundle from reaching the split.
+      - name: Build panel bundle
+        run: npx vite build
+        working-directory: packages/panel
+
+      - name: Commit built assets
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(panel): rebuild compiled assets"
+          file_pattern: packages/panel/public/build
+          # public/build is gitignored; force it into the commit.
+          add_options: "--force"

--- a/packages/panel/vite.config.ts
+++ b/packages/panel/vite.config.ts
@@ -20,4 +20,25 @@ export default defineConfig(({ command }) => ({
         vue(),
         tailwindcss(),
     ],
+    build: {
+        rollupOptions: {
+            output: {
+                // flag-icons ships ~540 SVGs pulled in via CSS url(); hashing
+                // them re-emits every file on each build, churning committed
+                // assets. Pin flags to stable paths (content rarely changes)
+                // so rebuilds produce identical filenames and no git noise.
+                // The 4x3/1x1 split is preserved -- basenames collide across it.
+                assetFileNames: (assetInfo) => {
+                    const source = assetInfo.originalFileNames?.[0] ?? assetInfo.names?.[0] ?? '';
+                    const flag = source.match(/flag-icons[\\/]flags[\\/](1x1|4x3)[\\/](.+\.svg)$/i);
+
+                    if (flag) {
+                        return `assets/flags/${flag[1]}/${flag[2]}`;
+                    }
+
+                    return 'assets/[name]-[hash][extname]';
+                },
+            },
+        },
+    },
 }));


### PR DESCRIPTION
## Why

The panel ships **prebuilt** assets — `PanelServiceProvider` publishes `public/build` → `public/vendor/lunar-panel/build`, so consumers never run Vite. But `packages/panel/public/build` is gitignored, and the monorepo-split action only carries git-tracked files into `lunarphp/panel`. As-is, the first `2.x` tag would split a `lunarphp/panel` package with **no compiled assets**, so `composer require lunarphp/panel` would install a non-functional panel.

## What

**New workflow — `.github/workflows/build_panel_assets.yml`**
- Triggers on push to `2.x`, scoped to paths that affect the bundle (`packages/panel/resources/**`, `vite.config.ts`, `package.json`, the workflow itself).
- Two `npm install`s (the repo gitignores `package-lock.json`, matching `tests.yml`), then `npx vite build` — asset-only, decoupled from typecheck so a type error can't block a fresh bundle reaching the split.
- Force-commits `packages/panel/public/build` back to `2.x` via `git-auto-commit-action`.

No infinite loop: `GITHUB_TOKEN` commits don't retrigger workflows, and the committed path is outside the trigger paths regardless.

**Flag-icons churn fix — `vite.config.ts`**
- `flag-icons` pulls ~540 SVGs in through CSS `url()`; Vite content-hashes each, so every build re-emits all of them and churns the committed assets.
- `assetFileNames` now pins flags to stable, unhashed paths (`assets/flags/{4x3,1x1}/<code>.svg`), preserving the 4x3/1x1 split (basenames collide across it). Everything else still content-hashes. Verified: CSS `url()`s resolve, and consecutive builds produce an identical filename set.

## Notes

- `.gitignore` left as-is; CI force-adds. Local dev is unaffected — reviewers/contributors run `npm run dev` (Vite dev mode serves via the hot file, no compiled bundle needed). **To document when the time comes.**
- Merging this PR itself fires the workflow (touches `vite.config.ts`), seeding the first committed bundle automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)