### PR TITLE
test(admin): pin staff emails in Staff::search scope test

### DIFF
--- a/tests/admin/Unit/Models/StaffTest.php
+++ b/tests/admin/Unit/Models/StaffTest.php
@@ -16,19 +16,24 @@ test('can get full name', function () {
 });
 
 test('can search staff by name', function () {
+    // Pin emails: scopeSearch also matches on email, so an unconstrained faker
+    // email containing a search term ("joe", "bill") would inflate the counts.
     Staff::factory()->create([
         'first_name' => 'Joe',
         'last_name' => 'Bloggs',
+        'email' => 'joe.bloggs@example.com',
     ]);
 
     Staff::factory()->create([
         'first_name' => 'Tim',
         'last_name' => 'Bloggs',
+        'email' => 'tim.bloggs@example.com',
     ]);
 
     Staff::factory()->create([
         'first_name' => 'Bill',
         'last_name' => 'Chance',
+        'email' => 'bill.chance@example.com',
     ]);
 
     expect(Staff::search('Bloggs')->get())->toHaveCount(2)


### PR DESCRIPTION
## Problem

`Tests\admin\Unit\Models\StaffTest > can search staff by name` flakes:

```
Failed asserting that actual size 2 matches expected size 1.
  ->and(Staff::search('Joe Bloggs')->get())->toHaveCount(1);
```

## Cause

Same faker-substring class as #2588/#2589, in the `Staff::scopeSearch` scope ([Staff.php:127](packages/core/src/Models/Staff.php#L127)):

```php
foreach (explode(' ', $terms) as $term) {
    $query->whereAny(['email', 'first_name', 'last_name'], 'LIKE', "%{$term}%");
}
```

It matches on **`email`** too. The test's decoys (Tim Bloggs, Bill Chance) pinned names but left `email` to faker, so `search('Joe Bloggs')` (which ANDs the terms `Joe` and `Bloggs`) matched a decoy whose random email happened to contain "joe" — inflating the count to 2. Seed-dependent flake.

## Fix

Pin name-derived emails on all three staff so only the intended record matches each term. Verified: full `admin` suite green (235 passed).

## Note

This is the last outstanding case. A sweep across every non-panel suite (admin, core, search, stripe, shipping, upgrade, filament, demo-data) found no other unfixed instances of the pattern — the only substring search scope in the tree is `Staff::scopeSearch`, search-engine tests use mocked results, and other count/sort tests pin the columns they query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)