### PR TITLE
feat(admin): serve the Filament admin at /admin by default

### DIFF
--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -274,7 +274,7 @@ class LunarPanelManager
             ->favicon($brandAsset('lunar-icon.png'))
             ->brandLogoHeight('2rem')
             ->topbar(false)
-            ->path('lunar')
+            ->path('admin')
             ->authGuard('staff')
             ->defaultAvatarProvider(GravatarProvider::class)
             ->login()


### PR DESCRIPTION
## Summary

Changes the Filament admin shell's default panel path from `/lunar` to `/admin` in `LunarPanelManager::defaultPanel()`.

`/admin` is the conventional home for an admin panel and what most installs rename the path to anyway. v2 is the natural moment for the switch — installs migrating from v1 are already updating URLs, and no code or test in the monorepo pins the old path.

## Impact

- One-line default change; no schema, lang, or test changes needed (nothing asserts the path — routes are referenced by name).
- Consumers who want a different path (including keeping `/lunar`) already have the override:

  ```php
  LunarPanel::panel(fn (Panel $panel) => $panel->path('lunar'))->register();
  ```

- Worth a release-note callout since bookmarks and reverse-proxy rules pointing at `/lunar` will need updating.

## Tests

`admin` suite: 235 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)