### PR TITLE
test(panel): stabilise flaky index search tests (faker-substring collisions)

### DIFF
--- a/tests/panel/Feature/Customers/CustomerIndexTest.php
+++ b/tests/panel/Feature/Customers/CustomerIndexTest.php
@@ -35,7 +35,15 @@ it('searches customers by name, company, tax identifier and account ref', functi
     $this->actingAs(Staff::factory()->create(['admin' => true]), 'staff');
 
     $match = Customer::factory()->create(['first_name' => 'Ada', 'last_name' => 'Lovelace']);
-    Customer::factory()->create(['first_name' => 'Grace', 'last_name' => 'Hopper']);
+    // Pin the decoy's searchable fields: the factory otherwise fills company_name
+    // and tax_identifier with faker values that can contain "ada" and inflate the
+    // result count. account_ref defaults to null.
+    Customer::factory()->create([
+        'first_name' => 'Grace',
+        'last_name' => 'Hopper',
+        'company_name' => null,
+        'tax_identifier' => null,
+    ]);
 
     $this->get(route('panel.customers.index', ['q' => 'Ada']))
         ->assertInertia(fn (Assert $page) => $page

--- a/tests/panel/Feature/Settings/StaffTest.php
+++ b/tests/panel/Feature/Settings/StaffTest.php
@@ -9,7 +9,9 @@ use Spatie\Permission\PermissionRegistrar;
 uses(TestCase::class);
 
 beforeEach(function () {
-    $this->staff = Staff::factory()->create(['admin' => true, 'first_name' => 'Ada', 'last_name' => 'Admin']);
+    // Pin the email: the search test queries email LIKE %term%, and an
+    // unconstrained faker email on the acting staff can contain the term.
+    $this->staff = Staff::factory()->create(['admin' => true, 'first_name' => 'Ada', 'last_name' => 'Admin', 'email' => 'ada.admin@example.com']);
     $this->actingAs($this->staff, 'staff');
 });
 


### PR DESCRIPTION
## Problem

Panel index/search feature tests intermittently fail across the CI matrix — e.g. `CustomerIndexTest > searches customers...` and `StaffTest > the staff index can be searched` asserting a result count of 1 but getting 2. These surfaced as red `panel` jobs on unrelated PRs (#2587) whenever the faker seed was unlucky.

## Cause

These tests search a `q` term across several columns, but the **decoy** records were created with unconstrained faker values on columns the search actually queries:

- **Customers** — search covers `first_name, last_name, company_name, tax_identifier, account_ref`. The decoy "Grace Hopper" had faker `company_name` (`faker->company`) and `tax_identifier` (`Str::random()`); either can contain the substring **"ada"**, so `q=Ada` matched 2.
- **Staff** — search covers `email, first_name, last_name`. The decoy is the acting `Ada Admin` from `beforeEach`, whose unconstrained `faker->safeEmail()` username can contain **"bob"**, so `q=bob` matched 2.

Short, common 3-letter terms make substring collisions likely enough to flake by seed.

## Fix

Pin the at-risk columns on the decoys so only the intended record can match — `company_name`/`tax_identifier` to null on the customer decoy, and a fixed `email` on the acting staff.

## Scope note

A sweep of every panel index test (Customers, Staff, Products, ProductTypes, Brands, Collections, Channels, Currencies) found these were the only genuinely-vulnerable cases. **Collections** search tests share the pattern (decoy `handle` is faker-derived) but are **not** affected: their terms (`Raincoats`, `outer-things`, `super-slug`) cannot occur as substrings of faker's lorem-word handles, so no change is needed. Channels/Currencies have no `q` search. The related `BrandIndexTest` flake is fixed at the factory level in #2588.

Verified: full `panel` suite green (739 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)