### PR TITLE
Reprice the cart when the session currency changes

### DIFF
--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -219,6 +219,13 @@ class CartSessionManager implements CartSessionInterface
             $this->cart->update([
                 'currency_id' => $currency->id,
             ]);
+
+            // Prices are resolved from the cart's loaded relations, and the
+            // lines carry their own copy of the cart (see lunar.cart.eager_load).
+            // Without dropping these the next calculate() prices in the old
+            // currency.
+            $this->cart->unsetRelation('currency');
+            $this->cart->unsetRelation('lines');
         }
     }
 

--- a/tests/core/Unit/Managers/CartSessionSetCurrencyTest.php
+++ b/tests/core/Unit/Managers/CartSessionSetCurrencyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Facades\CartSession;
+use Lunar\Models\Cart;
+use Lunar\Models\Channel;
+use Lunar\Models\Currency;
+use Lunar\Models\CustomerGroup;
+use Lunar\Models\Price;
+use Lunar\Models\ProductVariant;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+/**
+ * CartSession::setCurrency() writes currency_id to the cart row but leaves the
+ * already-loaded relations on the in-memory cart untouched. Since prices are
+ * resolved from those relations, a cart calculated after the switch is still
+ * priced in the old currency.
+ */
+function currencySwitchCart(): array
+{
+    CustomerGroup::factory()->create(['default' => true]);
+    $channel = Channel::factory()->create(['default' => true]);
+
+    $gbp = Currency::factory()->create(['code' => 'GBP', 'default' => true, 'exchange_rate' => 1]);
+    $usd = Currency::factory()->create(['code' => 'USD', 'default' => false, 'exchange_rate' => 1]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 1000, // £10
+        'min_quantity' => 1,
+        'currency_id' => $gbp->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 2500, // $25 — deliberately unrelated to the GBP price
+        'min_quantity' => 1,
+        'currency_id' => $usd->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $gbp->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 1,
+    ]);
+
+    CartSession::use($cart->refresh());
+
+    return [$cart, $gbp, $usd];
+}
+
+test('switching the session currency reprices the cart', function () {
+    [$cart, $gbp, $usd] = currencySwitchCart();
+
+    $cart->calculate();
+    expect($cart->subTotal->value)->toEqual(1000);
+
+    CartSession::setCurrency($usd);
+
+    $cart->calculate();
+
+    expect($cart->subTotal->value)->toEqual(2500);
+});
+
+test('switching the session currency reprices a cart read back from the session', function () {
+    [$cart, $gbp, $usd] = currencySwitchCart();
+
+    $cart->calculate();
+
+    CartSession::setCurrency($usd);
+
+    expect(CartSession::current()->subTotal->value)->toEqual(2500);
+});


### PR DESCRIPTION

A shopper switches the store to another currency. The currency label changes and
the prices do not.

### What happens now

- `CartSession::setCurrency()` is called, the cart's `currency_id` is updated.
- The next `calculate()` still prices every line in the previous currency.
- Because prices are stored per currency rather than converted, these are not
  slightly-off amounts — they are simply another currency's prices shown under
  the new symbol.
- A cart re-read in a later request is correct, so it presents as a display
  glitch that "fixes itself".

### What should happen

- After the switch, the cart is priced from the new currency's `Price` rows.

### Why

`setCurrency()` updates the row but leaves the loaded relations alone:

```php
$this->cart->update([
    'currency_id' => $currency->id,
]);
```

Pricing does not read `currency_id`. `Pipelines\CartLine\GetUnitPrice` resolves
against `$cartLine->cart->currency` — and `lunar.cart.eager_load` contains
`lines.cart.currency`, so every line holds its **own** loaded copy of the cart.
Updating the parent's column leaves all of those still pointing at the old
currency, and `CalculateLines` reads `->factor` and `->decimal_places` from the
stale relation too.

### The fix

When the currency actually changes, drop the cart's `currency` and `lines`
relations so the next `calculate()` reloads them. That is the whole change — no
new query is issued at switch time, and nothing happens when the currency is
unchanged.

Left alone deliberately: `Cart::calculate()`'s `isCalculated()` short-circuit,
and the `lines.cart.currency` eager-load itself. Both are arguably worth
revisiting, but neither is needed to fix this and both would widen the blast
radius.

### Tests

`tests/core/Unit/Managers/CartSessionSetCurrencyTest.php`:

- **switching the session currency reprices the cart** — a cart held across the
  switch.
- **…reprices a cart read back from the session** — the same via
  `CartSession::current()`.

Both fail on `1.x` with `Failed asserting that 1000 matches expected 2500`. The
GBP and USD prices are deliberately unrelated (£10 / $25) so a pass cannot come
from an exchange-rate coincidence.