### PR TITLE
fix(core): stop ProductFactory eagerly creating an orphan brand

### DIFF
--- a/packages/core/database/factories/ProductFactory.php
+++ b/packages/core/database/factories/ProductFactory.php
@@ -17,7 +17,7 @@ class ProductFactory extends BaseFactory
             'public_id' => (string) Str::ulid(),
             'product_type_id' => ProductType::factory(),
             'status' => 'published',
-            'brand_id' => Brand::factory()->create()->id,
+            'brand_id' => Brand::factory(),
             'name' => collect(['en' => $this->faker->words(3, true)]),
             'description' => collect(['en' => $this->faker->paragraph]),
             'short_description' => collect(['en' => $this->faker->sentence]),


### PR DESCRIPTION
## Problem

`Tests\panel\Feature\Brands\BrandIndexTest > it sorts by the allow-listed columns` is flaky — it failed on the `panel - PHP 8.4 - L13.*` job (and passes on L12), asserting `Failed asserting that 3 is identical to 1`.

## Cause

[`ProductFactory`](packages/core/database/factories/ProductFactory.php) defined the brand foreign key eagerly:

```php
'brand_id' => Brand::factory()->create()->id,
```

Because that's a concrete `->create()->id` (not a closure/factory instance), it runs on **every** `Product::factory()->create()` call — even when the caller passes `brand_id` explicitly. So `Product::factory()->create(['brand_id' => $zulu->id])` still spawns a throwaway brand with a random faker name, then discards it. That orphan brand pollutes the brand listing; when its faker name happens to sort before the fixtures, `brands.data.0` isn't the expected brand and the assertion flips. Purely seed-dependent → flaky across the matrix.

## Fix

Make it lazy, matching its sibling `product_type_id => ProductType::factory()`:

```php
'brand_id' => Brand::factory(),
```

Laravel resolves the factory only when `brand_id` isn't supplied, and skips it entirely when it is — no orphan. Behaviour for the default (no override) case is unchanged.

Verified: previously-failing test passes; full `core` (1172) and `panel` (739) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)