### PR TITLE
Fix hub product option mapping and new variant tax class

### DIFF
--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -28,7 +28,7 @@ class MapVariantsToProductOptions
                 $valueDifference = array_diff_assoc($permutation, $variant['values']);
 
                 if (! count($valueDifference)) {
-                    return $variant;
+                    return true;
                 }
 
                 $amountMatched = count($permutation) - count($valueDifference);
@@ -36,12 +36,17 @@ class MapVariantsToProductOptions
                 return $amountMatched == count($variant['values']);
             });
 
-            $variant = $variants[$variantIndex] ?? null;
+            // search() returns false when nothing matches; PHP coerces false to 0 as an array index.
+            $variant = $variantIndex === false ? null : ($variants[$variantIndex] ?? null);
 
             $variantId = $variant['id'] ?? null;
             $sku = $variant['sku'] ?? null;
             $copiedFrom = null;
             $shouldFill = true;
+
+            if (! $variant && ! $fillMissing) {
+                $shouldFill = false;
+            }
 
             if ($variant) {
                 // Does this variant already exist in our permutations?

--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -36,7 +36,7 @@ class MapVariantsToProductOptions
                 return $amountMatched == count($variant['values']);
             });
 
-            // search() returns false when nothing matches; PHP coerces false to 0 as an array index.
+            // search() returns false when nothing matches; PHP coerces false to index 0.
             $variant = $variantIndex === false ? null : ($variants[$variantIndex] ?? null);
 
             $variantId = $variant['id'] ?? null;
@@ -48,13 +48,9 @@ class MapVariantsToProductOptions
                 $shouldFill = false;
             }
 
-            // Unmatched permutations (e.g. a newly enabled Size/Colour value) have
-            // no variant_id. Copy the first existing variant so saveVariantsAction
-            // can replicate() tax_class_id and a base price instead of inserting a
-            // bare row (tax_class_id is NOT NULL with no default).
+            // New option combinations still need tax_class_id on insert; copy a sibling.
             if (! $variant && $fillMissing) {
-                $firstExisting = collect($variants)->first();
-                $copiedFrom = is_array($firstExisting) ? ($firstExisting['id'] ?? null) : null;
+                $copiedFrom = collect($variants)->pluck('id')->first();
             }
 
             if ($variant) {

--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -48,6 +48,15 @@ class MapVariantsToProductOptions
                 $shouldFill = false;
             }
 
+            // Unmatched permutations (e.g. a newly enabled Size/Colour value) have
+            // no variant_id. Copy the first existing variant so saveVariantsAction
+            // can replicate() tax_class_id and a base price instead of inserting a
+            // bare row (tax_class_id is NOT NULL with no default).
+            if (! $variant && $fillMissing) {
+                $firstExisting = collect($variants)->first();
+                $copiedFrom = is_array($firstExisting) ? ($firstExisting['id'] ?? null) : null;
+            }
+
             if ($variant) {
                 // Does this variant already exist in our permutations?
                 // if so we want to mark it as new but

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -21,12 +21,10 @@ use Lunar\Facades\DB;
 use Lunar\Models\Contracts\ProductOption as ProductOptionContract;
 use Lunar\Models\Contracts\ProductOptionValue as ProductOptionValueContract;
 use Lunar\Models\Contracts\ProductVariant as ProductVariantContract;
-use Lunar\Models\Currency;
 use Lunar\Models\Language;
 use Lunar\Models\ProductOption;
 use Lunar\Models\ProductOptionValue;
 use Lunar\Models\ProductVariant;
-use Lunar\Models\TaxClass;
 
 class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
 {
@@ -415,38 +413,9 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                         $basePrice->priceable_id = $variant->id;
                     }
 
-                    /**
-                     * After MapVariantsToProductOptions skips false-index matches,
-                     * a new permutation can have neither variant_id nor copied_id.
-                     * Inserting a bare variant omits tax_class_id, which is NOT NULL
-                     * without a default. Replicate the first existing variant so tax
-                     * class and a base price are present.
-                     */
-                    if (! $variant->exists) {
-                        $sourceVariant = $this->record->variants()->first();
-
-                        if ($sourceVariant) {
-                            $variant = $sourceVariant->replicate();
-                            $variant->product_id = $this->record->id;
-                            $basePrice = $sourceVariant->basePrices->first()?->replicate();
-                        } else {
-                            $variant->tax_class_id = TaxClass::getDefault()?->id;
-                        }
-                    }
-
                     $variant->sku = $variantData['sku'];
                     $variant->stock = $variantData['stock'];
                     $variant->save();
-
-                    if (! $basePrice) {
-                        $basePrice = $variant->prices()->make([
-                            'min_quantity' => 1,
-                            'currency_id' => Currency::getDefault()->id,
-                            'price' => 0,
-                        ]);
-                    } elseif ($basePrice->priceable_id !== $variant->id) {
-                        $basePrice->priceable_id = $variant->id;
-                    }
 
                     $basePrice->price = (int) bcmul($variantData['price'], $basePrice->currency->factor);
                     $basePrice->save();

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -401,6 +401,10 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                         $basePrice = $variant->basePrices->first();
                     }
 
+                    if (empty($variantData['variant_id']) && empty($variantData['copied_id'])) {
+                        $variantData['copied_id'] = $this->record->variants()->value('id');
+                    }
+
                     if (! empty($variantData['copied_id'])) {
                         $copiedVariant = ProductVariant::find(
                             $variantData['copied_id']

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -21,10 +21,12 @@ use Lunar\Facades\DB;
 use Lunar\Models\Contracts\ProductOption as ProductOptionContract;
 use Lunar\Models\Contracts\ProductOptionValue as ProductOptionValueContract;
 use Lunar\Models\Contracts\ProductVariant as ProductVariantContract;
+use Lunar\Models\Currency;
 use Lunar\Models\Language;
 use Lunar\Models\ProductOption;
 use Lunar\Models\ProductOptionValue;
 use Lunar\Models\ProductVariant;
+use Lunar\Models\TaxClass;
 
 class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
 {
@@ -413,9 +415,38 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                         $basePrice->priceable_id = $variant->id;
                     }
 
+                    /**
+                     * After MapVariantsToProductOptions skips false-index matches,
+                     * a new permutation can have neither variant_id nor copied_id.
+                     * Inserting a bare variant omits tax_class_id, which is NOT NULL
+                     * without a default. Replicate the first existing variant so tax
+                     * class and a base price are present.
+                     */
+                    if (! $variant->exists) {
+                        $sourceVariant = $this->record->variants()->first();
+
+                        if ($sourceVariant) {
+                            $variant = $sourceVariant->replicate();
+                            $variant->product_id = $this->record->id;
+                            $basePrice = $sourceVariant->basePrices->first()?->replicate();
+                        } else {
+                            $variant->tax_class_id = TaxClass::getDefault()?->id;
+                        }
+                    }
+
                     $variant->sku = $variantData['sku'];
                     $variant->stock = $variantData['stock'];
                     $variant->save();
+
+                    if (! $basePrice) {
+                        $basePrice = $variant->prices()->make([
+                            'min_quantity' => 1,
+                            'currency_id' => Currency::getDefault()->id,
+                            'price' => 0,
+                        ]);
+                    } elseif ($basePrice->priceable_id !== $variant->id) {
+                        $basePrice->priceable_id = $variant->id;
+                    }
 
                     $basePrice->price = (int) bcmul($variantData['price'], $basePrice->currency->factor);
                     $basePrice->save();

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Livewire\Livewire;
+use Lunar\Admin\Filament\Resources\ProductResource\Widgets\ProductOptionsWidget;
+use Lunar\Models\Currency;
+use Lunar\Models\Language;
+use Lunar\Models\Product;
+use Lunar\Models\ProductVariant;
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.product.widgets');
+
+it('can save a new size and colour permutation that has no variant_id or copied_id', function () {
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'default' => true,
+        'decimal_places' => 2,
+    ]);
+
+    $product = Product::factory()->create();
+    $variant = ProductVariant::factory()->create([
+        'product_id' => $product->id,
+        'sku' => 'SMALL-RED',
+        'stock' => 4,
+    ]);
+
+    $variant->prices()->create([
+        'price' => 1500,
+        'currency_id' => $currency->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    Livewire::test(ProductOptionsWidget::class, [
+        'record' => $product->fresh(),
+    ])->set('variants', [
+        [
+            'key' => 'existing',
+            'variant_id' => $variant->id,
+            'copied_id' => null,
+            'sku' => 'SMALL-RED',
+            'price' => 15,
+            'stock' => 4,
+            'values' => [],
+        ],
+        [
+            'key' => 'new',
+            'variant_id' => null,
+            'copied_id' => null,
+            'sku' => 'LARGE-BLUE',
+            'price' => 18,
+            'stock' => 0,
+            'values' => [],
+        ],
+    ])->callAction('saveVariants')
+        ->assertHasNoErrors();
+
+    $created = ProductVariant::query()
+        ->where('product_id', $product->id)
+        ->where('sku', 'LARGE-BLUE')
+        ->first();
+
+    expect($created)->not->toBeNull()
+        ->and($created->tax_class_id)->toBe($variant->tax_class_id)
+        ->and($created->stock)->toBe(0)
+        ->and($created->basePrices->first()?->price->value)->toBe(1800);
+});

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
@@ -79,3 +79,62 @@ it('can save newly filled size and colour permutations', function () {
         ->and($variants->pluck('tax_class_id')->unique()->all())->toBe([$variant->tax_class_id])
         ->and($variants->pluck('sku'))->toContain('SMALL-RED');
 });
+
+it('can save a new size and colour permutation when copied_id is missing', function () {
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'default' => true,
+        'decimal_places' => 2,
+    ]);
+
+    $product = Product::factory()->create();
+    $variant = ProductVariant::factory()->create([
+        'product_id' => $product->id,
+        'sku' => 'SMALL-RED',
+        'stock' => 4,
+    ]);
+
+    $variant->prices()->create([
+        'price' => 1500,
+        'currency_id' => $currency->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    Livewire::test(ProductOptionsWidget::class, [
+        'record' => $product->fresh(),
+    ])->set('variants', [
+        [
+            'key' => 'existing',
+            'variant_id' => $variant->id,
+            'copied_id' => null,
+            'sku' => 'SMALL-RED',
+            'price' => 15,
+            'stock' => 4,
+            'values' => [],
+        ],
+        [
+            'key' => 'new',
+            'variant_id' => null,
+            'copied_id' => null,
+            'sku' => 'LARGE-BLUE',
+            'price' => 18,
+            'stock' => 0,
+            'values' => [],
+        ],
+    ])->callAction('saveVariants')
+        ->assertHasNoErrors();
+
+    $created = ProductVariant::query()
+        ->where('product_id', $product->id)
+        ->where('sku', 'LARGE-BLUE')
+        ->first();
+
+    expect($created)->not->toBeNull()
+        ->and($created->tax_class_id)->toBe($variant->tax_class_id)
+        ->and($created->stock)->toBe(0)
+        ->and($created->basePrices->first()?->price->value)->toBe(1800);
+});

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Livewire\Livewire;
+use Lunar\Admin\Actions\Products\MapVariantsToProductOptions;
 use Lunar\Admin\Filament\Resources\ProductResource\Widgets\ProductOptionsWidget;
 use Lunar\Models\Currency;
 use Lunar\Models\Language;
@@ -10,7 +11,7 @@ use Lunar\Models\ProductVariant;
 uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
     ->group('resource.product.widgets');
 
-it('can save a new size and colour permutation that has no variant_id or copied_id', function () {
+it('can save newly filled size and colour permutations', function () {
     Language::factory()->create([
         'default' => true,
     ]);
@@ -32,39 +33,49 @@ it('can save a new size and colour permutation that has no variant_id or copied_
         'currency_id' => $currency->id,
     ]);
 
+    $mapped = collect(MapVariantsToProductOptions::map(
+        [
+            'Size' => [
+                'Small',
+                'Large',
+            ],
+            'Colour' => [
+                'Red',
+                'Blue',
+            ],
+        ],
+        [
+            [
+                'id' => $variant->id,
+                'sku' => 'SMALL-RED',
+                'price' => 15,
+                'stock' => 4,
+                'values' => [
+                    'Size' => 'Small',
+                    'Colour' => 'Red',
+                ],
+            ],
+        ],
+    ))->map(function (array $row) {
+        $row['sku'] = $row['sku'] ?: collect($row['values'])->join('-');
+        $row['values'] = [];
+
+        return $row;
+    })->all();
+
     $this->asStaff(admin: true);
 
     Livewire::test(ProductOptionsWidget::class, [
         'record' => $product->fresh(),
-    ])->set('variants', [
-        [
-            'key' => 'existing',
-            'variant_id' => $variant->id,
-            'copied_id' => null,
-            'sku' => 'SMALL-RED',
-            'price' => 15,
-            'stock' => 4,
-            'values' => [],
-        ],
-        [
-            'key' => 'new',
-            'variant_id' => null,
-            'copied_id' => null,
-            'sku' => 'LARGE-BLUE',
-            'price' => 18,
-            'stock' => 0,
-            'values' => [],
-        ],
-    ])->callAction('saveVariants')
+    ])->set('variants', $mapped)
+        ->callAction('saveVariants')
         ->assertHasNoErrors();
 
-    $created = ProductVariant::query()
+    $variants = ProductVariant::query()
         ->where('product_id', $product->id)
-        ->where('sku', 'LARGE-BLUE')
-        ->first();
+        ->get();
 
-    expect($created)->not->toBeNull()
-        ->and($created->tax_class_id)->toBe($variant->tax_class_id)
-        ->and($created->stock)->toBe(0)
-        ->and($created->basePrices->first()?->price->value)->toBe(1800);
+    expect($variants)->toHaveCount(4)
+        ->and($variants->pluck('tax_class_id')->unique()->all())->toBe([$variant->tax_class_id])
+        ->and($variants->pluck('sku'))->toContain('SMALL-RED');
 });

--- a/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
+++ b/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
@@ -183,12 +183,12 @@ it('keeps unmatched permutations without binding the first variant when fillMiss
     );
 
     expect($exact['sku'])->toBe('SMALL-RED')
-        ->and($exact['variant_id'])->toBe(10);
+        ->and($exact['variant_id'])->toBe(10)
+        ->and($exact['copied_id'])->toBeNull();
 
-    $unmatchedSkus = collect($result)
-        ->reject(fn (array $row) => $row['variant_id'] === 10)
-        ->pluck('sku')
-        ->all();
+    $unmatched = collect($result)
+        ->reject(fn (array $row) => $row['variant_id'] === 10);
 
-    expect($unmatchedSkus)->each->toBeNull();
+    expect($unmatched->pluck('sku')->all())->each->toBeNull();
+    expect($unmatched->pluck('copied_id')->unique()->all())->toBe([10]);
 });

--- a/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
+++ b/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
@@ -77,3 +77,118 @@ it('can map variants given three sets of option values', function () {
 
     expect($result)->toHaveCount(4);
 });
+
+it('does not assign the first variant sku to unmatched sparse permutations', function () {
+    $optionValues = [
+        'Size' => [
+            'XS',
+            'L',
+        ],
+        'Colour' => [
+            'Navy',
+            'White',
+        ],
+        'Length' => [
+            'Long',
+            'Short',
+        ],
+        'Fit' => [
+            'Slim',
+        ],
+    ];
+
+    $variants = [
+        [
+            'id' => 1,
+            'sku' => 'TEE-L-NAVY-SHORT',
+            'price' => 0,
+            'stock' => 0,
+            'values' => [
+                'Size' => 'L',
+                'Colour' => 'Navy',
+                'Length' => 'Short',
+                'Fit' => 'Slim',
+            ],
+        ],
+        [
+            'id' => 2,
+            'sku' => 'TEE-XS-WHITE-LONG',
+            'price' => 0,
+            'stock' => 0,
+            'values' => [
+                'Size' => 'XS',
+                'Colour' => 'White',
+                'Length' => 'Long',
+                'Fit' => 'Slim',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: false);
+
+    expect($result)->toHaveCount(2);
+
+    $mappedBySku = collect($result)->keyBy('sku');
+
+    expect($mappedBySku['TEE-L-NAVY-SHORT']['values'])->toBe([
+        'Size' => 'L',
+        'Colour' => 'Navy',
+        'Length' => 'Short',
+        'Fit' => 'Slim',
+    ])->and($mappedBySku['TEE-XS-WHITE-LONG']['values'])->toBe([
+        'Size' => 'XS',
+        'Colour' => 'White',
+        'Length' => 'Long',
+        'Fit' => 'Slim',
+    ]);
+
+    // First cartesian permutation is XS/Navy/Long — must not steal the first variant SKU.
+    expect(
+        collect($result)->contains(fn (array $row) => $row['sku'] === 'TEE-L-NAVY-SHORT'
+            && $row['values']['Size'] === 'XS')
+    )->toBeFalse();
+});
+
+it('keeps unmatched permutations without binding the first variant when fillMissing is enabled', function () {
+    $optionValues = [
+        'Size' => [
+            'Small',
+            'Large',
+        ],
+        'Colour' => [
+            'Red',
+            'Blue',
+        ],
+    ];
+
+    $variants = [
+        [
+            'id' => 10,
+            'sku' => 'SMALL-RED',
+            'price' => 1,
+            'stock' => 5,
+            'values' => [
+                'Size' => 'Small',
+                'Colour' => 'Red',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: true);
+
+    expect($result)->toHaveCount(4);
+
+    $exact = collect($result)->first(
+        fn (array $row) => $row['values'] === ['Size' => 'Small', 'Colour' => 'Red']
+    );
+
+    expect($exact['sku'])->toBe('SMALL-RED')
+        ->and($exact['variant_id'])->toBe(10);
+
+    $unmatchedSkus = collect($result)
+        ->reject(fn (array $row) => $row['variant_id'] === 10)
+        ->pluck('sku')
+        ->all();
+
+    expect($unmatchedSkus)->each->toBeNull();
+});


### PR DESCRIPTION
## Summary
Supersedes #2593.

Two related Hub variants bugs:

1. **Wrong SKU on unmatched permutations.** `collect()->search()` returns `false` when nothing matches, and PHP coerces `$variants[false]` to `$variants[0]`. Sparse Size/Colour matrices could show the first SKU under the wrong option labels. Unmatched rows are no longer bound to that first variant; with `fillMissing: false` they are skipped.

2. **New permutations fail to save.** After (1), a newly filled Size/Colour row has no `variant_id`. Hub then inserts a bare variant (`product_id`, `sku`, `stock` only). `tax_class_id` is NOT NULL with no default.

   - The mapper sets `copied_id` from an existing sibling so `saveVariants` can `replicate()` tax class and price.
   - If `copied_id` is missing on save (e.g. Livewire dropped it), `saveVariants` fills it from the first sibling and uses the same replicate path.

## Test plan
- [x] `vendor/bin/pest tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php`
- [x] `vendor/bin/pest tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php`
- [ ] In Hub, open a product with a sparse Size/Colour matrix and confirm option labels match each SKU.
- [ ] Add a new Size or Colour value, save variants, and confirm the new SKU is created with the same tax class.