### PR TITLE
test(core): pin currency codes to fix unique-constraint flake

### DIFF
--- a/tests/core/Unit/Managers/StorefrontSessionManagerTest.php
+++ b/tests/core/Unit/Managers/StorefrontSessionManagerTest.php
@@ -32,8 +32,12 @@ beforeEach(function (): void {
         'default' => true,
     ]);
 
+    // Pin the code: the factory draws a random currencyCode from a ~150-value
+    // pool, which can collide with the explicit 'EUR' currencies other tests
+    // create, violating the unique constraint on lunar_currencies.code.
     Currency::factory()->create([
         'default' => true,
+        'code' => 'USD',
     ]);
 });
 
@@ -176,6 +180,7 @@ test('can set currency', function (): void {
     /** @var Currency */
     $otherCurrency = Currency::factory()->create([
         'default' => false,
+        'code' => 'GBP',
     ]);
 
     /** @var StorefrontSessionManager */


### PR DESCRIPTION
## Problem

`core` suite failed on the PHP 8.5 / L12 job ([run](https://github.com/lunarphp/lunar/actions/runs/30118166022/job/89563877143)):

```
UniqueConstraintViolationException
SQLSTATE[23000]: UNIQUE constraint failed: lunar_currencies.code
(... values (Garth Reichert, EUR, ...))
```

in `Tests\core\Unit\Managers\StorefrontSessionManagerTest`.

## Cause

A new flake class (unique-column collision, distinct from the substring-search flakes in #2588–#2590). `CurrencyFactory` sets `code => faker->unique()->currencyCode` — a ~150-value pool. The test's `beforeEach` default currency used that random code, while two tests explicitly create a `code => 'EUR'` currency. Faker's `unique()` tracker only knows about values *it* generated, not explicitly-set ones, so when the `beforeEach` code randomly landed on `EUR`, the explicit insert violated the unique constraint. Seed-dependent → intermittent across the matrix.

## Fix

Pin the two unpinned currencies in the file to fixed, distinct codes (`USD` for the default, `GBP` for the "other" currency), so it never collides with the explicit `EUR` records.

Verified: full `core` suite green (1172 passed).

## Scope

A targeted scan for the vulnerable shape (an unpinned factory currency co-located with an explicit currency code in the same test) found this file as the offender. The shared `buildCart()` helper also creates a random-code default currency, but its consumers don't create a second explicit-code currency, so it isn't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)