### PR TITLE
fix(core): accept DateTimeImmutable in scheduling and scope methods

### DIFF
--- a/packages/core/src/Models/Concerns/CanScheduleAvailability.php
+++ b/packages/core/src/Models/Concerns/CanScheduleAvailability.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Core\Models\Concerns;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Lunar\Core\Exceptions\SchedulingException;
@@ -22,8 +22,8 @@ trait CanScheduleAvailability
     protected function schedule(
         Relation $relation,
         mixed $models,
-        ?DateTime $starts = null,
-        ?DateTime $ends = null,
+        ?DateTimeInterface $starts = null,
+        ?DateTimeInterface $ends = null,
         array $pivotData = []
     ): void {
         // Convert to collection if it's an array

--- a/packages/core/src/Models/Concerns/HasChannels.php
+++ b/packages/core/src/Models/Concerns/HasChannels.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Core\Models\Concerns;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -50,7 +50,7 @@ trait HasChannels
         ])->withTimestamps();
     }
 
-    public function scheduleChannel($channel, ?DateTime $startsAt = null, ?DateTime $endsAt = null)
+    public function scheduleChannel($channel, ?DateTimeInterface $startsAt = null, ?DateTimeInterface $endsAt = null)
     {
         if ($channel instanceof Model) {
             $channel = collect([$channel]);
@@ -93,7 +93,7 @@ trait HasChannels
      * @param  Builder  $query
      * @return Builder
      */
-    public function scopeChannel($query, Channel|iterable|null $channel = null, ?DateTime $startsAt = null, ?DateTime $endsAt = null)
+    public function scopeChannel($query, Channel|iterable|null $channel = null, ?DateTimeInterface $startsAt = null, ?DateTimeInterface $endsAt = null)
     {
         if (blank($channel)) {
             return $query;

--- a/packages/core/src/Models/Concerns/HasCustomerGroups.php
+++ b/packages/core/src/Models/Concerns/HasCustomerGroups.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Core\Models\Concerns;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -49,8 +49,8 @@ trait HasCustomerGroups
      */
     public function scheduleCustomerGroup(
         $models,
-        ?DateTime $starts = null,
-        ?DateTime $ends = null,
+        ?DateTimeInterface $starts = null,
+        ?DateTimeInterface $ends = null,
         array $pivotData = []
     ) {
         $this->schedule(
@@ -93,7 +93,7 @@ trait HasCustomerGroups
     /**
      * Apply customer group scope.
      */
-    public function applyCustomerGroupScope(Builder $query, Collection $groupIds, DateTime $startsAt, DateTime $endsAt): Builder
+    public function applyCustomerGroupScope(Builder $query, Collection $groupIds, DateTimeInterface $startsAt, DateTimeInterface $endsAt): Builder
     {
         return $query->whereHas('customerGroups', function ($relation) use ($groupIds, $startsAt, $endsAt) {
             $relation->whereIn(
@@ -119,7 +119,7 @@ trait HasCustomerGroups
      * @param  CustomerGroup|string  $customerGroup
      * @return Builder
      */
-    public function scopeCustomerGroup($query, CustomerGroup|iterable|null $customerGroup = null, ?DateTime $startsAt = null, ?DateTime $endsAt = null)
+    public function scopeCustomerGroup($query, CustomerGroup|iterable|null $customerGroup = null, ?DateTimeInterface $startsAt = null, ?DateTimeInterface $endsAt = null)
     {
         if (blank($customerGroup)) {
             return $query;

--- a/tests/core/Unit/Base/Traits/HasChannelsTest.php
+++ b/tests/core/Unit/Base/Traits/HasChannelsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Core\Models\Channel;
 use Lunar\Core\Models\Product;
@@ -94,4 +95,26 @@ test('can scope results to a channel', function () {
     expect(Product::channel($channelA)->get())->toHaveCount(0);
 
     expect(Product::channel($channelA, $startsAt, $endsAt)->get())->toHaveCount(1);
+});
+
+test('can schedule and scope using immutable dates', function () {
+    $channel = Channel::factory()->create();
+
+    $product = Product::factory()->create();
+
+    $startsAt = CarbonImmutable::now()->addDay();
+    $endsAt = CarbonImmutable::now()->addDays(2);
+
+    $product->scheduleChannel($channel, $startsAt, $endsAt);
+
+    $this->assertDatabaseHas($product->channels()->getTable(), [
+        'channel_id' => $channel->id,
+        'channelable_type' => $product->getMorphClass(),
+        'channelable_id' => $product->id,
+        'starts_at' => $startsAt,
+        'ends_at' => $endsAt,
+        'enabled' => 1,
+    ]);
+
+    expect(Product::channel($channel, $startsAt, $endsAt)->get())->toHaveCount(1);
 });

--- a/tests/core/Unit/Base/Traits/HasCustomerGroupsTest.php
+++ b/tests/core/Unit/Base/Traits/HasCustomerGroupsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Core\Exceptions\SchedulingException;
 use Lunar\Core\Models\Channel;
@@ -241,6 +242,29 @@ test('can scope results to a customer group', function () {
     expect(Product::customerGroup($groupA)->get())->toHaveCount(0);
 
     expect(Product::customerGroup($groupA, $startsAt, $endsAt)->get())->toHaveCount(1);
+});
+
+test('can schedule and scope using immutable dates', function () {
+    $group = CustomerGroup::factory()->create();
+
+    $product = Product::factory()->create();
+
+    $startsAt = CarbonImmutable::now()->addDay();
+    $endsAt = CarbonImmutable::now()->addDays(2);
+
+    $product->scheduleCustomerGroup($group, $startsAt, $endsAt);
+
+    $this->assertDatabaseHas(
+        'lunar_customer_group_product',
+        [
+            'customer_group_id' => $group->id,
+            'starts_at' => $startsAt,
+            'ends_at' => $endsAt,
+            'enabled' => 1,
+        ],
+    );
+
+    expect(Product::customerGroup($group, $startsAt, $endsAt)->get())->toHaveCount(1);
 });
 
 test('customer groups are synced on model creation', function () {


### PR DESCRIPTION
Apps that set `Date::use(CarbonImmutable::class)` get `CarbonImmutable` from `now()`, which is not a `DateTime` subclass. Any cart/discount calculation then throws:

```
TypeError: Discount::applyCustomerGroupScope(): Argument #3 ($startsAt) must be of type DateTime, Carbon\CarbonImmutable given
```

This happens with no unusual usage, `scopeCustomerGroup()` defaults its dates to `now()` internally.

**Fix:** widen `DateTime` parameter typehints to `DateTimeInterface` in `HasCustomerGroups`, `HasChannels`, and `CanScheduleAvailability`. Contravariant-safe; the values are only read, never mutated.

**Tests:** added regression tests passing `CarbonImmutable` into the schedule + scope methods of both traits, both fail with the `TypeError` before the fix.