### PR TITLE
fix(upgrade): reconcile v1 soft-deleted records onto v2 state

### DIFF
--- a/packages/upgrade/database/migrations/2026_06_01_000013_reconcile_dropped_soft_deletes.php
+++ b/packages/upgrade/database/migrations/2026_06_01_000013_reconcile_dropped_soft_deletes.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Core\Database\Migration;
+
+/**
+ * v1 → v2 upgrade data step: reconcile the models that dropped SoftDeletes.
+ *
+ * v2 removed the SoftDeletes trait from Product, ProductVariant, Channel and
+ * Collection (Cart and Staff keep it), replacing soft-deletion with explicit
+ * state: products and collections retire via `status` ('archived'), channels via
+ * `status` ('inactive'), variants via the `enabled` flag. The v2 create-table
+ * migrations no longer add `deleted_at`, so a fresh install has no such column on
+ * these tables.
+ *
+ * An upgraded v1 database still carries the v1 `deleted_at` column and every
+ * soft-deleted row. Nothing in v2 reads that column, so those records resurface as
+ * live / enabled catalogue entries after the upgrade (a v1 soft-deleted variant is
+ * `enabled = true` from 000012's backfill; a soft-deleted product keeps its old
+ * `published` status). Map each v1 soft-delete onto the v2 state, then drop the
+ * orphaned column so the upgraded schema matches a fresh install.
+ *
+ * Rows are kept, not deleted: historical order lines reference retired variants and
+ * must still resolve their purchasable. Guarded per table on the presence of
+ * `deleted_at`, so re-runs, already-v2 databases, and the SoftDeletes-keeping
+ * Cart/Staff tables are untouched. There is no `down()`: upgrade-package data
+ * migrations are one-way — recover from a backup rather than reversing a data move.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        // [table (unprefixed), v2 "hidden" column, value written for soft-deleted rows]
+        $reconcile = [
+            ['products', 'status', 'archived'],
+            ['product_variants', 'enabled', false],
+            ['collections', 'status', 'archived'],
+            ['channels', 'status', 'inactive'],
+        ];
+
+        foreach ($reconcile as [$name, $column, $hidden]) {
+            $table = $this->prefix . $name;
+
+            if (!Schema::hasTable($table) || !Schema::hasColumn($table, 'deleted_at')) {
+                continue;
+            }
+
+            if (Schema::hasColumn($table, $column)) {
+                DB::table($table)
+                    ->whereNotNull('deleted_at')
+                    ->update([$column => $hidden]);
+            }
+
+            Schema::table($table, function ($blueprint) {
+                $blueprint->dropColumn('deleted_at');
+            });
+        }
+    }
+};

--- a/tests/upgrade/Feature/ReconcileDroppedSoftDeletesTest.php
+++ b/tests/upgrade/Feature/ReconcileDroppedSoftDeletesTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Tests\Upgrade\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Isolated prefix so this stands up its own throwaway schema without touching the
+ * shared lunar_* tables.
+ */
+const SD_UPG_PREFIX = 'upgsd_';
+
+beforeEach(function () {
+    config(['lunar.database.table_prefix' => SD_UPG_PREFIX]);
+});
+
+afterEach(function () {
+    foreach (['products', 'product_variants', 'collections', 'channels'] as $table) {
+        Schema::dropIfExists(SD_UPG_PREFIX.$table);
+    }
+});
+
+function reconcileSoftDeletesMigration(): object
+{
+    $path = glob(dirname(__DIR__, 3).'/packages/upgrade/database/migrations/*reconcile_dropped_soft_deletes.php');
+
+    return require $path[0];
+}
+
+/**
+ * Stand up the four v1-shaped tables as they exist by this point in the upgrade:
+ * each still carries the v1 `deleted_at` column alongside its v2 "hidden" column —
+ * products/collections/channels a `status`, variants the `enabled` added by 000012.
+ */
+function simulateV1SoftDeletableTables(): void
+{
+    Schema::create(SD_UPG_PREFIX.'products', function (Blueprint $table) {
+        $table->id();
+        $table->string('status')->default('published');
+        $table->softDeletes();
+    });
+    Schema::create(SD_UPG_PREFIX.'product_variants', function (Blueprint $table) {
+        $table->id();
+        $table->boolean('enabled')->default(true);
+        $table->softDeletes();
+    });
+    Schema::create(SD_UPG_PREFIX.'collections', function (Blueprint $table) {
+        $table->id();
+        $table->string('status')->default('published');
+        $table->softDeletes();
+    });
+    Schema::create(SD_UPG_PREFIX.'channels', function (Blueprint $table) {
+        $table->id();
+        $table->string('status')->default('active');
+        $table->softDeletes();
+    });
+}
+
+test('it maps every v1 soft-deleted row onto the v2 hidden state and drops deleted_at', function () {
+    simulateV1SoftDeletableTables();
+
+    $deleted = '2024-01-01 00:00:00';
+
+    DB::table(SD_UPG_PREFIX.'products')->insert([
+        ['id' => 1, 'status' => 'published', 'deleted_at' => null],
+        ['id' => 2, 'status' => 'published', 'deleted_at' => $deleted],
+    ]);
+    DB::table(SD_UPG_PREFIX.'product_variants')->insert([
+        ['id' => 1, 'enabled' => true, 'deleted_at' => null],
+        ['id' => 2, 'enabled' => true, 'deleted_at' => $deleted],
+    ]);
+    DB::table(SD_UPG_PREFIX.'collections')->insert([
+        ['id' => 1, 'status' => 'published', 'deleted_at' => null],
+        ['id' => 2, 'status' => 'published', 'deleted_at' => $deleted],
+    ]);
+    DB::table(SD_UPG_PREFIX.'channels')->insert([
+        ['id' => 1, 'status' => 'active', 'deleted_at' => null],
+        ['id' => 2, 'status' => 'active', 'deleted_at' => $deleted],
+    ]);
+
+    reconcileSoftDeletesMigration()->up();
+
+    // The orphaned v1 column is gone everywhere, matching a fresh v2 install.
+    foreach (['products', 'product_variants', 'collections', 'channels'] as $table) {
+        expect(Schema::hasColumn(SD_UPG_PREFIX.$table, 'deleted_at'))->toBeFalse();
+    }
+
+    // Soft-deleted rows are hidden via the v2 mechanism; live rows are untouched.
+    expect(DB::table(SD_UPG_PREFIX.'products')->find(1)->status)->toBe('published')
+        ->and(DB::table(SD_UPG_PREFIX.'products')->find(2)->status)->toBe('archived')
+        ->and((bool) DB::table(SD_UPG_PREFIX.'product_variants')->find(1)->enabled)->toBeTrue()
+        ->and((bool) DB::table(SD_UPG_PREFIX.'product_variants')->find(2)->enabled)->toBeFalse()
+        ->and(DB::table(SD_UPG_PREFIX.'collections')->find(1)->status)->toBe('published')
+        ->and(DB::table(SD_UPG_PREFIX.'collections')->find(2)->status)->toBe('archived')
+        ->and(DB::table(SD_UPG_PREFIX.'channels')->find(1)->status)->toBe('active')
+        ->and(DB::table(SD_UPG_PREFIX.'channels')->find(2)->status)->toBe('inactive');
+});
+
+test('it is a no-op on a fresh v2 table that never had deleted_at', function () {
+    Schema::create(SD_UPG_PREFIX.'product_variants', function (Blueprint $table) {
+        $table->id();
+        $table->boolean('enabled')->default(true);
+    });
+    DB::table(SD_UPG_PREFIX.'product_variants')->insert(['id' => 1, 'enabled' => true]);
+
+    reconcileSoftDeletesMigration()->up();
+
+    expect((bool) DB::table(SD_UPG_PREFIX.'product_variants')->find(1)->enabled)->toBeTrue();
+});


### PR DESCRIPTION
### Summary

Fixes #2613 . Reconciles the models that dropped the `SoftDeletes` trait in v2 during `lunar:upgrade`.

v2 removed `SoftDeletes` from `Product`, `ProductVariant`, `Channel` and `Collection` (`Cart` and `Staff` keep it), replacing soft-deletion with explicit state. But the upgrade left the v1 `deleted_at` column and its rows untouched — and `000012_add_product_variant_enabled` marks every variant `enabled = true` — so records a merchant soft-deleted in v1 resurface as live / enabled catalogue entries after upgrading, and the upgraded schema keeps a `deleted_at` column that a fresh install does not have.

### Changes

- Adds `packages/upgrade/database/migrations/2026_06_01_000013_reconcile_dropped_soft_deletes.php`. For each dropped-`SoftDeletes` model it maps every `deleted_at IS NOT NULL` row onto the v2 hidden state, then drops the orphaned `deleted_at` column so the upgraded schema matches a fresh install:

  | Model | v2 hidden state |
  |---|---|
  | `product_variants` | `enabled = false` |
  | `products` | `status = 'archived'` |
  | `collections` | `status = 'archived'` |
  | `channels` | `status = 'inactive'` |

- Guarded per table on the presence of `deleted_at`, so re-runs, already-v2 databases, and the `SoftDeletes`-keeping `Cart` / `Staff` tables are untouched.
- Rows are **kept, not hard-deleted**: historical order lines reference retired variants and must still resolve their purchasable.
- One-way, like the other upgrade data steps (no `down()`). Runs after `000012` (which adds the `enabled` column), auto-discovered by `DataMigrationStep`.

### Tests

Adds `tests/upgrade/Feature/ReconcileDroppedSoftDeletesTest.php`: asserts every model maps its soft-deleted rows onto the v2 state while leaving live rows untouched and dropping `deleted_at`, plus a fresh-schema no-op case.
