### PR TITLE
fix(panel): track compiled bundle so CI can commit built assets

### DIFF
--- a/.github/workflows/build_panel_assets.yml
+++ b/.github/workflows/build_panel_assets.yml
@@ -63,5 +63,3 @@ jobs:
         with:
           commit_message: "chore(panel): rebuild compiled assets"
           file_pattern: packages/panel/public/build
-          # public/build is gitignored; force it into the commit.
-          add_options: "--force"

--- a/packages/panel/.gitattributes
+++ b/packages/panel/.gitattributes
@@ -1,0 +1,4 @@
+# Compiled panel bundle -- committed so composer installs ship working assets,
+# but it's generated output: collapse it in diffs and exclude from language
+# stats so PRs stay reviewable.
+public/build/** linguist-generated=true -diff

--- a/packages/panel/.gitignore
+++ b/packages/panel/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
-public/build/
+# The compiled bundle IS committed (shipped to consumers via the split; built
+# by the build-panel-assets workflow). Only the transient Vite dev hot file is
+# ignored -- `npm run dev` writes it and it must never be committed.
+public/build/hot


### PR DESCRIPTION
## Problem

After #2586 merged, the `build-panel-assets` workflow [ran successfully](https://github.com/lunarphp/lunar/actions/runs/30106412371) but committed nothing — the commit step logged:

> Working tree clean. Nothing to commit.

**Cause:** `git-auto-commit-action` runs its dirty check with `git status` **before** the `git add`, and `git status` respects `.gitignore`. Because `packages/panel/public/build` was gitignored, git reported the tree as clean and the action bailed out *before* ever reaching the `--force` add. `add_options: --force` only affects `git add`, never the dirty check — so the force-add-while-ignored approach can't work.

## Fix

Track the compiled bundle instead of force-adding an ignored path:

- `.gitignore` now ignores only the transient Vite **`hot`** file (`public/build/hot`), not the whole `public/build/` dir. The compiled assets are tracked normally, so the dirty check sees them, the commit proceeds, and no-op runs still exit cleanly.
- Dropped the now-redundant `add_options: --force` from the workflow.
- Added `packages/panel/.gitattributes` marking `public/build/**` as `linguist-generated -diff` so PR diffs collapse the generated blob and it's excluded from language stats.

## Local dev impact

None. `npm run dev` (the documented contributor flow) writes only the still-ignored `hot` file and never the bundle, so local trees stay clean.

Merging this PR re-fires the workflow (it touches the workflow file), which will produce the first real assets commit on `2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)