### PR TITLE
fix(admin): don't adopt the first variant when no variant matches

### DIFF
--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -36,7 +36,11 @@ class MapVariantsToProductOptions
                 return $amountMatched == count($variant['values']);
             });
 
-            $variant = $variants[$variantIndex] ?? null;
+            // search() returns false when no variant matches. Since $variants is a
+            // list, $variants[false] would resolve to $variants[0] and silently adopt
+            // the first variant's id, sku, price and stock for a permutation that has
+            // no variant at all.
+            $variant = $variantIndex === false ? null : $variants[$variantIndex];
 
             $variantId = $variant['id'] ?? null;
             $sku = $variant['sku'] ?? null;

--- a/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
+++ b/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
@@ -78,3 +78,57 @@ it('can map variants given three sets of option values', function () {
 
     expect($result)->toHaveCount(4);
 });
+
+it('does not adopt the first variant for a permutation that matches nothing', function () {
+
+    $optionValues = [
+        'Colour' => [
+            'Red',
+            'Blue',
+        ],
+        'Size' => [
+            'Small',
+            'Large',
+        ],
+    ];
+
+    // A sparse product: only two of the four combinations actually exist.
+    $variants = [
+        [
+            'id' => 1,
+            'sku' => 'RED-SMALL',
+            'price' => 10,
+            'stock' => 1,
+            'values' => [
+                'Colour' => 'Red',
+                'Size' => 'Small',
+            ],
+        ],
+        [
+            'id' => 2,
+            'sku' => 'BLUE-LARGE',
+            'price' => 20,
+            'stock' => 2,
+            'values' => [
+                'Colour' => 'Blue',
+                'Size' => 'Large',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants);
+
+    expect($result)->toHaveCount(4);
+
+    $blueSmall = collect($result)->first(
+        fn ($row) => $row['values'] === ['Colour' => 'Blue', 'Size' => 'Small']
+    );
+
+    // "Blue/Small" matches neither variant, so it must not inherit the id, sku,
+    // price or stock of whichever variant happens to be first in the list.
+    expect($blueSmall['copied_id'])->toBeNull()
+        ->and($blueSmall['variant_id'])->toBeNull()
+        ->and($blueSmall['sku'])->toBeNull()
+        ->and($blueSmall['price'])->toBe(0)
+        ->and($blueSmall['stock'])->toBe(0);
+});


### PR DESCRIPTION
## What's wrong

When a permutation in the variant matrix has no matching variant, it silently takes over the first variant's `id`, `sku`, `price` and `stock`.

Here's the loop in `MapVariantsToProductOptions::map()` (`packages/admin/src/Actions/Products/MapVariantsToProductOptions.php:26-48`):

```php
foreach ($permutations as $permutation) {
    $variantIndex = collect($variants)->search(function ($variant) use ($permutation) {
        $valueDifference = array_diff_assoc($permutation, $variant['values']);

        if (! count($valueDifference)) {
            return $variant;
        }

        $amountMatched = count($permutation) - count($valueDifference);

        return $amountMatched == count($variant['values']);
    });

    $variant = $variants[$variantIndex] ?? null;   // <-- here

    $variantId = $variant['id'] ?? null;
    $sku = $variant['sku'] ?? null;
    $copiedFrom = null;
    $shouldFill = true;
```

`Collection::search()` returns `false` when the callback never matches. `$variants` is a list, so `$variants[false]` gets cast to `$variants[0]`, and the `?? null` never fires because key `0` genuinely exists.

Quick illustration of the cast:

```php
$variants = [['id' => 'FIRST'], ['id' => 'SECOND']];

$miss = collect($variants)->search(fn ($v) => false);
var_dump($miss);                    // bool(false)

var_dump($variants[$miss] ?? null); // ['id' => 'FIRST']  <-- not null
```

Worth noting it depends on the array keys. The same code against an array that doesn't start at 0 behaves differently:

```php
$assoc = [5 => ['id' => 'FIVE'], 9 => ['id' => 'NINE']];

var_dump($assoc[false] ?? null);    // NULL
```

So whether you get a wrong variant or a correct `null` comes down to how the array happens to be keyed. That's what convinced me this is a bug rather than an intentional "fall back to the first variant as a template" — you wouldn't design behaviour that flips based on key numbering.

## How I ran into it

I was debugging a product in our own admin whose variants page rendered an empty list, while the storefront showed the same product's variants fine. That turned out to be something else entirely on our side: the product had a third option attached that none of its variants carried a value for, and since `ProductOptionsWidget::query()` only eager-loads option values that are linked to one of the product's variants, that option came back with zero values.

An empty set then collapses the whole cartesian product in `Arr::permutate()` (`packages/core/src/Utils/Arr.php`), because the inner loop never runs:

```php
foreach ($a as $valueA) {
    if ($valueA) {
        foreach ($b as $valueB) {
            // never reached when $b is empty
        }
    }
}
```

Zero permutations means zero rows, and the real variants are never consulted. That part was our own data problem and I fixed it on our end.

But while reading through `MapVariantsToProductOptions` to understand that, I got stuck on the `$variants[$variantIndex] ?? null` line and wondered what actually happens when a permutation matches nothing.

Our product couldn't answer that, because its matrix is complete: 8 sizes × 1 variant value = 8 permutations, each matching exactly one variant. You need a *sparse* product — options fully populated, but not every combination existing as a variant. So I built one:

```php
$optionValues = [
    'Colour' => ['Red', 'Blue'],
    'Size'   => ['Small', 'Large'],
];

// Only two of the four combinations exist.
$variants = [
    ['id' => 1, 'sku' => 'RED-SMALL',  'price' => 10, 'stock' => 1,
     'values' => ['Colour' => 'Red',  'Size' => 'Small']],
    ['id' => 2, 'sku' => 'BLUE-LARGE', 'price' => 20, 'stock' => 2,
     'values' => ['Colour' => 'Blue', 'Size' => 'Large']],
];

MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: true);
```

First I checked the matcher predicate on its own, to see which permutations find nothing:

```
["Red","Small"]   -> hits: variant index 0
["Red","Large"]   -> hits: NONE
["Blue","Small"]  -> hits: NONE
["Blue","Large"]  -> hits: variant index 1
```

Two permutations match nothing, so both hit the `false` path. And this is what `map()` returns:

```
values=["Red","Small"]   variant_id=1     copied_id=NULL  sku='RED-SMALL'        price=10  stock=1
values=["Red","Large"]   variant_id=NULL  copied_id=1     sku='RED-SMALL-Large'  price=10  stock=1
values=["Blue","Small"]  variant_id=NULL  copied_id=1     sku='RED-SMALL-Blue'   price=10  stock=1
values=["Blue","Large"]  variant_id=2     copied_id=NULL  sku='BLUE-LARGE'       price=20  stock=2
```

`Blue/Small` matches neither variant, yet comes back with `copied_id=1` and `RED-SMALL`'s price and stock, because `$variants[false]` handed it variant 1. It then walks straight into the `$existing` branch (`:50-65`), which treats it as a duplicate of a variant it never matched:

```php
if ($variant) {
    // Does this variant already exist in our permutations?
    $existing = collect($variantPermutations)
        ->first(fn ($p) => $p['variant_id'] == $variant['id']);

    if ($existing) {
        $diff = array_diff_assoc($permutation, $variant['values']);
        $sku = $existing['sku'].'-'.implode('-', array_values($diff));
        $variantId = null;
        $copiedFrom = $variant['id'];
    }

    if ($existing && ! $fillMissing) {
        $shouldFill = false;
    }
}
```

That's where the fabricated `RED-SMALL-Blue` SKU comes from, and the price/stock get carried over by the array build at the end (`:67-77`):

```php
$variantPermutations[] = [
    'key' => Str::random(),
    'variant_id' => $variantId,
    'copied_id' => $copiedFrom,
    'sku' => $sku,
    'price' => $variant['price'] ?? 0,     // variant 1's price
    'stock' => $variant['stock'] ?? 0,     // variant 1's stock
    'values' => $permutation,
];
```

## Why it matters

`copied_id` isn't cosmetic. On save, `ProductOptionsWidget` replicates the referenced variant, base prices included (`packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php:404-414`):

```php
if (! empty($variantData['copied_id'])) {
    $copiedVariant = ProductVariant::find(
        $variantData['copied_id']
    );

    $variant = $copiedVariant->replicate();
    $variant->save();

    $basePrice = $copiedVariant->basePrices->first()->replicate();
    $basePrice->priceable_id = $variant->id;
}
```

So a combination that was never meant to exist gets created as a clone of whichever variant happens to sit first in the list, priced accordingly. In our catalogue variants of a single product run from about €518 to €729, so landing on the wrong one is a genuine pricing problem, not a display glitch.

Two things have kept this quiet so far:

1. It needs a sparse matrix. On a complete matrix every permutation matches, so `search()` never returns `false`.
2. It needs `fillMissing: true`. On initial page load `configureBaseOptions()` calls `mapVariantPermutations(fillMissing: false)`, and the `$existing && ! $fillMissing` check drops those rows before you see them. Configuring options is what surfaces it.

## The fix

Check for `false` explicitly rather than leaning on the index:

```php
// search() returns false when no variant matches. Since $variants is a
// list, $variants[false] would resolve to $variants[0] and silently adopt
// the first variant's id, sku, price and stock for a permutation that has
// no variant at all.
$variant = $variantIndex === false ? null : $variants[$variantIndex];
```

With that in place `$variant` is `null` for an unmatched permutation, so `$variantId`, `$sku` and `$copiedFrom` stay `null` and the `?? 0` fallbacks for price and stock do what they were clearly written to do.

## Tests

Added a test to `tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php` covering the sparse case:

```php
it('does not adopt the first variant for a permutation that matches nothing', function () {

    $optionValues = [
        'Colour' => ['Red', 'Blue'],
        'Size' => ['Small', 'Large'],
    ];

    // A sparse product: only two of the four combinations actually exist.
    $variants = [
        [
            'id' => 1,
            'sku' => 'RED-SMALL',
            'price' => 10,
            'stock' => 1,
            'values' => ['Colour' => 'Red', 'Size' => 'Small'],
        ],
        [
            'id' => 2,
            'sku' => 'BLUE-LARGE',
            'price' => 20,
            'stock' => 2,
            'values' => ['Colour' => 'Blue', 'Size' => 'Large'],
        ],
    ];

    $result = MapVariantsToProductOptions::map($optionValues, $variants);

    expect($result)->toHaveCount(4);

    $blueSmall = collect($result)->first(
        fn ($row) => $row['values'] === ['Colour' => 'Blue', 'Size' => 'Small']
    );

    // "Blue/Small" matches neither variant, so it must not inherit the id, sku,
    // price or stock of whichever variant happens to be first in the list.
    expect($blueSmall['copied_id'])->toBeNull()
        ->and($blueSmall['variant_id'])->toBeNull()
        ->and($blueSmall['sku'])->toBeNull()
        ->and($blueSmall['price'])->toBe(0)
        ->and($blueSmall['stock'])->toBe(0);
});
```

To be sure it's a real regression test and not something that passes either way, I ran those exact assertions against both the current implementation and the patched one:

```
=== UNPATCHED (current 1.x) ===
  count = 4
  Blue/Small -> variant_id=NULL copied_id=1 sku='RED-SMALL-Blue' price=10 stock=1
  TEST: FAIL

=== PATCHED (this PR) ===
  count = 4
  Blue/Small -> variant_id=NULL copied_id=NULL sku=NULL price=0 stock=0
  TEST: PASS
```

Note the count is 4 in both cases — the fix doesn't add or remove rows, it only stops an unmatched row from borrowing another variant's data.

The two existing tests in that file still produce the same results, so matching for products with a complete matrix is unchanged.
