### PR TITLE
Fix saving new product option permutations without a tax class

### DIFF
--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -36,12 +36,26 @@ class MapVariantsToProductOptions
                 return $amountMatched == count($variant['values']);
             });
 
-            $variant = $variants[$variantIndex] ?? null;
+            // search() returns false when nothing matches; PHP coerces false to 0 as an array index.
+            $variant = $variantIndex === false ? null : ($variants[$variantIndex] ?? null);
 
             $variantId = $variant['id'] ?? null;
             $sku = $variant['sku'] ?? null;
             $copiedFrom = null;
             $shouldFill = true;
+
+            if (! $variant && ! $fillMissing) {
+                $shouldFill = false;
+            }
+
+            // Unmatched permutations (e.g. a newly enabled option value) have no
+            // variant_id. Copy the first existing variant so saveVariantsAction
+            // can replicate() tax_class_id and a base price instead of inserting
+            // a bare row (tax_class_id is NOT NULL with no default).
+            if (! $variant && $fillMissing) {
+                $firstExisting = collect($variants)->first();
+                $copiedFrom = is_array($firstExisting) ? ($firstExisting['id'] ?? null) : null;
+            }
 
             if ($variant) {
                 // Does this variant already exist in our permutations?

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -21,10 +21,12 @@ use Lunar\Facades\DB;
 use Lunar\Models\Contracts\ProductOption as ProductOptionContract;
 use Lunar\Models\Contracts\ProductOptionValue as ProductOptionValueContract;
 use Lunar\Models\Contracts\ProductVariant as ProductVariantContract;
+use Lunar\Models\Currency;
 use Lunar\Models\Language;
 use Lunar\Models\ProductOption;
 use Lunar\Models\ProductOptionValue;
 use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
 
 class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
 {
@@ -413,9 +415,38 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                         $basePrice->priceable_id = $variant->id;
                     }
 
+                    /**
+                     * MapVariantsToProductOptions can emit a new permutation with
+                     * neither variant_id nor copied_id (e.g. a newly enabled option
+                     * value). Inserting a bare variant omits tax_class_id, which is
+                     * NOT NULL without a default. Replicate the first existing
+                     * variant so tax class and a base price are present.
+                     */
+                    if (! $variant->exists) {
+                        $sourceVariant = $this->record->variants()->first();
+
+                        if ($sourceVariant) {
+                            $variant = $sourceVariant->replicate();
+                            $variant->product_id = $this->record->id;
+                            $basePrice = $sourceVariant->basePrices->first()?->replicate();
+                        } else {
+                            $variant->tax_class_id = TaxClass::getDefault()?->id;
+                        }
+                    }
+
                     $variant->sku = $variantData['sku'];
                     $variant->stock = $variantData['stock'];
                     $variant->save();
+
+                    if (! $basePrice) {
+                        $basePrice = $variant->prices()->make([
+                            'min_quantity' => 1,
+                            'currency_id' => Currency::getDefault()->id,
+                            'price' => 0,
+                        ]);
+                    } elseif ($basePrice->priceable_id !== $variant->id) {
+                        $basePrice->priceable_id = $variant->id;
+                    }
 
                     $basePrice->price = (int) bcmul($variantData['price'], $basePrice->currency->factor);
                     $basePrice->save();

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Livewire\Livewire;
+use Lunar\Admin\Filament\Resources\ProductResource\Widgets\ProductOptionsWidget;
+use Lunar\Models\Currency;
+use Lunar\Models\Language;
+use Lunar\Models\Product;
+use Lunar\Models\ProductVariant;
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.product.widgets');
+
+it('can save a new option permutation that has no variant_id or copied_id', function () {
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'default' => true,
+        'decimal_places' => 2,
+    ]);
+
+    $product = Product::factory()->create();
+    $variant = ProductVariant::factory()->create([
+        'product_id' => $product->id,
+        'sku' => 'ABC-12W',
+        'stock' => 4,
+    ]);
+
+    $variant->prices()->create([
+        'price' => 1500,
+        'currency_id' => $currency->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    Livewire::test(ProductOptionsWidget::class, [
+        'record' => $product->fresh(),
+    ])->set('variants', [
+        [
+            'key' => 'existing',
+            'variant_id' => $variant->id,
+            'copied_id' => null,
+            'sku' => $variant->sku,
+            'price' => 15,
+            'stock' => 4,
+            'values' => [],
+        ],
+        [
+            'key' => 'new',
+            'variant_id' => null,
+            'copied_id' => null,
+            'sku' => 'ABC-18W',
+            'price' => 18,
+            'stock' => 0,
+            'values' => [],
+        ],
+    ])->callAction('saveVariants')
+        ->assertHasNoErrors();
+
+    $created = ProductVariant::query()
+        ->where('product_id', $product->id)
+        ->where('sku', 'ABC-18W')
+        ->first();
+
+    expect($created)->not->toBeNull()
+        ->and($created->tax_class_id)->toBe($variant->tax_class_id)
+        ->and($created->stock)->toBe(0)
+        ->and($created->basePrices->first()?->price->value)->toBe(1800);
+});

--- a/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
+++ b/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
@@ -77,3 +77,37 @@ it('can map variants given three sets of option values', function () {
 
     expect($result)->toHaveCount(4);
 });
+
+it('copies the first existing variant onto unmatched permutations', function () {
+    $result = MapVariantsToProductOptions::map(
+        [
+            'Wattage' => [
+                '12W',
+                '18W',
+            ],
+        ],
+        [
+            [
+                'id' => 10,
+                'sku' => 'ABC-12W',
+                'price' => 15,
+                'stock' => 4,
+                'values' => [
+                    'Wattage' => '12W',
+                ],
+            ],
+        ]
+    );
+
+    $twelve = collect($result)->first(
+        fn (array $row): bool => ($row['values']['Wattage'] ?? null) === '12W'
+    );
+    $eighteen = collect($result)->first(
+        fn (array $row): bool => ($row['values']['Wattage'] ?? null) === '18W'
+    );
+
+    expect($twelve['variant_id'])->toBe(10)
+        ->and($twelve['copied_id'])->toBeNull()
+        ->and($eighteen['variant_id'])->toBeNull()
+        ->and($eighteen['copied_id'])->toBe(10);
+});


### PR DESCRIPTION
## Summary
- Saving a new Hub option permutation (no `variant_id` / `copied_id`) inserted a bare `lunar_product_variants` row with only `product_id`, `sku`, and `stock`.
- `tax_class_id` is NOT NULL with no default, so MariaDB/SQLite reject the insert (`Field 'tax_class_id' doesn't have a default value`).
- Unmatched permutations now copy the first existing variant, and `saveVariants` replicates that sibling (tax class + base price) before insert.

## Test plan
- [x] `vendor/bin/pest tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php`
- [x] `vendor/bin/pest tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php`
- [ ] In Hub, open a product with one variant, add a new option value, save variants, and confirm the new SKU is created with the same tax class and a base price.


Made with [Cursor](https://cursor.com)