### PR TITLE
Store automatically added BuyXGetY reward lines using the morph map

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -268,7 +268,7 @@ class BuyXGetY extends AbstractDiscountType
 
                 if (! $rewardLine) {
                     $rewardLine = $cart->lines()->make([
-                        'purchasable_type' => get_class($purchasable),
+                        'purchasable_type' => $purchasable->getMorphClass(),
                         'purchasable_id' => $purchasable->id,
                         'quantity' => 1,
                     ]);

--- a/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\DiscountTypes\AmountOff;
 use Lunar\DiscountTypes\BuyXGetY;
 use Lunar\Models\Cart;
+use Lunar\Models\CartLine;
 use Lunar\Models\Channel;
 use Lunar\Models\Collection;
 use Lunar\Models\Currency;
@@ -1547,4 +1548,98 @@ test('does not discount products not in the reward collection', function () {
     expect($lineB->discountTotal->value)->toEqual(1000);
     // productC (not in collection) should not be discounted
     expect($lineC->discountTotal->value)->toEqual(0);
+});
+
+test('can store an automatically added reward line using the morph map', function () {
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $channel = Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'code' => 'GBP',
+    ]);
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+    ]);
+
+    $productA = Product::factory()->create();
+    $productB = Product::factory()->create();
+
+    $purchasableA = ProductVariant::factory()->create([
+        'product_id' => $productA->id,
+    ]);
+    $purchasableB = ProductVariant::factory()->create([
+        'product_id' => $productB->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000, // £10
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableA->getMorphClass(),
+        'priceable_id' => $purchasableA->id,
+    ]);
+
+    Price::factory()->create([
+        'price' => 1000, // £10
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasableB->getMorphClass(),
+        'priceable_id' => $purchasableB->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableA->getMorphClass(),
+        'purchasable_id' => $purchasableA->id,
+        'quantity' => 1,
+    ]);
+
+    $discount = Discount::factory()->create([
+        'type' => BuyXGetY::class,
+        'name' => 'Test Product Discount',
+        'data' => [
+            'min_qty' => 1,
+            'reward_qty' => 1,
+            'automatically_add_rewards' => true,
+        ],
+    ]);
+
+    $discount->customerGroups()->sync([
+        $customerGroup->id => [
+            'enabled' => true,
+            'starts_at' => now(),
+        ],
+    ]);
+
+    $discount->channels()->sync([
+        $channel->id => [
+            'enabled' => true,
+            'starts_at' => now()->subHour(),
+        ],
+    ]);
+
+    $discount->discountableConditions()->create([
+        'discountable_type' => $productA->getMorphClass(),
+        'discountable_id' => $productA->id,
+    ]);
+
+    $discount->discountableRewards()->create([
+        'discountable_type' => $productB->getMorphClass(),
+        'discountable_id' => $productB->id,
+        'type' => 'reward',
+    ]);
+
+    $cart->calculate();
+
+    $rewardLine = CartLine::where('cart_id', $cart->id)
+        ->where('purchasable_id', $purchasableB->id)
+        ->first();
+
+    expect($rewardLine->purchasable_type)->toEqual($purchasableB->getMorphClass());
 });


### PR DESCRIPTION
A reward line added automatically by a Buy X Get Y discount is written to
`lunar_cart_lines` with a different `purchasable_type` than every other line
holding the same product.

### What happens now

- The reward line stores `Lunar\Models\ProductVariant`, while a line the
  shopper added stores `product_variant`.
- The same purchasable therefore appears under two different types in one
  cart.
- Any query that filters cart lines by morph type — reporting, an
  `whereHasMorph`, a custom pipeline stage — silently skips these lines.
- It survives into `lunar_order_lines`, so the inconsistency is persisted
  against the placed order too.

### What should happen

- A reward line stores the same `purchasable_type` as any other line for that
  purchasable.

### Why

Lunar registers a morph map at boot (`ModelManifest::morphMap()`, keyed by the
snake-cased class basename), so `ProductVariant::getMorphClass()` returns
`product_variant`. Every cart line in the codebase is created with
`getMorphClass()`, except this one:

```php
$rewardLine = $cart->lines()->make([
    'purchasable_type' => get_class($purchasable),
```

`get_class()` bypasses the map and writes the concrete class name.

### The fix

Use `getMorphClass()`, matching how cart lines are created everywhere else. It
also means a store that has extended `ProductVariant` gets the mapped alias
rather than its own class name written into the table.

Deliberately out of scope: with `reward_qty` greater than one this method also
creates one cart line per reward unit rather than a single line, because its
"is it already in cart?" check reads an in-memory `$cart->lines` the loop never
appends to. That is a real but separate defect, and fixing it here would make
this diff much harder to review. Also note #2509 is currently rewriting this
method for stock availability — no overlap in intent, but a rebase for whichever
lands second.

### Tests

`tests/core/Unit/DiscountTypes/BuyXGetYTest.php`:

- **can store an automatically added reward line using the morph map** — an
  automatic reward on a qualifying cart, asserting the persisted
  `purchasable_type`. Fails on `1.x` with:

  ```
  -'product_variant'
  +'Lunar\Models\ProductVariant'
  ```
