### PR TITLE
Prevent shipping modifiers re-entering while options are resolving

### DIFF
--- a/packages/core/src/Base/ShippingManifest.php
+++ b/packages/core/src/Base/ShippingManifest.php
@@ -18,6 +18,11 @@ class ShippingManifest implements ShippingManifestInterface
     public ?Closure $getOptionUsing = null;
 
     /**
+     * Whether the shipping modifiers are currently being run.
+     */
+    protected bool $resolving = false;
+
+    /**
      * Initiate the class.
      */
     public function __construct()
@@ -77,11 +82,24 @@ class ShippingManifest implements ShippingManifestInterface
      */
     public function getOptions(Cart $cart): Collection
     {
-        app(Pipeline::class)
-            ->send($cart)
-            ->through(
-                app(ShippingModifiers::class)->getModifiers()->toArray()
-            )->thenReturn();
+        // A modifier is free to calculate the cart, which runs ApplyShipping
+        // and lands back here. Hand back what has been resolved so far rather
+        // than running the modifiers again.
+        if ($this->resolving) {
+            return $this->options;
+        }
+
+        $this->resolving = true;
+
+        try {
+            app(Pipeline::class)
+                ->send($cart)
+                ->through(
+                    app(ShippingModifiers::class)->getModifiers()->toArray()
+                )->thenReturn();
+        } finally {
+            $this->resolving = false;
+        }
 
         return $this->options;
     }

--- a/tests/core/Stubs/TestRecursiveShippingModifier.php
+++ b/tests/core/Stubs/TestRecursiveShippingModifier.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs;
+
+use Closure;
+use Lunar\Base\ShippingModifier;
+use Lunar\Models\Contracts\Cart as CartContract;
+
+class TestRecursiveShippingModifier extends ShippingModifier
+{
+    /**
+     * The number of times this modifier has been run.
+     */
+    public static int $calls = 0;
+
+    /**
+     * A self-imposed ceiling so an unguarded re-entry fails the test
+     * rather than exhausting the stack.
+     */
+    public static int $limit = 25;
+
+    public function handle(CartContract $cart, Closure $next)
+    {
+        static::$calls++;
+
+        if (static::$calls < static::$limit) {
+            $cart->calculate();
+        }
+
+        return $next($cart);
+    }
+}

--- a/tests/core/Unit/Base/ShippingManifestTest.php
+++ b/tests/core/Unit/Base/ShippingManifestTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Base\ShippingModifiers;
 use Lunar\DataTypes\Price;
 use Lunar\DataTypes\ShippingOption;
 use Lunar\Facades\ShippingManifest;
@@ -12,6 +13,7 @@ use Lunar\Models\Price as PriceModel;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRateAmount;
+use Lunar\Tests\Core\Stubs\TestRecursiveShippingModifier;
 use Lunar\Tests\Core\TestCase;
 
 uses(TestCase::class);
@@ -252,4 +254,34 @@ test('can retrieve cart shipping option using', function () {
     ShippingManifest::getOptionUsing(fn (Cart $cart, $identifier): ShippingOption => $option->getIdentifier() == $identifier ? $option : null);
 
     expect(ShippingManifest::getShippingOption($this->cart))->toBe($option);
+});
+
+test('can not re-enter shipping modifiers while resolving options', function () {
+    TestRecursiveShippingModifier::$calls = 0;
+
+    $taxClass = TaxClass::factory()->create();
+
+    CartAddress::factory()->create([
+        'cart_id' => $this->cart->id,
+        'type' => 'shipping',
+        'shipping_option' => 'BASDEL',
+    ]);
+
+    ShippingManifest::addOption(
+        new ShippingOption(
+            name: 'Basic Delivery',
+            description: 'Basic Delivery',
+            identifier: 'BASDEL',
+            price: new Price(500, $this->cart->currency, 1),
+            taxClass: $taxClass
+        )
+    );
+
+    app(ShippingModifiers::class)->add(TestRecursiveShippingModifier::class);
+
+    $this->cart->calculate();
+
+    // ApplyShipping and CalculateTax each resolve the shipping option once, so
+    // a single calculate runs the modifiers twice. Neither run may re-enter.
+    expect(TestRecursiveShippingModifier::$calls)->toEqual(2);
 });


### PR DESCRIPTION

A shipping modifier that calculates the cart — to read a discounted subtotal
before picking a rate band, say — takes the request down with a stack
overflow.

### What happens now

- `Cart::calculate()` → `ApplyShipping` → `ShippingManifest::getOptions()` →
  the modifier → `Cart::calculate()` again, with nothing to stop it.
- The process dies on stack exhaustion, so there is no useful error and
  nothing to catch.
- It only bites once the cart has a shipping address with an option selected,
  which is why it shows up at checkout and never in earlier testing.
- Modifiers that need post-discount totals have no supported way to get them,
  so this is a natural thing to write.

### What should happen

- A modifier may calculate the cart. Doing so does not run the modifiers
  again.

### Why

`getOptions()` runs the modifier pipeline every time it is called, with no
notion of already being inside it:

```php
public function getOptions(Cart $cart): Collection
{
    app(Pipeline::class)
        ->send($cart)
        ->through(app(ShippingModifiers::class)->getModifiers()->toArray())
        ->thenReturn();

    return $this->options;
}
```

`ApplyShipping` calls it on every calculate, so a modifier calling
`calculate()` re-enters immediately.

### The fix

Track whether the modifier pipeline is already running and, if it is, return
the options resolved so far instead of running them again. The flag is cleared
in a `finally`, so a modifier that throws does not leave the manifest wedged
for the rest of the process — which matters under Octane, where the manifest
outlives the request.

This is a behaviour change to a public API, so worth being explicit: a modifier
that re-enters now sees a partially built option set rather than a fatal. If
you would rather not change the semantics, the smaller alternative is to
document that modifiers must not calculate the cart, and I am happy to send
that instead.

`addOption()` is deliberately untouched — it is called directly from
`tests/Pest.php` and a number of tests, so anything that changes when options
are cleared would be a much larger discussion.

One thing noticed in passing, not addressed here: `ApplyShipping` and
`CalculateTax` each resolve the shipping option, so every calculate runs the
modifiers twice. For a modifier that calls a carrier API that is two requests
per calculate.

### Tests

`tests/core/Unit/Base/ShippingManifestTest.php`, with a
`TestRecursiveShippingModifier` stub that calls `$cart->calculate()` and counts
its own invocations, capped at 25 so an unguarded run fails the assertion
rather than exhausting the stack:

- **can not re-enter shipping modifiers while resolving options** — fails on
  `1.x` with `Failed asserting that 50 matches expected 2`; the modifier ran
  until it hit its own ceiling. Passes after, at the two legitimate
  resolutions per calculate.