### PR TITLE
Scope state tax zone lookups to the address country

### DIFF
--- a/packages/core/src/Actions/Taxes/GetTaxZone.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZone.php
@@ -17,7 +17,7 @@ class GetTaxZone
         }
 
         if ($address && $address->state) {
-            $stateZone = app(GetTaxZoneState::class)->execute($address->state);
+            $stateZone = app(GetTaxZoneState::class)->execute($address->state, $address->country_id);
             if ($stateZone) {
                 return $stateZone->taxZone;
             }

--- a/packages/core/src/Actions/Taxes/GetTaxZoneState.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZoneState.php
@@ -10,11 +10,12 @@ class GetTaxZoneState
      * Execute the action.
      *
      * @param  string  $state
+     * @param  null|int  $countryId
      * @return null|TaxZoneState
      */
-    public function execute($state)
+    public function execute($state, $countryId = null)
     {
-        $stateZone = $this->getZoneMatches($state);
+        $stateZone = $this->getZoneMatches($state, $countryId);
 
         if ($stateZone instanceof TaxZoneState) {
             return $stateZone;
@@ -27,16 +28,29 @@ class GetTaxZoneState
      * Return the zone or zones which match the given state name/code.
      *
      * @param  string  $state
+     * @param  null|int  $countryId
      * @return null|TaxZoneState
      */
-    protected function getZoneMatches($state)
+    protected function getZoneMatches($state, $countryId = null)
     {
         $state = (string) $state;
 
-        $stateZone = TaxZoneState::whereHas('state', function ($query) use ($state) {
-            return $query
-                ->where('name', $state)
-                ->orWhere('code', $state);
+        $stateZone = TaxZoneState::whereHas('state', function ($query) use ($state, $countryId) {
+            $query->where(function ($query) use ($state) {
+                return $query
+                    ->where('name', $state)
+                    ->orWhere('code', $state);
+            });
+
+            if ($countryId) {
+                $query->where(function ($query) use ($countryId) {
+                    return $query
+                        ->whereNull('country_id')
+                        ->orWhere('country_id', $countryId);
+                });
+            }
+
+            return $query;
         })->whereHas('taxZone', function ($query) {
             return $query->where('active', true);
         })->first();

--- a/tests/core/Unit/Actions/Taxes/GetTaxZoneStateTest.php
+++ b/tests/core/Unit/Actions/Taxes/GetTaxZoneStateTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Actions\Taxes\GetTaxZoneState;
+use Lunar\Models\Country;
 use Lunar\Models\State;
 use Lunar\Models\TaxZoneState;
 use Lunar\Tests\Core\TestCase;
@@ -84,4 +85,83 @@ test('can mismatch exact state name', function () {
     expect($zone)->toBeNull();
 
     $this->assertNotEquals($al->id, $zone?->id);
+});
+
+test('can match a state in the given country', function () {
+    $australia = Country::factory()->create([
+        'name' => 'Australia',
+    ]);
+
+    $unitedStates = Country::factory()->create([
+        'name' => 'United States',
+    ]);
+
+    $westernAustralia = State::factory()->create([
+        'country_id' => $australia->id,
+        'code' => 'WA',
+        'name' => 'Western Australia',
+    ]);
+
+    $washington = State::factory()->create([
+        'country_id' => $unitedStates->id,
+        'code' => 'WA',
+        'name' => 'Washington',
+    ]);
+
+    // Created first, so an unscoped lookup returns this one.
+    TaxZoneState::factory()->create([
+        'state_id' => $washington->id,
+    ]);
+
+    $auZone = TaxZoneState::factory()->create([
+        'state_id' => $westernAustralia->id,
+    ]);
+
+    $zone = app(GetTaxZoneState::class)->execute('WA', $australia->id);
+
+    expect($zone?->id)->toEqual($auZone->id);
+});
+
+test('can mismatch a state in another country', function () {
+    $australia = Country::factory()->create([
+        'name' => 'Australia',
+    ]);
+
+    $unitedStates = Country::factory()->create([
+        'name' => 'United States',
+    ]);
+
+    $washington = State::factory()->create([
+        'country_id' => $unitedStates->id,
+        'code' => 'WA',
+        'name' => 'Washington',
+    ]);
+
+    TaxZoneState::factory()->create([
+        'state_id' => $washington->id,
+    ]);
+
+    $zone = app(GetTaxZoneState::class)->execute('WA', $australia->id);
+
+    expect($zone)->toBeNull();
+});
+
+test('can match a state which is not assigned to a country', function () {
+    $australia = Country::factory()->create([
+        'name' => 'Australia',
+    ]);
+
+    $alabama = State::factory()->create([
+        'country_id' => null,
+        'code' => 'AL',
+        'name' => 'Alabama',
+    ]);
+
+    $alZone = TaxZoneState::factory()->create([
+        'state_id' => $alabama->id,
+    ]);
+
+    $zone = app(GetTaxZoneState::class)->execute('AL', $australia->id);
+
+    expect($zone?->id)->toEqual($alZone->id);
 });

--- a/tests/core/Unit/Actions/Taxes/GetTaxZoneTest.php
+++ b/tests/core/Unit/Actions/Taxes/GetTaxZoneTest.php
@@ -89,3 +89,43 @@ test('can prioritize taxzones', function () {
 
     expect($zone3->id)->toEqual($defaultTaxZone->id);
 });
+
+test('can ignore a state tax zone from another country', function () {
+    $australia = Country::factory()->create([
+        'name' => 'Australia',
+    ]);
+
+    $unitedStates = Country::factory()->create([
+        'name' => 'United States',
+    ]);
+
+    $washington = State::factory()->create([
+        'country_id' => $unitedStates->id,
+        'code' => 'WA',
+        'name' => 'Washington',
+    ]);
+
+    TaxZoneState::factory()->create([
+        'tax_zone_id' => TaxZone::factory(['default' => false]),
+        'state_id' => $washington->id,
+    ]);
+
+    $auZone = TaxZoneCountry::factory()->create([
+        'tax_zone_id' => TaxZone::factory(['default' => false]),
+        'country_id' => $australia->id,
+    ]);
+
+    TaxZone::factory(['default' => true])->create();
+
+    // Western Australia is also "WA", but has no tax zone of its own, so the
+    // Australian country zone should apply.
+    $address = Address::factory()->create([
+        'postcode' => '6000',
+        'state' => 'WA',
+        'country_id' => $australia->id,
+    ]);
+
+    $zone = app(GetTaxZone::class)->execute($address);
+
+    expect($zone->id)->toEqual($auZone->tax_zone_id);
+});


### PR DESCRIPTION

A shopper in Perth is charged Washington State sales tax. Their address is in
Australia; the tax zone that applied belongs to a US state that happens to share
the code `WA`.

### What happens now

- A state-scoped tax zone applies to any address whose state name or code
  matches, in any country.
- Codes and names collide across countries — `WA` is both Washington and Western
  Australia — and the first matching row wins, with nothing ordering them.
- Because the state lookup runs before the country lookup, a wrong state match
  also suppresses the correct country zone.
- Stores only see it once they have real address data, which is why it reads as
  arbitrary: it depends on which state row was inserted first.

### What should happen

- A tax zone on a state applies only to addresses in that state's country.
- When no state zone matches, the lookup falls through to the country zone and
  then the default, as documented.

### Why

`GetTaxZone::execute()` holds the full address, but passes only the state name
to the state lookup:

```php
if ($address && $address->state) {
    $stateZone = app(GetTaxZoneState::class)->execute($address->state);
```

`$address->country_id` is available — it is used two blocks further down for the
country zone — but the state lookup never receives it, so
`GetTaxZoneState::getZoneMatches()` matches on `name` or `code` alone.

The suite misses this because its fixtures create states with no `country_id`,
so no collision is possible. `lunar:import:address-data` creates states with
`$country->states()->createMany()`, so on a real install every state is tied to
a country and the collision is live.

### The fix

Pass the address's country into the action and constrain the state match to it.
States with a null `country_id` still match any country, which preserves
behaviour for stores that created states by hand and keeps `can prioritize
taxzones` green. The new argument is optional, so anything calling the action
directly is unaffected. The existing name/code pair is wrapped in a group so the
added condition does not change its precedence.

Deliberately out of scope: `GetTaxZonePostcode` has the same gap, and choosing
between a country-scoped and an unscoped state when both match. Both are better
as their own changes — the postcode matcher has wildcard fallback logic that
needs more care than this.

### Tests

`tests/core/Unit/Actions/Taxes/GetTaxZoneStateTest.php`:

- **can match a state in the given country** — two states coded `WA` in
  different countries. Fails on `1.x` with
  `Failed asserting that 1 matches expected 2`.
- **can mismatch a state in another country** — a US-only state zone must not
  match an Australian address.
- **can match a state which is not assigned to a country** — passes before and
  after, pinning the fallback that existing installs rely on.

`tests/core/Unit/Actions/Taxes/GetTaxZoneTest.php`:

- **can ignore a state tax zone from another country** — the full address path,
  asserting the Australian *country* zone wins. Same failure on `1.x`.