### PR TITLE
Scope the memoised discount set to the cart it was built for

### DIFF
--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -257,7 +257,7 @@ class DiscountManager implements DiscountManagerInterface
             $cart->id,
             $cart->coupon_code ?? '',
             $cart->customer_id ?? '',
-            $cart->lines->pluck('purchasable_id')->sort()->implode(','),
+            $cart->lines->map(fn ($line) => $line->purchasable_type.':'.$line->purchasable_id)->sort()->implode(','),
         ]);
     }
 

--- a/packages/core/src/Managers/DiscountManager.php
+++ b/packages/core/src/Managers/DiscountManager.php
@@ -38,6 +38,11 @@ class DiscountManager implements DiscountManagerInterface
     protected ?Collection $discounts = null;
 
     /**
+     * Identifies the cart state $discounts was built from.
+     */
+    protected ?string $discountsKey = null;
+
+    /**
      * The available discount types
      *
      * @var array
@@ -218,8 +223,11 @@ class DiscountManager implements DiscountManagerInterface
 
     public function apply(CartContract $cart): CartContract
     {
-        if (! $this->discounts || $this->discounts?->isEmpty()) {
+        $key = $this->getDiscountsCacheKey($cart);
+
+        if ($this->discounts === null || $this->discountsKey !== $key) {
             $this->discounts = $this->getDiscounts($cart);
+            $this->discountsKey = $key;
         }
 
         foreach ($this->discounts as $discount) {
@@ -237,9 +245,26 @@ class DiscountManager implements DiscountManagerInterface
         return $cart;
     }
 
+    /**
+     * Build the cache key for the memoised discounts.
+     *
+     * getDiscounts() filters on the cart's coupon code and on the purchasables
+     * in its lines, so a set built for one cart state is not valid for another.
+     */
+    protected function getDiscountsCacheKey(CartContract $cart): string
+    {
+        return implode('|', [
+            $cart->id,
+            $cart->coupon_code ?? '',
+            $cart->customer_id ?? '',
+            $cart->lines->pluck('purchasable_id')->sort()->implode(','),
+        ]);
+    }
+
     public function resetDiscounts(): self
     {
         $this->discounts = null;
+        $this->discountsKey = null;
 
         return $this;
     }

--- a/tests/core/Unit/Managers/DiscountManagerMemoisationTest.php
+++ b/tests/core/Unit/Managers/DiscountManagerMemoisationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\DiscountTypes\AmountOff;
+use Lunar\Facades\Discounts;
+use Lunar\Models\Cart;
+use Lunar\Models\Channel;
+use Lunar\Models\Currency;
+use Lunar\Models\CustomerGroup;
+use Lunar\Models\Discount;
+use Lunar\Models\Price;
+use Lunar\Models\ProductVariant;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+/**
+ * `DiscountManager::apply()` memoises the applicable-discount set on the first
+ * call of a request. `getDiscounts()` filters on the cart's `coupon_code`, so a
+ * set built while the cart had no coupon cannot contain a coupon discount — and
+ * a coupon applied afterwards has no effect.
+ *
+ * `can get discount with coupon` in DiscountManagerTest does not cover this: it
+ * calls `Discounts::getDiscounts()` directly, which bypasses `apply()` and
+ * therefore the memoisation. These go through the cart pipeline instead.
+ */
+function discountMemoFixture(): Cart
+{
+    $currency = Currency::factory()->create([
+        'code' => 'GBP',
+        'default' => true,
+    ]);
+
+    $customerGroup = CustomerGroup::factory()->create(['default' => true]);
+    $channel = Channel::factory()->create(['default' => true]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 1000,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    $attach = function (Discount $discount) use ($channel, $customerGroup) {
+        $discount->channels()->attach([
+            $channel->id => ['enabled' => true, 'starts_at' => now()->subDay()],
+        ]);
+
+        $discount->customerGroups()->attach([
+            $customerGroup->id => ['enabled' => true, 'starts_at' => now()->subDay()],
+        ]);
+    };
+
+    // An always-on discount is required to reproduce this: apply() re-queries
+    // whenever the memoised set is empty, so the staleness only shows once the
+    // first calculation already found something.
+    $attach(Discount::factory()->create([
+        'type' => AmountOff::class,
+        'name' => 'Always on',
+        'coupon' => null,
+        'starts_at' => now()->subDay(),
+        'data' => ['fixed_value' => true, 'fixed_values' => ['GBP' => 1]],
+    ]));
+
+    $attach(Discount::factory()->create([
+        'type' => AmountOff::class,
+        'name' => 'Coupon discount',
+        'coupon' => 'SAVE',
+        'starts_at' => now()->subDay(),
+        'data' => ['fixed_value' => true, 'fixed_values' => ['GBP' => 5]],
+    ]));
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+        'channel_id' => $channel->id,
+        'coupon_code' => null,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 2,
+    ]);
+
+    return $cart->refresh();
+}
+
+test('a coupon applied after the cart has been calculated is applied', function () {
+    $cart = discountMemoFixture();
+
+    // The storefront renders the cart, which calculates it. The cart has no
+    // coupon yet, so the memoised set cannot contain the coupon discount.
+    $cart->recalculate();
+
+    $withoutCoupon = $cart->total->value;
+
+    $cart->coupon_code = 'SAVE';
+    $cart->save();
+    $cart->recalculate();
+
+    expect($cart->coupon_code)->toBe('SAVE')
+        ->and($cart->total->value)->toBeLessThan($withoutCoupon);
+});
+
+test('resetting the discount manager applies the same coupon', function () {
+    $cart = discountMemoFixture();
+
+    $cart->recalculate();
+    $withoutCoupon = $cart->total->value;
+
+    $cart->coupon_code = 'SAVE';
+    $cart->save();
+
+    // Same cart, same coupon, only the memoised set dropped.
+    Discounts::resetDiscounts();
+    $cart->recalculate();
+
+    expect($cart->total->value)->toBeLessThan($withoutCoupon);
+});


### PR DESCRIPTION

A shopper types a valid coupon into their cart. It is accepted and shown as
applied — and the total does not move.

### What happens now

- The coupon is accepted. No error, no warning; the cart shows it as applied.
- The total stays exactly where it was.
- Reloading the page makes the discount appear, so it gets reported as
  "only happens sometimes" and closed as unreproducible.
- Only on stores with at least one always-on discount. With none, coupons work.

### What should happen

- The coupon is accepted and the total drops immediately.
- Reloading changes nothing, because there was nothing to correct.

### Why

`DiscountManager::apply()` caches the applicable-discount set on its first call
in a request and never re-queries it:

```php
if (! $this->discounts || $this->discounts?->isEmpty()) {
    $this->discounts = $this->getDiscounts($cart);
}
```

`getDiscounts($cart)` is cart-dependent — it filters on `coupon_code`, applying
`whereNull('coupon')` when there is none, which excludes every coupon discount.
That set is then reused for the whole request regardless of the cart's later
state. A storefront calculates the cart before the shopper reaches the coupon
field (`Cart::add()` recalculates), so the cache is already built without it.

Both odd behaviours come from the same line: the cache refreshes only when
**empty**, so a store with no active discount never sees it; and a reload is a
new request, which rebuilds the set with the coupon present.

### The fix

Key the cache on the cart state it was built from — the cart, its coupon, its
customer, and the purchasables in its lines. When those change it rebuilds;
otherwise it is reused exactly as before, so the caching benefit is unchanged.
`resetDiscounts()` clears the key too.

This also covers a product added mid-request whose discount was not picked up —
same stale cache, different trigger. Nothing else in `getDiscounts()` is touched.

### Tests

`tests/core/Unit/Managers/DiscountManagerMemoisationTest.php`, driving the real
cart pipeline:

- **a coupon applied after the cart has been calculated is applied** — fails on
  `1.x` with `Failed asserting that 2399 is less than 2399`, passes after.
- **resetting the discount manager applies the same coupon** — passes before and
  after. It localises the fault: the same cart and coupon work the moment the
  cache is dropped, so the problem is the caching, not coupon handling.

The existing `can get discount with coupon` test does not catch this — it calls
`Discounts::getDiscounts()` directly, bypassing `apply()` and the cache.

Core suite **556 → 558 passing**. Pint and PHPStan clean on both files.
