### PR TITLE
Include the selected shipping option in the cart fingerprint

### DIFF
--- a/packages/core/src/Actions/Carts/GenerateFingerprint.php
+++ b/packages/core/src/Actions/Carts/GenerateFingerprint.php
@@ -21,7 +21,10 @@ class GenerateFingerprint
                 $line->subTotal;
         });
 
-        $value .= $cart->user_id.$cart->currency_id.$cart->coupon_code;
+        $value .= $cart->user_id.
+            $cart->currency_id.
+            $cart->coupon_code.
+            $cart->shippingAddress?->shipping_option;
 
         return sha1($value);
     }

--- a/tests/core/Unit/Actions/Carts/GenerateFingerprintTest.php
+++ b/tests/core/Unit/Actions/Carts/GenerateFingerprintTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Actions\Carts\GenerateFingerprint;
 use Lunar\Models\Cart;
+use Lunar\Models\CartAddress;
 use Lunar\Models\Channel;
 use Lunar\Models\Currency;
 use Lunar\Models\Price;
@@ -77,4 +78,44 @@ test('can generate cart fingerprint', function () {
     ]);
 
     $this->assertNotSame($fingerprintFromCart, $cart->fingerprint());
+});
+
+test('can generate a different cart fingerprint when the shipping option changes', function () {
+    $currency = Currency::factory()->create();
+    $channel = Channel::factory()->create();
+
+    $cart = Cart::create([
+        'currency_id' => $currency->id,
+        'channel_id' => $channel->id,
+    ]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 1,
+    ]);
+
+    CartAddress::factory()->create([
+        'cart_id' => $cart->id,
+        'type' => 'shipping',
+        'shipping_option' => 'BASDEL',
+    ]);
+
+    $fingerprint = $cart->fingerprint();
+
+    $cart->shippingAddress->update([
+        'shipping_option' => 'EXPDEL',
+    ]);
+
+    expect($cart->fingerprint())->not->toBe($fingerprint);
 });

--- a/tests/core/Unit/Actions/Carts/GenerateFingerprintTest.php
+++ b/tests/core/Unit/Actions/Carts/GenerateFingerprintTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Actions\Carts\GenerateFingerprint;
 use Lunar\Models\Cart;
+use Lunar\Models\CartAddress;
 use Lunar\Models\Channel;
 use Lunar\Models\Currency;
 use Lunar\Models\Price;
@@ -77,4 +78,87 @@ test('can generate cart fingerprint', function () {
     ]);
 
     $this->assertNotSame($fingerprintFromCart, $cart->fingerprint());
+});
+
+test('can generate a different cart fingerprint when the shipping option changes', function () {
+    $currency = Currency::factory()->create();
+    $channel = Channel::factory()->create();
+
+    $cart = Cart::create([
+        'currency_id' => $currency->id,
+        'channel_id' => $channel->id,
+    ]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 1,
+    ]);
+
+    CartAddress::factory()->create([
+        'cart_id' => $cart->id,
+        'type' => 'shipping',
+        'shipping_option' => 'BASDEL',
+    ]);
+
+    $fingerprint = $cart->fingerprint();
+
+    $cart->shippingAddress->update([
+        'shipping_option' => 'EXPDEL',
+    ]);
+
+    expect($cart->fingerprint())->not->toBe($fingerprint);
+});
+
+test('can generate a cart fingerprint before a shipping option is selected', function () {
+    $currency = Currency::factory()->create();
+    $channel = Channel::factory()->create();
+
+    $cart = Cart::create([
+        'currency_id' => $currency->id,
+        'channel_id' => $channel->id,
+    ]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 1,
+    ]);
+
+    expect($cart->shippingAddress)->toBeNull();
+
+    $fingerprint = $cart->fingerprint();
+
+    expect($fingerprint)->toBeString();
+
+    // Choosing delivery for the first time still has to register as a change.
+    CartAddress::factory()->create([
+        'cart_id' => $cart->id,
+        'type' => 'shipping',
+        'shipping_option' => 'BASDEL',
+    ]);
+
+    $cart->unsetRelation('shippingAddress');
+
+    expect($cart->fingerprint())->not->toBe($fingerprint);
 });


### PR DESCRIPTION
A shopper reaches payment, switches from express to standard delivery in
another tab, and pays. `checkFingerprint()` reports the cart as unchanged,
because the fingerprint does not cover the delivery choice.

### What happens now

- Two carts that differ only in their selected shipping option hash
  identically.
- `Cart::checkFingerprint()` — the documented "have the contents changed?"
  guard — returns `true` after a shipping change, so a checkout that trusts it
  proceeds on a stale amount.
- Every other input to the order total *is* covered: lines, quantities,
  user, currency and coupon. Shipping is the one gap.
- It goes unnoticed because `currentDraftOrder()` also compares `total`, so the
  draft-order reuse path happens to be protected. The exposed path is any
  storefront using `checkFingerprint()` directly.

### What should happen

- Changing the shipping option changes the fingerprint.
- `checkFingerprint()` reports a change whenever anything that moves the order
  total has moved.

### Why

`GenerateFingerprint` hashes the lines, then appends the remaining cart-level
inputs:

```php
$value .= $cart->user_id.$cart->currency_id.$cart->coupon_code;
```

The selected shipping option lives on the cart's shipping address
(`cart_addresses.shipping_option`) and is never read. `ApplyShipping` resolves
the cart's shipping cost from exactly that column, so it is the input that
decides the shipping charge — and it is the only total-affecting field the
fingerprint omits.

### The fix

Append the shipping address's `shipping_option` to the hashed value. It is a
persisted column, so the fingerprint stays a pure function of stored cart
state — deliberately *not* the shipping total, which is transient and only
exists after a calculate. Carts with no shipping address are unaffected, since
the null-safe read contributes nothing.

One compatibility note: fingerprints already stored on orders will not match a
freshly generated one for carts that have a shipping address. That is inherent
to changing the hash inputs, and only affects an in-flight checkout at the
moment of upgrade.

Not related to #2517 / #2518, which also concern the fingerprint but through
line *ordering* on PostgreSQL; that fix is in `Cart::lines()` and does not
touch this action.

### Tests

`tests/core/Unit/Actions/Carts/GenerateFingerprintTest.php`:

- **can generate a different cart fingerprint when the shipping option
  changes** — one cart, one line, shipping option moved from `BASDEL` to
  `EXPDEL`. Fails on `1.x` with
  `Expecting '5411acac202fe57320451f405edc3…a9d85d' not to be
  '5411acac202fe57320451f405edc3…a9d85d'`.

The existing `can generate cart fingerprint` test is unchanged and still
passes, so the covered inputs still behave as before.
