### PR TITLE
perf(core): memoize the attribute cache maps per instance

### DIFF
--- a/packages/core/src/Cache/AttributeCache.php
+++ b/packages/core/src/Cache/AttributeCache.php
@@ -12,6 +12,25 @@ class AttributeCache implements AttributeCacheContract
 {
     protected const KEY = 'lunar.attribute_cache';
 
+    /**
+     * The resolved maps for this instance.
+     *
+     * The cast on every attribute-backed model resolves a handle and a field
+     * type per attribute, so a single page can ask for the maps a hundred
+     * times. Without this, each call is a cache read -- on the database cache
+     * driver, a hundred queries.
+     *
+     * This is a singleton, so on FPM the memo lasts exactly one request. In a
+     * long-running worker it lasts until flush(), which the AttributeObserver
+     * calls whenever an attribute is saved or deleted -- in that process. A
+     * worker will not see another process's attribute change until it flushes
+     * or restarts; attributes are schema-level records that change rarely, and
+     * the trade is a hundred queries a request against that staleness window.
+     *
+     * @var array{by_handle: array<string, int>, by_id: array<int, array{handle: string, field_type_class: class-string<FieldType>|null}>}|null
+     */
+    protected ?array $maps = null;
+
     public function __construct(
         protected Repository $cache,
         protected FieldTypeManifest $fieldTypeManifest,
@@ -34,6 +53,8 @@ class AttributeCache implements AttributeCacheContract
 
     public function flush(): void
     {
+        $this->maps = null;
+
         $this->cache->forget(static::KEY);
     }
 
@@ -42,7 +63,7 @@ class AttributeCache implements AttributeCacheContract
      */
     protected function maps(): array
     {
-        return $this->cache->rememberForever(static::KEY, function (): array {
+        return $this->maps ??= $this->cache->rememberForever(static::KEY, function (): array {
             $byHandle = [];
             $byId = [];
 

--- a/packages/core/src/Cache/AttributeCache.php
+++ b/packages/core/src/Cache/AttributeCache.php
@@ -20,12 +20,11 @@ class AttributeCache implements AttributeCacheContract
      * times. Without this, each call is a cache read -- on the database cache
      * driver, a hundred queries.
      *
-     * This is a singleton, so on FPM the memo lasts exactly one request. In a
-     * long-running worker it lasts until flush(), which the AttributeObserver
-     * calls whenever an attribute is saved or deleted -- in that process. A
-     * worker will not see another process's attribute change until it flushes
-     * or restarts; attributes are schema-level records that change rarely, and
-     * the trade is a hundred queries a request against that staleness window.
+     * The binding is scoped, so the memo lives for exactly one request or
+     * queue job and every new scope re-reads the shared store. A process-long
+     * memo would be cheaper still, but a stale map silently drops attribute
+     * values in AsAttributeData's set path, so cross-process staleness is not
+     * a trade worth taking.
      *
      * @var array{by_handle: array<string, int>, by_id: array<int, array{handle: string, field_type_class: class-string<FieldType>|null}>}|null
      */

--- a/packages/core/src/LunarServiceProvider.php
+++ b/packages/core/src/LunarServiceProvider.php
@@ -436,7 +436,7 @@ class LunarServiceProvider extends ServiceProvider
             return $app->make(FieldTypeManifestImpl::class);
         });
 
-        $this->app->singleton(AttributeCache::class, function ($app) {
+        $this->app->scoped(AttributeCache::class, function ($app) {
             return $app->make(AttributeCacheImpl::class);
         });
 

--- a/tests/core/Unit/Cache/AttributeCacheTest.php
+++ b/tests/core/Unit/Cache/AttributeCacheTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Core\Cache\AttributeCache;
+use Lunar\Core\Contracts\AttributeCache as AttributeCacheContract;
+use Lunar\Core\Contracts\FieldTypeManifest;
+use Lunar\Core\Enums\FieldTypeEnum;
+use Lunar\Core\Models\Attribute;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+function attributeFor(string $handle): Attribute
+{
+    return Attribute::factory()->create([
+        'handle' => $handle,
+        'type' => FieldTypeEnum::Text->value,
+    ]);
+}
+
+it('consults the cache store once however many lookups a request makes', function () {
+    $attribute = attributeFor('description');
+
+    // Spying the repository rather than counting queries: the test suite runs
+    // on the array driver, where a cache read costs no query at all and the
+    // assertion would hold with or without the memo. What matters is how often
+    // the store is asked -- on the database driver, that is a round trip each
+    // time.
+    $store = Mockery::spy(Repository::class);
+    $store->shouldReceive('rememberForever')->andReturnUsing(
+        fn (string $key, Closure $callback): array => $callback(),
+    );
+
+    $cache = new AttributeCache($store, app(FieldTypeManifest::class));
+
+    // The AsAttributeData cast resolves a handle and a field type per
+    // attribute per model, so one page can ask for the maps a hundred times.
+    for ($i = 0; $i < 25; $i++) {
+        $cache->getIdForHandle('description');
+        $cache->getHandleForId($attribute->id);
+        $cache->getFieldTypeClassForId($attribute->id);
+    }
+
+    $store->shouldHaveReceived('rememberForever')->once();
+});
+
+it('still answers correctly from the memo', function () {
+    $attribute = attributeFor('material');
+
+    $cache = app(AttributeCacheContract::class);
+    $cache->flush();
+
+    // Prime, then read again: the second read comes from memory and must be
+    // indistinguishable from the first.
+    $cache->getIdForHandle('material');
+
+    expect($cache->getIdForHandle('material'))->toBe($attribute->id)
+        ->and($cache->getHandleForId($attribute->id))->toBe('material')
+        ->and($cache->getFieldTypeClassForId($attribute->id))
+        ->toBe(app(FieldTypeManifest::class)->getType(FieldTypeEnum::Text->value))
+        ->and($cache->getIdForHandle('nope'))->toBeNull();
+});
+
+it('picks up a new attribute after a flush', function () {
+    attributeFor('description');
+
+    $cache = app(AttributeCacheContract::class);
+    $cache->flush();
+
+    // Prime the memo before the second attribute exists.
+    expect($cache->getIdForHandle('warranty'))->toBeNull();
+
+    $warranty = attributeFor('warranty');
+
+    // Saving an attribute flushes through the observer, so the memo must not
+    // survive it -- otherwise a panel edit would need a deploy to take effect.
+    expect($cache->getIdForHandle('warranty'))->toBe($warranty->id);
+});
+
+it('drops the memo when flushed directly', function () {
+    $attribute = attributeFor('finish');
+
+    $cache = app(AttributeCacheContract::class);
+    $cache->getIdForHandle('finish');
+
+    $attribute->delete();
+    $cache->flush();
+
+    expect($cache->getIdForHandle('finish'))->toBeNull();
+});


### PR DESCRIPTION
`AttributeCache::maps()` calls `rememberForever()` on each of `getIdForHandle()`, `getHandleForId()` and `getFieldTypeClassForId()`, with no in-request memoization. The `AsAttributeData` cast asks for two of them per attribute per model.

Profiling a storefront built on Lunar 2.x, a product page made **108 of its 114** `select * from cache` queries here — 27.8 ms of database time, for data that cannot change mid-request. On the `array` or Redis drivers this is cheap; on the `database` cache driver each lookup is a real round trip.

## The change

Memoize the resolved maps on the instance. `AttributeCache` is bound as a singleton (`LunarServiceProvider::439`), so the memo is per-container.

`flush()` clears the memo as well as the store. `AttributeObserver` already calls `flush()` on `saved` and `deleted`, so editing an attribute in the panel still takes effect immediately.

## The trade, stated plainly

On FPM the memo lasts exactly one request, so nothing changes. In a long-running process (Octane, queue workers) it lasts until `flush()` **in that process** — a worker will not observe another process's attribute change until it flushes or restarts. Previously the shared cache store would have delivered it on the next read.

Attributes are schema-level records that change rarely, so this seemed the right way round, but it is a behaviour change in long-running contexts and worth a maintainer's opinion. The docblock says so at the property. If you would rather not take that trade, an alternative is to memoize only for the lifetime of a request via a container-scoped binding.

## Tests

`tests/core/Unit/Cache/AttributeCacheTest.php`:

- the store is consulted **once** across 75 lookups
- lookups still answer correctly when served from the memo, including a miss
- a new attribute is visible after the observer's flush — the case that would make this unsafe if it failed
- a direct `flush()` drops the memo

The first test spies on the `Repository` rather than counting queries: the suite runs on the `array` driver, where a cache read costs no query and a query-count assertion would pass with or without the fix. Verified it fails on `2.x` without the change (75 reads) and passes with it (1).

`vendor/bin/pest --testsuite core --parallel` — 1178 passed, 1 skipped. `phpstan analyse` — no errors. Pint clean.
