### PR TITLE
Import the Route facade in opayo and paypal route files

### DIFF
--- a/packages/opayo/routes/web.php
+++ b/packages/opayo/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 Route::get('opayo-threedsecure', function () {
     return view('lunar::opayo.threed-secure-iframe');

--- a/packages/paypal/routes/web.php
+++ b/packages/paypal/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
 use Lunar\Paypal\Http\Controllers\GetPaypalOrderController;
 
 Route::group([


### PR DESCRIPTION
PHPStan (level 0) currently fails on `1.x` with three errors, all of the same kind:

```
packages/opayo/routes/web.php:5   Call to static method get() on an unknown class Route.
packages/opayo/routes/web.php:9   Call to static method post() on an unknown class Route.
packages/paypal/routes/web.php:5  Call to static method group() on an unknown class Route.
```

Both files call the `Route` facade through the runtime root-namespace alias, which PHPStan/Larastan cannot resolve. Adding the explicit `use Illuminate\Support\Facades\Route;` import fixes all three — the same convention `packages/stripe/routes/webhooks.php` already follows.

No behaviour change. `vendor/bin/phpstan analyse` now reports **No errors**, and Pint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)