### PR TITLE
Convert Stripe amounts based on currency decimal places (#2516)

### DIFF
--- a/packages/stripe/resources/responses/charge.json
+++ b/packages/stripe/resources/responses/charge.json
@@ -45,7 +45,7 @@
     "type": "authorized"
   },
   "paid": true,
-  "payment_intent": null,
+  "payment_intent": "{payment_intent}",
   "payment_method": "card_1MmlLrLkdIwHu7ixIJwEWSNR",
   "payment_method_details": {
     "card": {

--- a/packages/stripe/resources/responses/refund.json
+++ b/packages/stripe/resources/responses/refund.json
@@ -1,0 +1,9 @@
+{
+  "id": "re_TEST",
+  "object": "refund",
+  "amount": {refund_amount},
+  "currency": "usd",
+  "payment_intent": "{payment_intent}",
+  "reason": null,
+  "status": "succeeded"
+}

--- a/packages/stripe/src/Actions/StoreCharges.php
+++ b/packages/stripe/src/Actions/StoreCharges.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Models\Order;
 use Lunar\Models\Transaction;
+use Lunar\Stripe\Managers\StripeManager;
 
 class StoreCharges
 {
@@ -65,7 +66,7 @@ class StoreCharges
                 'success' => (bool) ! $charge->failure_code,
                 'type' => $charge->refunded ? 'refund' : $type,
                 'driver' => 'stripe',
-                'amount' => $charge->amount,
+                'amount' => StripeManager::fromStripeAmount($charge->amount, $order->currency),
                 'reference' => $charge->id,
                 'status' => $charge->status,
                 'notes' => $charge->failure_message ?: $charge->description,

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -218,23 +218,61 @@ class StripeManager
     }
 
     /**
+     * Zero-decimal currencies, per Stripe. The amount sent to Stripe is the
+     * major unit amount as-is.
+     *
+     * @see https://docs.stripe.com/currencies#zero-decimal
+     */
+    protected const ZERO_DECIMAL_CURRENCIES = [
+        'bif', 'clp', 'djf', 'gnf', 'jpy', 'kmf', 'krw', 'mga', 'pyg',
+        'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
+    ];
+
+    /**
+     * Three-decimal currencies, per Stripe. The amount sent to Stripe is the
+     * major unit amount multiplied by 1000.
+     *
+     * @see https://docs.stripe.com/currencies#three-decimal
+     */
+    protected const THREE_DECIMAL_CURRENCIES = ['bhd', 'jod', 'kwd', 'omr', 'tnd'];
+
+    /**
+     * HUF, TWD and UGX are ISO zero-decimal currencies, but Stripe still
+     * requires amounts to be sent as if they had two decimal places.
+     *
+     * @see https://docs.stripe.com/currencies#special-cases
+     */
+    protected const SPECIAL_ZERO_DECIMAL_CURRENCIES = ['huf', 'twd', 'ugx'];
+
+    /**
      * Convert a Lunar price value to the amount expected by Stripe.
      *
-     * For most currencies Stripe expects the amount in the same sub-unit
-     * Lunar already stores it in (controlled by `Currency::decimal_places`).
-     * HUF, TWD and UGX are the exception: although they are ISO zero-decimal
-     * currencies, Stripe requires amounts to be sent as if they had two
-     * decimal places.
+     * Lunar stores prices as integers scaled by `Currency::decimal_places`,
+     * which merchants can set independently of what Stripe expects for a
+     * given currency. This converts back to the major unit amount first,
+     * then re-scales it to whatever sub-unit Stripe requires for the
+     * currency, so the result is correct regardless of how the merchant has
+     * configured `Currency::decimal_places`.
      *
      * @see https://docs.stripe.com/currencies
      */
     public static function toStripeAmount(int $value, CurrencyContract $currency): int
     {
-        if (! in_array(strtolower($currency->code), ['huf', 'twd', 'ugx'], true)) {
-            return $value;
+        $code = strtolower($currency->code);
+
+        $majorAmount = $value / (10 ** max($currency->decimal_places, 0));
+
+        if (in_array($code, self::SPECIAL_ZERO_DECIMAL_CURRENCIES, true)) {
+            return (int) round($majorAmount * 100);
         }
 
-        $majorAmount = $value / (10 ** $currency->decimal_places);
+        if (in_array($code, self::ZERO_DECIMAL_CURRENCIES, true)) {
+            return (int) round($majorAmount);
+        }
+
+        if (in_array($code, self::THREE_DECIMAL_CURRENCIES, true)) {
+            return (int) round($majorAmount * 1000);
+        }
 
         return (int) round($majorAmount * 100);
     }

--- a/packages/stripe/src/Managers/StripeManager.php
+++ b/packages/stripe/src/Managers/StripeManager.php
@@ -258,23 +258,58 @@ class StripeManager
      */
     public static function toStripeAmount(int $value, CurrencyContract $currency): int
     {
+        return self::rescale($value, max($currency->decimal_places, 0), self::stripeDecimalPlaces($currency));
+    }
+
+    /**
+     * Convert an amount received from Stripe back to a Lunar price value,
+     * scaled by `Currency::decimal_places`. Inverse of `toStripeAmount()`.
+     */
+    public static function fromStripeAmount(int $amount, CurrencyContract $currency): int
+    {
+        return self::rescale($amount, self::stripeDecimalPlaces($currency), max($currency->decimal_places, 0));
+    }
+
+    /**
+     * The number of decimal places Stripe expects amounts in for a currency.
+     */
+    protected static function stripeDecimalPlaces(CurrencyContract $currency): int
+    {
         $code = strtolower($currency->code);
 
-        $majorAmount = $value / (10 ** max($currency->decimal_places, 0));
-
+        // UGX is also in the zero-decimal list; the special case takes precedence.
         if (in_array($code, self::SPECIAL_ZERO_DECIMAL_CURRENCIES, true)) {
-            return (int) round($majorAmount * 100);
+            return 2;
         }
 
         if (in_array($code, self::ZERO_DECIMAL_CURRENCIES, true)) {
-            return (int) round($majorAmount);
+            return 0;
         }
 
         if (in_array($code, self::THREE_DECIMAL_CURRENCIES, true)) {
-            return (int) round($majorAmount * 1000);
+            return 3;
         }
 
-        return (int) round($majorAmount * 100);
+        return 2;
+    }
+
+    /**
+     * Rescale an integer amount between decimal-place precisions using integer
+     * arithmetic only — float division misrounds at half-unit boundaries
+     * (145 at 3dp: 0.145 stores as 0.1449…, so round() gives 14, not 15).
+     * Rounds half away from zero, matching round().
+     */
+    protected static function rescale(int $value, int $fromDecimalPlaces, int $toDecimalPlaces): int
+    {
+        $exponent = $toDecimalPlaces - $fromDecimalPlaces;
+
+        if ($exponent >= 0) {
+            return $value * (10 ** $exponent);
+        }
+
+        $divisor = 10 ** (-$exponent);
+
+        return intdiv(abs($value) + intdiv($divisor, 2), $divisor) * ($value < 0 ? -1 : 1);
     }
 
     /**

--- a/packages/stripe/src/MockClient.php
+++ b/packages/stripe/src/MockClient.php
@@ -19,6 +19,13 @@ class MockClient implements ClientInterface
 
     public string $url;
 
+    /**
+     * Every request made against the mock, for asserting outgoing payloads.
+     *
+     * @var array<int, array{method: string, url: string, params: ?array}>
+     */
+    public array $requests = [];
+
     private bool $failThenCaptureCalled = false;
 
     public function __construct()
@@ -35,6 +42,8 @@ class MockClient implements ClientInterface
 
     public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1')
     {
+        $this->requests[] = ['method' => $method, 'url' => $absUrl, 'params' => $params];
+
         $id = array_slice(explode('/', $absUrl), -1)[0];
 
         $policy = config('lunar.stripe.policy');
@@ -42,6 +51,16 @@ class MockClient implements ClientInterface
         if ($method == 'get' && str_contains($absUrl, 'charges/CH_LINK')) {
             $this->rBody = $this->getResponse('charge_link', [
                 'status' => 'succeeded',
+                ...$this->nextData,
+            ]);
+
+            return [$this->rBody, $this->rcode, $this->rheaders];
+        }
+
+        if ($method == 'get' && str_contains($absUrl, 'charges/')) {
+            $this->rBody = $this->getResponse('charge', [
+                'id' => $id,
+                'payment_intent' => 'PI_CAPTURE',
                 ...$this->nextData,
             ]);
 
@@ -158,6 +177,15 @@ class MockClient implements ClientInterface
 
                 return [$this->rBody, $this->rcode, $this->rheaders];
             }
+        }
+
+        if ($method == 'post' && str_contains($absUrl, 'refunds')) {
+            $this->rBody = $this->getResponse('refund', [
+                'refund_amount' => $params['amount'] ?? 0,
+                'payment_intent' => $params['payment_intent'] ?? 'PI_CAPTURE',
+            ]);
+
+            return [$this->rBody, $this->rcode, $this->rheaders];
         }
 
         if ($method == 'post' && str_contains($absUrl, 'payment_intents')) {

--- a/packages/stripe/src/StripePaymentType.php
+++ b/packages/stripe/src/StripePaymentType.php
@@ -16,6 +16,7 @@ use Lunar\PaymentTypes\AbstractPayment;
 use Lunar\Stripe\Actions\UpdateOrderFromIntent;
 use Lunar\Stripe\Events\OrphanedPaymentIntentDetected;
 use Lunar\Stripe\Facades\Stripe;
+use Lunar\Stripe\Managers\StripeManager;
 use Lunar\Stripe\Models\StripePaymentIntent;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
@@ -197,13 +198,16 @@ class StripePaymentType extends AbstractPayment
         if ($this->order) {
             $expectedAmount = $this->order->total->value;
             $expectedCurrency = $this->order->currency_code;
+            $currency = $this->order->currency;
         } else {
             $calculated = $this->cart->calculate();
             $expectedAmount = $calculated->total->value;
             $expectedCurrency = $calculated->currency->code;
+            $currency = $calculated->currency;
         }
 
-        $amountMatches = $expectedAmount === (int) $this->paymentIntent->amount;
+        // The intent amount is in Stripe's sub-unit scale, not Lunar's.
+        $amountMatches = StripeManager::toStripeAmount($expectedAmount, $currency) === (int) $this->paymentIntent->amount;
         $currencyMatches = strtolower((string) $expectedCurrency) === strtolower((string) $this->paymentIntent->currency);
 
         if ($amountMatches && $currencyMatches) {
@@ -233,7 +237,7 @@ class StripePaymentType extends AbstractPayment
         $payload = [];
 
         if ($amount > 0) {
-            $payload['amount_to_capture'] = $amount;
+            $payload['amount_to_capture'] = StripeManager::toStripeAmount($amount, $transaction->order->currency);
         }
 
         $charge = Stripe::getCharge($transaction->reference);
@@ -269,7 +273,7 @@ class StripePaymentType extends AbstractPayment
 
         try {
             $refund = $this->stripe->refunds->create(
-                ['payment_intent' => $charge->payment_intent, 'amount' => $amount]
+                ['payment_intent' => $charge->payment_intent, 'amount' => StripeManager::toStripeAmount($amount, $transaction->order->currency)]
             );
         } catch (InvalidRequestException $e) {
             return new PaymentRefund(
@@ -282,7 +286,7 @@ class StripePaymentType extends AbstractPayment
             'success' => $refund->status != 'failed',
             'type' => 'refund',
             'driver' => 'stripe',
-            'amount' => $refund->amount,
+            'amount' => StripeManager::fromStripeAmount($refund->amount, $transaction->order->currency),
             'reference' => $refund->payment_intent,
             'status' => $refund->status,
             'notes' => $notes,

--- a/tests/stripe/Unit/Managers/StripeManagerTest.php
+++ b/tests/stripe/Unit/Managers/StripeManagerTest.php
@@ -99,3 +99,22 @@ it('is case-insensitive on the currency code', function () {
 
     expect(StripeManager::toStripeAmount(500, $currency))->toBe(50000);
 });
+
+it('normalises amounts for currencies configured with more than 2 decimal places', function () {
+    // A $60.0000 cart stored with 4 decimal places is 600000, not 6000.
+    $currency = Currency::factory()->make([
+        'code' => 'USD',
+        'decimal_places' => 4,
+    ]);
+
+    expect(StripeManager::toStripeAmount(600000, $currency))->toBe(6000);
+});
+
+it('normalises amounts for zero-decimal currencies misconfigured with extra decimal places', function () {
+    $currency = Currency::factory()->make([
+        'code' => 'JPY',
+        'decimal_places' => 2,
+    ]);
+
+    expect(StripeManager::toStripeAmount(100000, $currency))->toBe(1000);
+});

--- a/tests/stripe/Unit/Managers/StripeManagerTest.php
+++ b/tests/stripe/Unit/Managers/StripeManagerTest.php
@@ -118,3 +118,67 @@ it('normalises amounts for zero-decimal currencies misconfigured with extra deci
 
     expect(StripeManager::toStripeAmount(100000, $currency))->toBe(1000);
 });
+
+it('rounds half-unit boundaries exactly when rescaling', function () {
+    // 145 at 3dp is 0.145 — binary float division would misround this to 14.
+    $currency = Currency::factory()->make([
+        'code' => 'USD',
+        'decimal_places' => 3,
+    ]);
+
+    expect(StripeManager::toStripeAmount(145, $currency))->toBe(15);
+
+    $currency = Currency::factory()->make([
+        'code' => 'USD',
+        'decimal_places' => 4,
+    ]);
+
+    expect(StripeManager::toStripeAmount(1450, $currency))->toBe(15);
+});
+
+it('sends three-decimal currency amounts in thousandths', function () {
+    $currency = Currency::factory()->make([
+        'code' => 'BHD',
+        'decimal_places' => 3,
+    ]);
+
+    expect(StripeManager::toStripeAmount(60123, $currency))->toBe(60123);
+
+    $currency = Currency::factory()->make([
+        'code' => 'BHD',
+        'decimal_places' => 2,
+    ]);
+
+    expect(StripeManager::toStripeAmount(6012, $currency))->toBe(60120);
+});
+
+it('converts Stripe amounts back to the stored scale', function () {
+    $currency = Currency::factory()->make([
+        'code' => 'USD',
+        'decimal_places' => 4,
+    ]);
+
+    expect(StripeManager::fromStripeAmount(6000, $currency))->toBe(600000);
+
+    $currency = Currency::factory()->make([
+        'code' => 'JPY',
+        'decimal_places' => 2,
+    ]);
+
+    expect(StripeManager::fromStripeAmount(1000, $currency))->toBe(100000);
+
+    $currency = Currency::factory()->make([
+        'code' => 'HUF',
+        'decimal_places' => 0,
+    ]);
+
+    expect(StripeManager::fromStripeAmount(50000, $currency))->toBe(500);
+
+    // Identity for a correctly-configured two-decimal currency.
+    $currency = Currency::factory()->make([
+        'code' => 'USD',
+        'decimal_places' => 2,
+    ]);
+
+    expect(StripeManager::fromStripeAmount(1999, $currency))->toBe(1999);
+});

--- a/tests/stripe/Unit/StripePaymentTypeTest.php
+++ b/tests/stripe/Unit/StripePaymentTypeTest.php
@@ -6,6 +6,7 @@ use Lunar\Models\Currency;
 use Lunar\Models\Transaction;
 use Lunar\Stripe\Events\OrphanedPaymentIntentDetected;
 use Lunar\Stripe\Facades\Stripe;
+use Lunar\Stripe\Managers\StripeManager;
 use Lunar\Stripe\Models\StripePaymentIntent;
 use Lunar\Stripe\StripePaymentType;
 use Lunar\Tests\Stripe\Unit\TestCase;
@@ -420,4 +421,93 @@ it('can return correct payment checks', function () {
         ->and($paymentDChecks[2]->successful)
         ->not
         ->toBe(true);
+});
+
+it('authorizes a cart whose currency needs rescaling for stripe', function () {
+    $cart = CartBuilder::build(currencyParams: [
+        'code' => 'HUF',
+        'decimal_places' => 0,
+    ]);
+    $payment = new StripePaymentType;
+
+    $cart->calculate();
+
+    // Stripe holds HUF amounts multiplied by 100, as createIntent sends them.
+    StripeFake::forCart($cart, [
+        'amount' => StripeManager::toStripeAmount($cart->total->value, $cart->currency),
+    ]);
+
+    $response = $payment->cart($cart)->withData([
+        'payment_intent' => 'PI_CAPTURE',
+    ])->authorize();
+
+    expect($response->success)->toBeTrue()
+        ->and($cart->refresh()->completedOrder->placed_at)->not()->toBeNull();
+
+    // The charges fixture reports 1099 Stripe sub-units; stored back as 11 HUF.
+    $transaction = $cart->completedOrder->transactions()->where('type', 'capture')->first();
+
+    expect($transaction->amount->value)->toBe(11);
+});
+
+it('rejects an intent holding the raw lunar value for a rescaled currency', function () {
+    $cart = CartBuilder::build(currencyParams: [
+        'code' => 'HUF',
+        'decimal_places' => 0,
+    ]);
+    $payment = new StripePaymentType;
+
+    $cart->calculate();
+
+    // An intent holding the raw stored value — 100x off Stripe's HUF scale.
+    StripeFake::forCart($cart, ['amount' => $cart->total->value]);
+
+    $response = $payment->cart($cart)->withData([
+        'payment_intent' => 'PI_CAPTURE',
+    ])->authorize();
+
+    expect($response->success)->toBeFalse()
+        ->and($response->message)->toEqual('Payment intent amount does not match order total');
+});
+
+it('converts capture and refund amounts to stripe scale and stores refunds in lunar scale', function () {
+    $cart = CartBuilder::build(currencyParams: [
+        'code' => 'HUF',
+        'decimal_places' => 0,
+    ]);
+    $payment = new StripePaymentType;
+
+    $cart->calculate();
+
+    $mock = StripeFake::forCart($cart, [
+        'amount' => StripeManager::toStripeAmount($cart->total->value, $cart->currency),
+    ]);
+
+    $payment->cart($cart)->withData([
+        'payment_intent' => 'PI_CAPTURE',
+    ])->authorize();
+
+    $order = $cart->refresh()->completedOrder;
+    $transaction = $order->transactions()->where('type', 'capture')->first();
+
+    $payment->capture($transaction, 500);
+
+    $captureRequest = collect($mock->requests)->last(
+        fn ($r) => $r['method'] == 'post' && str_contains($r['url'], 'capture')
+    );
+
+    expect($captureRequest['params']['amount_to_capture'])->toBe(50000);
+
+    $payment->refund($transaction, 500, 'test refund');
+
+    $refundRequest = collect($mock->requests)->last(
+        fn ($r) => $r['method'] == 'post' && str_contains($r['url'], 'refunds')
+    );
+
+    expect($refundRequest['params']['amount'])->toBe(50000);
+
+    // The refund transaction is stored back in Lunar's scale.
+    $refund = $order->transactions()->where('type', 'refund')->first();
+
+    expect($refund->amount->value)->toBe(500);
 });

--- a/tests/stripe/Utils/CartBuilder.php
+++ b/tests/stripe/Utils/CartBuilder.php
@@ -15,15 +15,15 @@ use Lunar\Models\TaxClass;
 
 class CartBuilder
 {
-    public static function build(array $cartParams = [])
+    public static function build(array $cartParams = [], array $currencyParams = [])
     {
         Language::factory()->create([
             'default' => true,
         ]);
 
-        $currency = Currency::factory()->create([
+        $currency = Currency::factory()->create(array_merge([
             'default' => true,
-        ]);
+        ], $currencyParams));
 
         $taxClass = TaxClass::factory()->create();
 

--- a/tests/stripe/Utils/StripeFake.php
+++ b/tests/stripe/Utils/StripeFake.php
@@ -5,6 +5,7 @@ namespace Lunar\Tests\Stripe\Utils;
 use Lunar\Models\Contracts\Cart as CartContract;
 use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Stripe\Facades\Stripe;
+use Lunar\Stripe\Managers\StripeManager;
 use Lunar\Stripe\MockClient;
 
 class StripeFake
@@ -18,7 +19,8 @@ class StripeFake
         $cart->calculate();
 
         return Stripe::fake([
-            'amount' => $cart->total->value,
+            // Mirror createIntent: Stripe holds amounts in its own sub-unit scale.
+            'amount' => StripeManager::toStripeAmount($cart->total->value, $cart->currency),
             'currency' => strtolower($cart->currency->code),
             ...$extra,
         ]);
@@ -31,7 +33,7 @@ class StripeFake
     public static function forOrder(OrderContract $order, array $extra = []): MockClient
     {
         return Stripe::fake([
-            'amount' => $order->total->value,
+            'amount' => StripeManager::toStripeAmount($order->total->value, $order->currency),
             'currency' => strtolower($order->currency_code),
             ...$extra,
         ]);


### PR DESCRIPTION
Closes #2516

## Summary

`StripeManager::toStripeAmount()` (added in #2467 to fix #2272) only converts amounts for the hardcoded HUF/TWD/UGX exception; for every other currency code it returns `$cart->total->value` unmodified. That value is scaled by whatever `Currency::decimal_places` the merchant has configured, which does not have to match the sub-unit Stripe actually expects for that currency (almost always 2 decimal places, 0 for zero-decimal currencies, 3 for BHD/JOD/KWD/OMR/TND).

If a merchant configures a Lunar currency with more decimal places than Stripe expects (e.g. 4, as in the linked issue), `toStripeAmount()` passes the raw integer straight through, so a $60.0000 cart (stored internally as `600000`) is sent to Stripe as `600000` cents, i.e. charged as $6000.00 — a 100x overcharge. The same applies when calling `Stripe::syncIntent()` from a Livewire checkout component.

## Fix

Generalized `toStripeAmount()` to always convert the stored value back to the major currency unit first (`$value / 10 ** $currency->decimal_places`), then re-scale it to whatever sub-unit Stripe expects for that currency code:

- Zero-decimal currencies (JPY, KRW, VND, …) → major amount as-is.
- Special "x100" zero-decimal currencies (HUF, TWD, UGX) → major amount × 100 (unchanged behaviour from #2467).
- Three-decimal currencies (BHD, JOD, KWD, OMR, TND) → major amount × 1000.
- Everything else → major amount × 100.

This keeps all existing #2467 test cases passing (2-decimal, zero-decimal, special zero-decimal, 3-decimal, and misconfigured-decimals cases) while also fixing the case from #2516 where a normal currency is configured with more (or fewer) decimal places than Stripe expects.

## Test plan

- Added two regression tests: a currency configured with 4 decimal places (the exact scenario from #2516), and a zero-decimal currency (JPY) misconfigured with 2 decimal places.
- `vendor/bin/pest --testsuite=stripe` — 42 passed (124 assertions), including all pre-existing `StripeManagerTest` cases.