### PR TITLE
Fix hub product variants mapping unmatched permutations to first SKU

### DIFF
--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -28,7 +28,7 @@ class MapVariantsToProductOptions
                 $valueDifference = array_diff_assoc($permutation, $variant['values']);
 
                 if (! count($valueDifference)) {
-                    return $variant;
+                    return true;
                 }
 
                 $amountMatched = count($permutation) - count($valueDifference);
@@ -36,12 +36,17 @@ class MapVariantsToProductOptions
                 return $amountMatched == count($variant['values']);
             });
 
-            $variant = $variants[$variantIndex] ?? null;
+            // search() returns false when nothing matches; PHP coerces false to 0 as an array index.
+            $variant = $variantIndex === false ? null : ($variants[$variantIndex] ?? null);
 
             $variantId = $variant['id'] ?? null;
             $sku = $variant['sku'] ?? null;
             $copiedFrom = null;
             $shouldFill = true;
+
+            if (! $variant && ! $fillMissing) {
+                $shouldFill = false;
+            }
 
             if ($variant) {
                 // Does this variant already exist in our permutations?

--- a/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
+++ b/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
@@ -77,3 +77,118 @@ it('can map variants given three sets of option values', function () {
 
     expect($result)->toHaveCount(4);
 });
+
+it('does not assign the first variant sku to unmatched sparse permutations', function () {
+    $optionValues = [
+        'Size' => [
+            'XS',
+            'L',
+        ],
+        'Colour' => [
+            'Navy',
+            'White',
+        ],
+        'Length' => [
+            'Long',
+            'Short',
+        ],
+        'Fit' => [
+            'Slim',
+        ],
+    ];
+
+    $variants = [
+        [
+            'id' => 1,
+            'sku' => 'TEE-L-NAVY-SHORT',
+            'price' => 0,
+            'stock' => 0,
+            'values' => [
+                'Size' => 'L',
+                'Colour' => 'Navy',
+                'Length' => 'Short',
+                'Fit' => 'Slim',
+            ],
+        ],
+        [
+            'id' => 2,
+            'sku' => 'TEE-XS-WHITE-LONG',
+            'price' => 0,
+            'stock' => 0,
+            'values' => [
+                'Size' => 'XS',
+                'Colour' => 'White',
+                'Length' => 'Long',
+                'Fit' => 'Slim',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: false);
+
+    expect($result)->toHaveCount(2);
+
+    $mappedBySku = collect($result)->keyBy('sku');
+
+    expect($mappedBySku['TEE-L-NAVY-SHORT']['values'])->toBe([
+        'Size' => 'L',
+        'Colour' => 'Navy',
+        'Length' => 'Short',
+        'Fit' => 'Slim',
+    ])->and($mappedBySku['TEE-XS-WHITE-LONG']['values'])->toBe([
+        'Size' => 'XS',
+        'Colour' => 'White',
+        'Length' => 'Long',
+        'Fit' => 'Slim',
+    ]);
+
+    // First cartesian permutation is XS/Navy/Long — must not steal the first variant SKU.
+    expect(
+        collect($result)->contains(fn (array $row) => $row['sku'] === 'TEE-L-NAVY-SHORT'
+            && $row['values']['Size'] === 'XS')
+    )->toBeFalse();
+});
+
+it('keeps unmatched permutations without binding the first variant when fillMissing is enabled', function () {
+    $optionValues = [
+        'Size' => [
+            'Small',
+            'Large',
+        ],
+        'Colour' => [
+            'Red',
+            'Blue',
+        ],
+    ];
+
+    $variants = [
+        [
+            'id' => 10,
+            'sku' => 'SMALL-RED',
+            'price' => 1,
+            'stock' => 5,
+            'values' => [
+                'Size' => 'Small',
+                'Colour' => 'Red',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: true);
+
+    expect($result)->toHaveCount(4);
+
+    $exact = collect($result)->first(
+        fn (array $row) => $row['values'] === ['Size' => 'Small', 'Colour' => 'Red']
+    );
+
+    expect($exact['sku'])->toBe('SMALL-RED')
+        ->and($exact['variant_id'])->toBe(10);
+
+    $unmatchedSkus = collect($result)
+        ->reject(fn (array $row) => $row['variant_id'] === 10)
+        ->pluck('sku')
+        ->all();
+
+    expect($unmatchedSkus)->each->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Fixes a bug in `MapVariantsToProductOptions` where unmatched cartesian option permutations were incorrectly bound to the first product variant.
- Cause: `collect()->search()` returns `false` on no match, and PHP coerces `$variants[false]` to `$variants[0]`.
- With `fillMissing: false` (used by the Product Options / Variants hub widget), unmatched permutations are now skipped instead of inventing mislabelled rows.
- Adds regression coverage for sparse option matrices and for `fillMissing: true` leaving unmatched rows without an existing SKU.

### Reproduction
On a product with shared options and a non-cartesian variant matrix (for example Size/Colour/Length combinations that do not all exist), `/hub/products/{id}/variants` could show the first SKU under the wrong option labels.

## Test plan
- [x] Added Pest unit coverage in `MapVariantsToProductOptionsTest`
- [ ] Run `./vendor/bin/pest tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php`
- [ ] Confirm `/hub/products/{id}/variants` Option column matches each variant’s pivot values for a sparse shared-option product