### PR TITLE
fix(search): honour the model's Typesense search-parameters and quote facet filters by schema type

### DIFF
--- a/packages/search/src/Engines/TypesenseEngine.php
+++ b/packages/search/src/Engines/TypesenseEngine.php
@@ -234,11 +234,12 @@ class TypesenseEngine extends AbstractEngine
             $queryBy = $options['query_by'];
             $queryByWeights = $options['query_by_weights'] ?? null;
             $infix = $options['infix'] ?? null;
+            $prefix = $options['prefix'] ?? false;
 
             // Without a search term there is nothing to embed, so drop the
             // embedding field from query_by — together with its entries in the
-            // position-aligned weight/infix lists, otherwise Typesense rejects
-            // the whole request over the count mismatch.
+            // position-aligned weight/infix/prefix lists, otherwise Typesense
+            // rejects the whole request over the count mismatch.
             if (! $this->query) {
                 $fields = array_map('trim', explode(',', $queryBy));
                 $embeddingIndex = array_search('embedding', $fields, true);
@@ -248,6 +249,7 @@ class TypesenseEngine extends AbstractEngine
                     $queryBy = implode(',', $fields);
                     $queryByWeights = $this->stripListEntry($queryByWeights, $embeddingIndex);
                     $infix = $this->stripListEntry($infix, $embeddingIndex);
+                    $prefix = $this->stripListEntry($prefix, $embeddingIndex);
                 }
             }
 
@@ -257,8 +259,15 @@ class TypesenseEngine extends AbstractEngine
                 // Typesense requires q; '*' is its match-all for browse mode.
                 'q' => $searchQuery->query ?: '*',
                 'facet_query' => $facetQuery,
-                'prefix' => false,
-                'exclude_fields' => 'embedding',
+                'prefix' => $prefix,
+                // The embedding vector is never wanted in payloads; hosts can
+                // exclude further fields via search-parameters.
+                'exclude_fields' => collect(explode(',', (string) ($options['exclude_fields'] ?? '')))
+                    ->map(fn (string $field) => trim($field))
+                    ->filter()
+                    ->push('embedding')
+                    ->unique()
+                    ->join(','),
                 'max_facet_values' => $this->maxFacetValues,
                 'sort_by' => $this->sortRaw ?: ($this->sortByIsValid() ? $this->sort : '_text_match:desc'),
                 'facet_by' => implode(',', $searchQuery->facets),
@@ -274,9 +283,13 @@ class TypesenseEngine extends AbstractEngine
 
             // Hybrid semantic search only works when the collection schema
             // actually declares an auto-embed `embedding` field; requesting a
-            // vector query without one 404s the whole multi-search.
+            // vector query without one 404s the whole multi-search. Hosts can
+            // pin k/alpha with a `vector_query` search parameter; it only
+            // applies alongside a search term, so browse mode drops it.
             if ($this->query && $this->schemaHasEmbeddingField()) {
-                $params['vector_query'] = 'embedding:([], k: 200)';
+                $params['vector_query'] ??= 'embedding:([], k: 200)';
+            } else {
+                unset($params['vector_query']);
             }
 
             if ($filters->count()) {

--- a/packages/search/src/Engines/TypesenseEngine.php
+++ b/packages/search/src/Engines/TypesenseEngine.php
@@ -214,13 +214,11 @@ class TypesenseEngine extends AbstractEngine
             $facetQuery = $facetQuery->join(',');
 
             foreach ($searchQuery->facetFilters as $field => $values) {
-                $values = collect($values)->map(function ($value) {
-                    if ($value == 'false' || $value == 'true') {
-                        return $value;
-                    }
+                $fieldType = $this->getFieldType($field);
 
-                    return '`'.$value.'`';
-                });
+                $values = collect($values)->map(
+                    fn ($value) => $this->quoteFilterValue($value, $fieldType)
+                );
 
                 if ($values->count() > 1) {
                     $filters->push($field.':['.collect($values)->join(',').']');
@@ -342,6 +340,48 @@ class TypesenseEngine extends AbstractEngine
     {
         return collect($this->getFieldConfig())
             ->contains(fn (array $field): bool => ($field['name'] ?? null) === 'embedding');
+    }
+
+    /**
+     * Render a facet filter value for the filter_by grammar.
+     *
+     * Backticks escape a *string* literal, letting it carry spaces or commas.
+     * On a numeric field Typesense reads the backtick as a comparator and
+     * rejects the whole request ("Numerical field has an invalid comparator"),
+     * so quoting has to follow the field's schema type rather than the shape of
+     * the value — a string field whose values look numeric ('3M', '10') still
+     * needs the quotes to match exactly.
+     *
+     * A field the schema does not declare keeps the quoted form it has always
+     * had, so a host that configures its collection elsewhere cannot regress.
+     */
+    protected function quoteFilterValue(mixed $value, ?string $type): string
+    {
+        // Booleans have never been quoted — keep the literal strings working
+        // for hosts that pass them through from a request.
+        if (is_bool($value) || $value === 'true' || $value === 'false') {
+            return filter_var($value, FILTER_VALIDATE_BOOL) ? 'true' : 'false';
+        }
+
+        $baseType = str_replace('[]', '', (string) $type);
+
+        if (in_array($baseType, ['int32', 'int64', 'float'], true)) {
+            return (string) $value;
+        }
+
+        if ($baseType === 'bool') {
+            return filter_var($value, FILTER_VALIDATE_BOOL) ? 'true' : 'false';
+        }
+
+        return '`'.$value.'`';
+    }
+
+    protected function getFieldType(string $field): ?string
+    {
+        $config = collect($this->getFieldConfig())
+            ->first(fn (array $candidate): bool => ($candidate['name'] ?? null) === $field);
+
+        return $config['type'] ?? null;
     }
 
     protected function getFieldConfig(): array

--- a/packages/search/src/Engines/TypesenseEngine.php
+++ b/packages/search/src/Engines/TypesenseEngine.php
@@ -231,6 +231,15 @@ class TypesenseEngine extends AbstractEngine
                 $filters->push($field.':='.collect($values)->join(','));
             }
 
+            // Scout's buildSearchParameters() only forwards query_by and
+            // prefix from the model's search-parameters config; merge the
+            // full set so weights, infix, vector_query, exclude_fields and
+            // friends actually reach Typesense.
+            $options = [
+                ...$options,
+                ...config('scout.typesense.model-settings.'.$this->modelType.'.search-parameters', []),
+            ];
+
             $queryBy = $options['query_by'];
             $queryByWeights = $options['query_by_weights'] ?? null;
             $infix = $options['infix'] ?? null;

--- a/tests/search/Feature/Engines/TypesenseEngineTest.php
+++ b/tests/search/Feature/Engines/TypesenseEngineTest.php
@@ -379,3 +379,158 @@ it('strips a single entry from position-aligned parameter lists', function () {
         ->and($engine->exposedStripListEntry(['not', 'a', 'string'], 1))
         ->toBe(['not', 'a', 'string']);
 });
+
+it('merges the model search-parameters over the options scout supplies', function () {
+    Config::set('scout.typesense.model-settings.'.Product::class.'.search-parameters', [
+        'query_by_weights' => '10,5',
+        'infix' => 'always,off',
+        'prioritize_token_position' => 'true',
+        'num_typos' => '1',
+    ]);
+
+    // Scout only forwards query_by and prefix, so everything else arrives from
+    // the model settings or not at all.
+    $params = typesenseTestEngine()->query('shoes')->exposedBuildSearch([
+        'query_by' => 'name,description',
+        'filter_by' => [],
+    ])[0];
+
+    expect($params['query_by_weights'])
+        ->toBe('10,5')
+        ->and($params['infix'])
+        ->toBe('always,off')
+        ->and($params['prioritize_token_position'])
+        ->toBe('true')
+        ->and($params['num_typos'])
+        ->toBe('1');
+});
+
+it('takes prefix from the model search-parameters, defaulting to false', function () {
+    $options = ['query_by' => 'name,description', 'filter_by' => []];
+
+    expect(typesenseTestEngine()->exposedBuildSearch($options)[0]['prefix'])
+        ->toBeFalse();
+
+    Config::set(
+        'scout.typesense.model-settings.'.Product::class.'.search-parameters',
+        ['prefix' => 'true,false']
+    );
+
+    expect(typesenseTestEngine()->exposedBuildSearch($options)[0]['prefix'])
+        ->toBe('true,false');
+});
+
+it('unions the host exclude_fields with the embedding field', function () {
+    Config::set(
+        'scout.typesense.model-settings.'.Product::class.'.search-parameters',
+        ['exclude_fields' => 'notes, embedding, internal_ref']
+    );
+
+    $params = typesenseTestEngine()->exposedBuildSearch([
+        'query_by' => 'name',
+        'filter_by' => [],
+    ])[0];
+
+    expect($params['exclude_fields'])
+        ->toBe('notes,embedding,internal_ref');
+});
+
+it('strips the embedding entry from the prefix list when browsing', function () {
+    Config::set(
+        'scout.typesense.model-settings.'.Product::class.'.search-parameters',
+        ['prefix' => 'false,true,true']
+    );
+
+    // Without a term the embedding field leaves query_by, so every
+    // position-aligned list has to lose the same index or Typesense rejects
+    // the request over the count mismatch.
+    $params = typesenseTestEngine()->exposedBuildSearch([
+        'query_by' => 'embedding,name,description',
+        'filter_by' => [],
+    ])[0];
+
+    expect($params['query_by'])
+        ->toBe('name,description')
+        ->and($params['prefix'])
+        ->toBe('true,true');
+});
+
+it('leaves numeric facet filter values unquoted', function () {
+    Config::set('scout.typesense.model-settings.'.Product::class.'.collection-schema.fields', [
+        ['name' => 'collection_ids', 'type' => 'int64[]'],
+        ['name' => 'stock_level', 'type' => 'int32'],
+        ['name' => 'rating', 'type' => 'float'],
+    ]);
+
+    // Backticks escape a string literal; on a numeric field Typesense reads
+    // them as a comparator and rejects the whole request.
+    $filters = typesenseTestEngine()
+        ->setFacets([
+            'collection_ids' => [535, 533],
+            'stock_level' => [4],
+            'rating' => ['4.5'],
+        ])
+        ->exposedBuildSearch(['query_by' => 'name', 'filter_by' => []])[0]['filter_by'];
+
+    expect($filters)
+        ->toContain('collection_ids:[535,533]')
+        ->and($filters)
+        ->toContain('stock_level:=4')
+        ->and($filters)
+        ->toContain('rating:=4.5')
+        ->and($filters)
+        ->not->toContain('`');
+});
+
+it('quotes string facet filter values, including numeric-looking ones', function () {
+    Config::set('scout.typesense.model-settings.'.Product::class.'.collection-schema.fields', [
+        ['name' => 'brand', 'type' => 'string'],
+        ['name' => 'sizes', 'type' => 'string[]'],
+    ]);
+
+    $filters = typesenseTestEngine()
+        ->setFacets([
+            'brand' => ['3M'],
+            'sizes' => ['10', 'Extra Large'],
+        ])
+        ->exposedBuildSearch(['query_by' => 'name', 'filter_by' => []])[0]['filter_by'];
+
+    expect($filters)
+        ->toContain('brand:=`3M`')
+        ->and($filters)
+        ->toContain('sizes:[`10`,`Extra Large`]');
+});
+
+it('normalises bool facet filter values', function () {
+    Config::set('scout.typesense.model-settings.'.Product::class.'.collection-schema.fields', [
+        ['name' => 'oversized', 'type' => 'bool'],
+        ['name' => 'clearance', 'type' => 'bool'],
+    ]);
+
+    $filters = typesenseTestEngine()
+        ->setFacets([
+            'oversized' => [true],
+            'clearance' => ['false'],
+        ])
+        ->exposedBuildSearch(['query_by' => 'name', 'filter_by' => []])[0]['filter_by'];
+
+    expect($filters)
+        ->toContain('oversized:=true')
+        ->and($filters)
+        ->toContain('clearance:=false');
+});
+
+it('quotes facet filter values for fields the schema does not declare', function () {
+    Config::set('scout.typesense.model-settings.'.Product::class.'.collection-schema.fields', [
+        ['name' => 'name', 'type' => 'string'],
+    ]);
+
+    // An unmapped field keeps the quoted form it has always had, so a host
+    // whose schema lives outside this config cannot regress.
+    $filters = typesenseTestEngine()
+        ->setFacets(['colour' => ['Red']])
+        ->exposedBuildSearch(['query_by' => 'name', 'filter_by' => []])[0]['filter_by'];
+
+    expect($filters)
+        ->toContain('colour:=`Red`');
+});


### PR DESCRIPTION
Two related fixes to the Typesense engine's request building, both found while tuning search on a production catalogue.

## 1. The model's `search-parameters` were mostly discarded

`buildSearch()` built its request from Scout's `buildSearchParameters()`, which only forwards `query_by` and `prefix` from `scout.typesense.model-settings.*.search-parameters`. Everything else a host configures there — `query_by_weights`, `infix`, `vector_query`, `exclude_fields`, `num_typos`, `prioritize_*` — was dropped, and two values were hardcoded into the request: `'prefix' => false` and `'exclude_fields' => 'embedding'`.

`search-parameters` is the documented place for per-model Typesense tuning, so the config appeared to work while having no effect: field weights set there made no difference to ranking, infix matching never activated, and a pinned hybrid `alpha` was ignored.

The engine now merges the model's full `search-parameters` over the options Scout supplies, then derives:

- **`prefix`** from config, defaulting to `false` (the previous hardcoded value).
- **`exclude_fields`** as the union of the host's list with `embedding`, which is never wanted in a payload — so a host adding its own exclusions no longer loses the vector exclusion.

The empty-query path, which strips `embedding` out of the position-aligned `query_by` / `query_by_weights` / `infix` lists, now strips the matching `prefix` entry too. Without that, a host supplying a per-field prefix list hits a count mismatch and Typesense rejects the whole request.

Behaviour only changes for hosts that already have keys in `search-parameters` beyond `query_by`/`prefix` — those keys previously did nothing, so any change is the config finally being applied. With no `search-parameters` block the request is byte-identical to before.

## 2. Facet filtering on a numeric field failed the whole request

`buildSearch()` backticked every facet filter value except the literal strings `'true'` and `'false'`. Backticks escape a **string** literal, letting it carry spaces or commas; on an `int32`/`int64`/`float` field Typesense reads the backtick as a comparator and rejects the filter outright:

```
Error with filter field `collection_ids`: Numerical field has an invalid comparator.
```

Verified against a live collection (`collection_ids` is `int64[]`, `price` is `int64`):

| `filter_by` | Result |
| --- | --- |
| `collection_ids:=535` | found=16 |
| ``collection_ids:=`535` `` | error above |
| ``collection_ids:[`535`,`533`]`` | error above |
| `collection_ids:[535,533]` | found=20 |
| `price:=3825` | found=7 |
| ``price:=`3825` `` | error above |

So only string facets have ever worked through this path. Numeric filtering has been reachable only via the raw `filter()` / `addFilter()` seam, which builds its own unquoted syntax — the workaround, not the intended API.

Quoting now follows the field's declared type in the collection schema the engine already reads for `schemaHasEmbeddingField()`:

- `string` / `string[]` / `auto` → backticked, as today
- `int32` / `int64` / `float` and their `[]` variants → emitted raw
- `bool` / `bool[]` → normalised to `true` / `false`, covering real PHP booleans as well as the string forms the old special case handled
- **field not declared in the schema** → backticked, so a host that configures its collection outside this config cannot regress

Deciding from the value rather than the schema would be wrong: a string field with values like `3M` or `10` still needs its quotes to match exactly.

## Out of scope

The raw `filter()` path builds `$key.':'.$value` — `:` rather than `:=`, which on a string field is a loose token match rather than an exact one. That looks wrong too, but it is the seam people have been using to work around the bug above, so changing it is a behaviour break that deserves its own PR.

## Tests

`tests/search/Feature/Engines/TypesenseEngineTest.php`, all through the existing `exposedBuildSearch()` harness:

- the model `search-parameters` merge reaching the request (`query_by_weights`, `infix`, `prioritize_token_position`, `num_typos`)
- `prefix` taken from config, defaulting to `false`
- `exclude_fields` unioned with `embedding`, deduplicated
- the `embedding` entry stripped from the `prefix` list in browse mode
- numeric facet filters emitted unquoted, single (`stock_level:=4`) and multi (`collection_ids:[535,533]`)
- string facet filters still quoted, including numeric-looking values (`brand:=` + backticked `3M`)
- bool facet filters normalised from both PHP `true` and the string `'false'`
- a field absent from the schema still quoted

`vendor/bin/pest --testsuite search` — 28 passed. Pint clean. PHPStan clean for the touched packages (the only findings in my run are pre-existing `BaconQrCode` class-not-found errors in `panel`, from an optional dependency missing in my local vendor).
