### PR TITLE
Stop dropping media custom properties on create/edit

### DIFF
--- a/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
+++ b/packages/admin/src/Support/RelationManagers/MediaRelationManager.php
@@ -99,10 +99,7 @@ class MediaRelationManager extends BaseRelationManager
                             ->usingFileName(
                                 $data['media']->getClientOriginalName()
                             )
-                            ->withCustomProperties([
-                                'name' => $data['custom_properties']['name'],
-                                'primary' => $data['custom_properties']['primary'],
-                            ])
+                            ->withCustomProperties($data['custom_properties'] ?? [])
                             ->preservingOriginal()
                             ->toMediaCollection($this->mediaCollection);
                     })->after(
@@ -112,11 +109,20 @@ class MediaRelationManager extends BaseRelationManager
                     ),
             ])
             ->recordActions([
-                EditAction::make()->after(
-                    fn () => ModelMediaUpdated::dispatch(
-                        $this->getOwnerRecord()
-                    )
-                ),
+                EditAction::make()
+                    ->mutateDataUsing(function (array $data, Media $record): array {
+                        $data['custom_properties'] = array_merge(
+                            $record->custom_properties ?? [],
+                            $data['custom_properties'] ?? [],
+                        );
+
+                        return $data;
+                    })
+                    ->after(
+                        fn () => ModelMediaUpdated::dispatch(
+                            $this->getOwnerRecord()
+                        )
+                    ),
                 DeleteAction::make(),
                 Action::make('view_open')
                     ->label(__('lunarpanel::relationmanagers.medias.actions.view.label'))

--- a/tests/admin/Feature/Support/RelationManagers/MediaRelationManagerTest.php
+++ b/tests/admin/Feature/Support/RelationManagers/MediaRelationManagerTest.php
@@ -1,8 +1,15 @@
 <?php
 
+use Filament\Actions\CreateAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Illuminate\Http\UploadedFile;
 use Livewire\Livewire;
 use Lunar\Admin\Filament\Resources\BrandResource\Pages\ManageBrandMedia;
 use Lunar\Admin\Filament\Resources\ProductResource\Pages\ManageProductMedia;
+use Lunar\Admin\Support\Extending\RelationManagerExtension;
+use Lunar\Admin\Support\Facades\LunarPanel;
 use Lunar\Admin\Support\RelationManagers\MediaRelationManager;
 use Lunar\Models\Brand;
 use Lunar\Models\Language;
@@ -29,3 +36,81 @@ it('can render relation manager', function ($model, $page) {
     [Product::class, ManageProductMedia::class],
     [Brand::class, ManageBrandMedia::class],
 ]);
+
+it('persists custom properties added by an extension when creating media', function () {
+    $class = new class extends RelationManagerExtension
+    {
+        public function extendForm(Schema $schema): Schema
+        {
+            $schema->components([
+                ...$schema->getComponents(true),
+                TextInput::make('custom_properties.credits'),
+            ]);
+
+            return $schema;
+        }
+    };
+
+    LunarPanel::extensions([
+        MediaRelationManager::class => $class::class,
+    ]);
+
+    $this->asStaff();
+
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $brand = Brand::factory()->create();
+
+    Livewire::test(MediaRelationManager::class, [
+        'ownerRecord' => $brand,
+        'pageClass' => ManageBrandMedia::class,
+    ])->callTableAction(CreateAction::class, data: [
+        'custom_properties.name' => 'Test image',
+        'custom_properties.credits' => 'Jane Doe',
+        'media' => UploadedFile::fake()->image('foobar.jpg'),
+    ])->assertHasNoTableActionErrors();
+
+    $media = $brand->fresh()->getFirstMedia('default');
+
+    expect($media)->not->toBeNull()
+        ->and($media->getCustomProperty('name'))->toBe('Test image')
+        ->and($media->getCustomProperty('credits'))->toBe('Jane Doe');
+});
+
+it('preserves existing custom properties not present on the edit form', function () {
+    $this->asStaff();
+
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $brand = Brand::factory()->create();
+
+    $media = $brand
+        ->addMedia(UploadedFile::fake()->image('foobar.jpg'))
+        ->preservingOriginal()
+        ->withCustomProperties([
+            'name' => 'Original name',
+            'sha1' => 'abc123',
+        ])
+        ->toMediaCollection('default');
+
+    Livewire::test(MediaRelationManager::class, [
+        'ownerRecord' => $brand,
+        'pageClass' => ManageBrandMedia::class,
+    ])->mountTableAction(EditAction::class, $media)
+        ->setTableActionData([
+            'custom_properties' => [
+                'name' => 'Updated name',
+                'primary' => false,
+            ],
+        ])->callMountedTableAction()
+        ->assertHasNoTableActionErrors();
+
+    $media->refresh();
+
+    expect($media->getCustomProperty('name'))->toBe('Updated name')
+        ->and($media->getCustomProperty('sha1'))->toBe('abc123');
+});


### PR DESCRIPTION
Closes #2596

## Summary

`MediaRelationManager` treated `custom_properties` as a closed set of exactly two keys (`name`, `primary`), which silently broke Spatie Media Library's open key/value contract in two ways:

1. **Create** — the `CreateAction` handler enumerated only `name`/`primary` from the submitted form data and discarded everything else, so any field added via the documented `RelationManagerExtension::extendForm()` seam rendered, validated, and submitted — but its value was never persisted.
2. **Edit** — `EditAction` wrote the submitted form data straight onto the model. Because `custom_properties` is an `array`-cast column, this replaced the whole JSON value instead of merging into it, so any key not rendered by the edit form (imported metadata, dedup markers, alt text, etc.) was silently dropped on save.

## Fix

- **Create**: pass the full submitted `custom_properties` array through to `withCustomProperties()` instead of hand-picking `name`/`primary`.
- **Edit**: added `mutateDataUsing()` to the `EditAction` that merges the submitted `custom_properties` on top of the record's existing `custom_properties`, so unrendered keys survive while submitted keys still win.

## Testing

- Added a feature test asserting a custom property contributed via a `RelationManagerExtension::extendForm()` field is persisted when a media item is created.
- Added a feature test asserting editing a media item preserves an existing custom property key that the edit form does not render, while still applying the change to the field the form does render.
- Ran `vendor/bin/pest tests/admin/Feature/Support` (built a PHP 8.3 + intl/exif/bcmath/gd toolchain via Docker to install the monorepo's Composer dependencies): all 16 tests in that directory pass, including the 2 new tests and the pre-existing `PriceRelationManagerTest`/`RelationManagerExtensionTest`/`CreatePageExtensionTest` suites.
- Verified the new "persists custom properties added by an extension when creating media" test fails against the pre-fix code (`null` instead of `'Jane Doe'`), confirming it actually exercises bug 1.
- `php -l` on both changed files (no syntax errors).
