### PR TITLE
Annotate getDefault as nullable on HasDefaultRecord

### DIFF
--- a/packages/core/src/Base/Traits/HasDefaultRecord.php
+++ b/packages/core/src/Base/Traits/HasDefaultRecord.php
@@ -22,7 +22,7 @@ trait HasDefaultRecord
     /**
      * Get the default record.
      *
-     * @return self
+     * @return null|self
      */
     public static function getDefault()
     {

--- a/tests/core/Unit/Base/Traits/HasDefaultRecordTest.php
+++ b/tests/core/Unit/Base/Traits/HasDefaultRecordTest.php
@@ -31,3 +31,11 @@ test('can get default record with static helper', function () {
 
     expect(Channel::getDefault()->id)->toEqual($defaultChannel->id);
 });
+
+test('can return null when no record is marked as default', function () {
+    Channel::factory(3)->create([
+        'default' => false,
+    ]);
+
+    expect(Channel::getDefault())->toBeNull();
+});


### PR DESCRIPTION

`HasDefaultRecord::getDefault()` is annotated `@return self`, but it returns
`first()` and so returns `null` whenever no record is flagged as the default.

### What happens now

- The annotation promises a model, so static analysis and IDEs treat every
  `Channel::getDefault()` / `Currency::getDefault()` as non-null.
- Consumers write `Currency::getDefault()->code` and get no warning.
- Lunar's own code is split on it: `DiscountManager` guards
  (`if ($defaultChannel = Channel::getDefault())`) while
  `StorefrontSessionManager::initChannel()` passes the result straight into
  `setChannel(ChannelContract $channel)`.

### What should happen

- The annotation matches what the method returns, so callers are told the
  value can be null.

### Why

```php
/**
 * @return self
 */
public static function getDefault()
{
    return Blink::once($key, fn () => self::query()->default(true)->first());
}
```

`first()` returns null when nothing matches. Nothing guarantees a default
record exists — the flag is an ordinary column that admin can clear.

### The fix

Correct the annotation to `@return null|self`. No behaviour changes, and
PHPStan runs at level 0 so nothing in CI starts failing.

### One thing worth deciding separately

The nullable case is reachable today. With no default channel,
`StorefrontSession::initChannel()` throws
`TypeError: setChannel(): Argument #1 ($channel) must be of type ChannelContract, null given`.

We wrote guards for the three `init*` methods and then removed them, because
`getChannel(): ChannelContract` is also non-nullable — a guard just moves the
TypeError from `setChannel()` to `getChannel()`. Whether a store with no
default record should fail with a clear domain exception, or whether these
session getters should become nullable, is a call for the maintainers rather
than something to decide inside this PR. Happy to follow up with whichever
direction you prefer.

### Tests

`tests/core/Unit/Base/Traits/HasDefaultRecordTest.php`:

- **can return null when no record is marked as default** — three channels,
  none default. Passes before and after; it pins the contract the annotation
  now describes, alongside the two existing tests for the populated case.
