### PR TITLE
Import Route class

### DIFF
--- a/packages/opayo/routes/web.php
+++ b/packages/opayo/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 Route::get('opayo-threedsecure', function () {
     return view('lunar::opayo.threed-secure-iframe');

--- a/packages/paypal/routes/web.php
+++ b/packages/paypal/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
 use Lunar\Paypal\Http\Controllers\GetPaypalOrderController;
 
 Route::group([


### PR DESCRIPTION
Fixes an issue with PHPStan on Laravel 13 by importing the Route class used in the route files.