### PR TITLE
Support variant rewards when automatically adding BuyXGetY rewards

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -4,6 +4,7 @@ namespace Lunar\DiscountTypes;
 
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
+use Lunar\Base\Purchasable;
 use Lunar\Base\ValueObjects\Cart\DiscountBreakdown;
 use Lunar\Base\ValueObjects\Cart\DiscountBreakdownLine;
 use Lunar\DataTypes\Price;
@@ -251,6 +252,8 @@ class BuyXGetY extends AbstractDiscountType
                     $product = $selectedRewardItem->products()->inRandomOrder()->first();
                     $purchasable = $product?->variants()->first();
                     $selectedRewardItem = $product;
+                } elseif ($selectedRewardItem instanceof Purchasable) {
+                    $purchasable = $selectedRewardItem;
                 } else {
                     $purchasable = $selectedRewardItem->variants->first();
                 }

--- a/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
@@ -1548,3 +1548,95 @@ test('does not discount products not in the reward collection', function () {
     // productC (not in collection) should not be discounted
     expect($lineC->discountTotal->value)->toEqual(0);
 });
+
+test('can add an eligible variant reward when not in cart', function () {
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $channel = Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'code' => 'GBP',
+    ]);
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+    ]);
+
+    $productA = Product::factory()->create();
+    $productB = Product::factory()->create();
+
+    $purchasableA = ProductVariant::factory()->create([
+        'product_id' => $productA->id,
+    ]);
+    $purchasableB = ProductVariant::factory()->create([
+        'product_id' => $productB->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000, // £10
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableA->getMorphClass(),
+        'priceable_id' => $purchasableA->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000, // £10
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableB->getMorphClass(),
+        'priceable_id' => $purchasableB->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableA->getMorphClass(),
+        'purchasable_id' => $purchasableA->id,
+        'quantity' => 1,
+    ]);
+
+    $discount = Discount::factory()->create([
+        'type' => BuyXGetY::class,
+        'name' => 'Test Variant Reward Discount',
+        'data' => [
+            'min_qty' => 1,
+            'reward_qty' => 2,
+            'automatically_add_rewards' => true,
+        ],
+    ]);
+
+    $discount->customerGroups()->sync([
+        $customerGroup->id => [
+            'enabled' => true,
+            'starts_at' => now(),
+        ],
+    ]);
+
+    $discount->channels()->sync([
+        $channel->id => [
+            'enabled' => true,
+            'starts_at' => now()->subHour(),
+        ],
+    ]);
+
+    $discount->discountableConditions()->create([
+        'discountable_type' => $productA->getMorphClass(),
+        'discountable_id' => $productA->id,
+    ]);
+
+    // The reward is a variant, which the admin allows selecting.
+    $discount->discountableRewards()->create([
+        'discountable_type' => $purchasableB->getMorphClass(),
+        'discountable_id' => $purchasableB->id,
+        'type' => 'reward',
+    ]);
+
+    $cart = $cart->calculate();
+
+    $this->assertEquals(1200, $cart->total->value);
+    $this->assertCount(1, $cart->freeItems);
+});


### PR DESCRIPTION
A merchant picks a specific variant as a Buy X Get Y reward — which the admin
lets them do — and ticks "automatically add rewards". Every cart that qualifies
then dies with a 500.

### What happens now

- `Call to a member function first() on null` in
  `BuyXGetY::processAutomaticRewards()`, thrown during cart calculation.
- It takes down anything that calculates the cart, so the shopper cannot view
  their basket, not just complete checkout.
- Product rewards and collection rewards both work. Only the variant reward,
  combined with the automatic-add option, fails.

### What should happen

- A variant reward is added to the cart in the same way a product reward is.

### Why

#2214 made variants selectable as rewards, and #2461 added a branch for
collections. The remaining `else` still assumes the reward is a `Product` and
reaches for its variants:

```php
} else {
    $purchasable = $selectedRewardItem->variants->first();
}
```

A `ProductVariant` has no `variants` relation, so the property read returns
`null` and the `->first()` on it is fatal. The null guard immediately below
never runs, because the error is thrown before it is reached.

### The fix

Add a branch for a reward that is already purchasable, and use it directly.
`ProductVariant` implements `Lunar\Base\Purchasable`, and `Product` does not,
so the check separates the two cases without naming concrete models — the same
approach the existing collection branch takes.

Nothing else in the method changes: the existing product and collection paths
are untouched, and the reward still flows through the normal cart-line pipeline
afterwards.

Worth flagging: #2509 is currently rewriting this method to skip rewards that
cannot be fulfilled. The two changes do not overlap in intent, but whichever
lands second will want a rebase.

### Tests

`tests/core/Unit/DiscountTypes/BuyXGetYTest.php`:

- **can add an eligible variant reward when not in cart** — the existing
  `can add eligible products when not in cart` scenario with the reward
  registered against the variant instead of the product. Fails on `1.x` with
  `Call to a member function first() on null` at `BuyXGetY.php:255`, and
  asserts the same £12.00 total and single free item afterwards.
