### PR TITLE
fix(admin): keep record-url resolvers out of config as closures

### DIFF
--- a/packages/admin/src/LunarPanelProvider.php
+++ b/packages/admin/src/LunarPanelProvider.php
@@ -98,16 +98,18 @@ class LunarPanelProvider extends ServiceProvider
      */
     protected function registerBridgeRecordUrls(): void
     {
-        $this->app['config']->set('lunar.filament.record_urls.order',
-            fn ($record, array $context = []) => ManageOrder::getUrl([...$context, 'record' => $record]),
-        );
+        // Class strings rather than closures: these are written into config,
+        // and a closure anywhere in the tree makes the whole application's
+        // config non-serializable, so `php artisan config:cache` fails for
+        // every consumer of the admin shell.
+        $this->app['config']->set('lunar.filament.record_urls.order', ManageOrder::class);
 
         $this->app['config']->set('lunar.filament.record_urls.product_variant',
-            fn ($record, array $context = []) => ProductVariantResource::getUrl('edit', [...$context, 'record' => $record]),
+            [ProductVariantResource::class, 'edit'],
         );
 
         $this->app['config']->set('lunar.filament.record_urls.collection_edit',
-            fn ($record, array $context = []) => CollectionResource::getUrl('edit', [...$context, 'record' => $record]),
+            [CollectionResource::class, 'edit'],
         );
     }
 

--- a/packages/filament/README.md
+++ b/packages/filament/README.md
@@ -411,16 +411,17 @@ return $panel->widgets([
 
 Also available: `Lunar\Filament\Widgets\Customer\CustomerStatsOverviewWidget`, `Lunar\Filament\Widgets\Collections\CollectionTreeView`, `Lunar\Filament\Widgets\Products\ProductOptionsWidget`, `Lunar\Filament\Widgets\Products\VariantSwitcherTable`.
 
-Widgets that link to Lunar records (e.g. "click an order in this table") use a record-URL resolver. Wire it up to your own resources in your panel provider:
+Widgets and tables that link to Lunar records (e.g. "click an order in this table") resolve the target page through `lunar.filament.record_urls.{key}`. Point each key at your own panel's pages in `config/lunar/filament.php`:
 
 ```php
-use Lunar\Filament\Support\Facades\RecordUrls;
-
-RecordUrls::resolveUsing('order', fn ($order) => MyOrderResource::getUrl('view', ['record' => $order]));
-RecordUrls::resolveUsing('product_variant', fn ($variant) => MyProductResource::getUrl('edit', ['record' => $variant->product]));
+'record_urls' => [
+    'order' => ManageOrder::class,                            // ManageOrder::getUrl(['record' => $record])
+    'product_variant' => [MyProductResource::class, 'edit'],  // MyProductResource::getUrl('edit', ['record' => $record])
+    'collection_edit' => null,                                // omit the link
+],
 ```
 
-When no resolver is registered, the widget gracefully omits the link.
+Prefer the class-string forms: config has to survive `php artisan config:cache`, and a closure anywhere in the tree makes the whole application's config non-serializable. A callable — invoked as `$resolver($record, $context)` — is still accepted for a resolver that genuinely can't be expressed as a class and a page name, at the cost of config caching. When a key is `null` or unset, the component gracefully omits the link. The `lunarphp/admin` shell wires all three keys to its own pages at boot.
 
 ---
 

--- a/packages/filament/config/filament.php
+++ b/packages/filament/config/filament.php
@@ -49,15 +49,19 @@ return [
     |--------------------------------------------------------------------------
     |
     | Bridge tables and widgets link to per-record management pages owned by
-    | whichever panel is consuming them. Each entry is a Filament resource or
-    | page class string. The bridge calls `{class}::getUrl(['record' => $record])`
-    | when present; an empty string disables the link. The `lunarphp/admin`
-    | shell overrides these defaults at boot.
+    | whichever panel is consuming them. Each entry is a Filament page class
+    | string, called as `{class}::getUrl(['record' => $record])`, or a
+    | `[Resource::class, 'page']` pair, called as
+    | `{resource}::getUrl('page', ['record' => $record])`. A callable receiving
+    | ($record, $context) is also accepted, but closures do not survive
+    | `config:cache`. Null disables the link. The `lunarphp/admin` shell
+    | overrides these defaults at boot.
     |
     */
     'record_urls' => [
         'order' => null,
         'product_variant' => null,
+        'collection_edit' => null,
     ],
 
     /*

--- a/packages/filament/src/Support/RecordUrls.php
+++ b/packages/filament/src/Support/RecordUrls.php
@@ -7,20 +7,49 @@ namespace Lunar\Filament\Support;
  *
  * Bridge components link out to per-record pages that live in the consuming
  * panel — `lunarphp/admin` by default, or any Filament panel the consumer
- * builds. Each key under `lunar.filament.record_urls.{key}` is a closure
- * receiving the record and returning a URL, or null when the bridge should
- * skip the link.
+ * builds. Each key under `lunar.filament.record_urls.{key}` says how to reach
+ * that page:
+ *
+ *   null                        the bridge skips the link
+ *   Page::class                 Page::getUrl([...$context, 'record' => $record])
+ *   [Resource::class, 'edit']   Resource::getUrl('edit', [...$context, 'record' => $record])
+ *   callable                    $resolver($record, $context)
+ *
+ * The class-string forms are the ones to reach for: config has to survive
+ * `config:cache`, and a closure anywhere in the tree makes the whole of the
+ * application's config non-serializable, not just this key. The callable form
+ * stays supported for consumers already passing one, and for the rare resolver
+ * that genuinely cannot be expressed as a class and a page name.
  */
 class RecordUrls
 {
+    /**
+     * @param  array<string, mixed>  $context
+     */
     public static function for(string $key, mixed $record, array $context = []): ?string
     {
         $resolver = config('lunar.filament.record_urls.'.$key);
 
-        if (! is_callable($resolver)) {
-            return null;
+        $parameters = [...$context, 'record' => $record];
+
+        if (is_string($resolver) && method_exists($resolver, 'getUrl')) {
+            return $resolver::getUrl($parameters);
         }
 
-        return $resolver($record, $context);
+        // Checked before is_callable: [Resource::class, 'edit'] would satisfy
+        // is_callable if the resource happened to expose a static edit().
+        if (is_array($resolver) && count($resolver) === 2) {
+            [$class, $page] = $resolver;
+
+            if (is_string($class) && is_string($page) && method_exists($class, 'getUrl')) {
+                return $class::getUrl($page, $parameters);
+            }
+        }
+
+        if (is_callable($resolver)) {
+            return $resolver($record, $context);
+        }
+
+        return null;
     }
 }

--- a/packages/filament/src/Support/RecordUrls.php
+++ b/packages/filament/src/Support/RecordUrls.php
@@ -38,7 +38,7 @@ class RecordUrls
 
         // Checked before is_callable: [Resource::class, 'edit'] would satisfy
         // is_callable if the resource happened to expose a static edit().
-        if (is_array($resolver) && count($resolver) === 2) {
+        if (is_array($resolver) && array_is_list($resolver) && count($resolver) === 2) {
             [$class, $page] = $resolver;
 
             if (is_string($class) && is_string($page) && method_exists($class, 'getUrl')) {

--- a/tests/filament/Unit/Support/RecordUrlsTest.php
+++ b/tests/filament/Unit/Support/RecordUrlsTest.php
@@ -43,6 +43,10 @@ it('keeps working when the configured value is nonsense', function () {
 
     expect(RecordUrls::for('order', (object) ['id' => 1]))->toBeNull();
 
+    config()->set('lunar.filament.record_urls.order', ['class' => FakeRecordResource::class, 'page' => 'edit']);
+
+    expect(RecordUrls::for('order', (object) ['id' => 1]))->toBeNull();
+
     config()->set('lunar.filament.record_urls.order', 'Not\\A\\Real\\Class');
 
     expect(RecordUrls::for('order', (object) ['id' => 1]))->toBeNull();

--- a/tests/filament/Unit/Support/RecordUrlsTest.php
+++ b/tests/filament/Unit/Support/RecordUrlsTest.php
@@ -23,3 +23,74 @@ it('invokes the configured callable resolver', function () {
 it('returns null for unknown record keys', function () {
     expect(RecordUrls::for('not_a_real_key', (object) ['id' => 1]))->toBeNull();
 });
+
+it('resolves a page class string', function () {
+    config()->set('lunar.filament.record_urls.order', FakeRecordPage::class);
+
+    expect(RecordUrls::for('order', (object) ['id' => 7], ['tenant' => 'uk']))
+        ->toBe('page:{"tenant":"uk","record":7}');
+});
+
+it('resolves a resource class string with a page name', function () {
+    config()->set('lunar.filament.record_urls.product_variant', [FakeRecordResource::class, 'edit']);
+
+    expect(RecordUrls::for('product_variant', (object) ['id' => 9]))
+        ->toBe('resource:edit:{"record":9}');
+});
+
+it('keeps working when the configured value is nonsense', function () {
+    config()->set('lunar.filament.record_urls.order', ['not', 'a', 'pair']);
+
+    expect(RecordUrls::for('order', (object) ['id' => 1]))->toBeNull();
+
+    config()->set('lunar.filament.record_urls.order', 'Not\\A\\Real\\Class');
+
+    expect(RecordUrls::for('order', (object) ['id' => 1]))->toBeNull();
+});
+
+it('serialises to config that survives config:cache', function () {
+    // The whole point: var_export is what config:cache uses, and it throws on
+    // a closure anywhere in the tree.
+    config()->set('lunar.filament.record_urls', [
+        'order' => FakeRecordPage::class,
+        'product_variant' => [FakeRecordResource::class, 'edit'],
+        'collection_edit' => null,
+    ]);
+
+    expect(fn () => var_export(config('lunar.filament.record_urls'), true))
+        ->not->toThrow(Throwable::class);
+});
+
+class FakeRecordPage
+{
+    /**
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function getUrl(array $parameters = []): string
+    {
+        return 'page:'.json_encode(recordUrlIds($parameters));
+    }
+}
+
+class FakeRecordResource
+{
+    /**
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function getUrl(string $name = 'index', array $parameters = []): string
+    {
+        return 'resource:'.$name.':'.json_encode(recordUrlIds($parameters));
+    }
+}
+
+/**
+ * @param  array<string, mixed>  $parameters
+ * @return array<string, mixed>
+ */
+function recordUrlIds(array $parameters): array
+{
+    return array_map(
+        fn (mixed $value): mixed => is_object($value) ? $value->id : $value,
+        $parameters,
+    );
+}


### PR DESCRIPTION
Any application running the admin shell cannot cache its config:

```
$ php artisan config:cache
Your configuration files could not be serialized because the value at
"lunar.filament.record_urls.order" is non-serializable.
```

`LunarPanelProvider::registerBridgeRecordUrls()` writes three closures into config at boot. A single closure anywhere in the tree makes the **entire** application config unserializable, so this disables config caching for the whole app, not just for Lunar's keys — and any deploy script running `config:cache` fails outright.

## The contract was already documented

`packages/filament/config/filament.php` describes the intended design:

> Each entry is a Filament resource or page class string. The bridge calls `{class}::getUrl(['record' => $record])` when present; an empty string disables the link.

But `RecordUrls::for()` only ever handled callables, and the admin provider only ever set closures. This makes the implementation match the documented contract.

## What `RecordUrls::for()` now accepts

| Config value | Behaviour |
| --- | --- |
| `null` | bridge skips the link |
| `Page::class` | `Page::getUrl([...$context, 'record' => $record])` |
| `[Resource::class, 'edit']` | `Resource::getUrl('edit', [...$context, 'record' => $record])` |
| `callable` | `$resolver($record, $context)` — unchanged |

The array form is matched **before** `is_callable`, because `[Resource::class, 'edit']` would satisfy `is_callable` if the resource happened to expose a static `edit()`.

Callable support is retained, so this is additive: any consumer already configuring their own closure keeps working, and only the shipped defaults change shape. Malformed values fall through to `null` rather than fataling.

## Tests

`tests/filament/Unit/Support/RecordUrlsTest.php` keeps its three existing cases (including the callable one) and adds four: page class string with context, resource class plus page name, malformed values returning null, and a `var_export` check — that being what `config:cache` uses, and what throws on a closure.

Suites run: `filament` 49 passed, `admin` 235 passed, `panel` 739 passed, `core` 1174 passed / 1 skipped. `phpstan analyse` no errors. Pint clean.

## Verified end to end

On a Lunar 2.x storefront that previously failed, `php artisan config:cache` completes and the panel's order, variant and collection links still resolve.
