### PR TITLE
Add a multi-quantity BuyXGetY reward as one line

### DIFF
--- a/packages/core/src/DiscountTypes/BuyXGetY.php
+++ b/packages/core/src/DiscountTypes/BuyXGetY.php
@@ -241,6 +241,12 @@ class BuyXGetY extends AbstractDiscountType
 
     private function processAutomaticRewards(CartContract $cart, int $remainingRewardQty, Collection $affectedLines, int $discountTotal)
     {
+        // Reward lines this run has added, keyed by purchasable. The check below
+        // reads $cart->lines, which never receives a line made here, so without
+        // this a reward quantity of three opens three lines of one rather than
+        // one line of three.
+        $addedRewardLines = [];
+
         // we have lines to add
         if ($remainingRewardQty > 0) {
             while ($remainingRewardQty > 0) {
@@ -268,10 +274,25 @@ class BuyXGetY extends AbstractDiscountType
                     continue;
                 }
 
+                $rewardKey = $purchasable->getMorphClass().':'.$purchasable->id;
+
                 // is it already in cart?
-                $rewardLine = $cart->lines->first(function ($line) use ($purchasable) {
+                $rewardLine = $addedRewardLines[$rewardKey] ?? $cart->lines->first(function ($line) use ($purchasable) {
                     return $line->purchasable->id == $purchasable->id;
                 });
+
+                if ($rewardLine && isset($addedRewardLines[$rewardKey])) {
+                    // Another unit of a reward this run already added: raise the
+                    // quantity on that line. A line the shopper put in the cart
+                    // themselves is left at the quantity they chose, as before.
+                    $rewardLine->quantity++;
+
+                    $lineTotal = $rewardLine->unitPrice->value * $rewardLine->quantity;
+                    $unitQuantity = $purchasable->getUnitQuantity();
+
+                    $rewardLine->subTotal = new Price($lineTotal, $cart->currency, $unitQuantity);
+                    $rewardLine->total = new Price($lineTotal, $cart->currency, $unitQuantity);
+                }
 
                 if (! $rewardLine) {
                     $rewardLine = $cart->lines()->make([
@@ -303,6 +324,8 @@ class BuyXGetY extends AbstractDiscountType
                     $rewardLine->subTotal = new Price($rewardLine->unitPrice->value, $cart->currency, $unitQuantity);
                     $rewardLine->taxAmount = new Price(0, $cart->currency, $unitQuantity);
                     $rewardLine->total = new Price($rewardLine->unitPrice->value, $cart->currency, $unitQuantity);
+
+                    $addedRewardLines[$rewardKey] = $rewardLine;
                 }
 
                 $meta = $rewardLine->meta ?? json_decode('{}');

--- a/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
+++ b/tests/core/Unit/DiscountTypes/BuyXGetYTest.php
@@ -1735,3 +1735,189 @@ test('can store an automatically added reward line using the morph map', functio
 
     expect($rewardLine->purchasable_type)->toEqual($purchasableB->getMorphClass());
 });
+
+test('can add a multi quantity reward as a single line', function () {
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $channel = Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'code' => 'GBP',
+    ]);
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+    ]);
+
+    $productA = Product::factory()->create();
+    $productB = Product::factory()->create();
+
+    $purchasableA = ProductVariant::factory()->create([
+        'product_id' => $productA->id,
+    ]);
+    $purchasableB = ProductVariant::factory()->create([
+        'product_id' => $productB->id,
+    ]);
+
+    foreach ([$purchasableA, $purchasableB] as $purchasable) {
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'min_quantity' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => $purchasable->getMorphClass(),
+            'priceable_id' => $purchasable->id,
+        ]);
+    }
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableA->getMorphClass(),
+        'purchasable_id' => $purchasableA->id,
+        'quantity' => 1,
+    ]);
+
+    $discount = Discount::factory()->create([
+        'type' => BuyXGetY::class,
+        'name' => 'Test Product Discount',
+        'data' => [
+            'min_qty' => 1,
+            'reward_qty' => 3,
+            'automatically_add_rewards' => true,
+        ],
+    ]);
+
+    $discount->customerGroups()->sync([
+        $customerGroup->id => [
+            'enabled' => true,
+            'starts_at' => now(),
+        ],
+    ]);
+
+    $discount->channels()->sync([
+        $channel->id => [
+            'enabled' => true,
+            'starts_at' => now()->subHour(),
+        ],
+    ]);
+
+    $discount->discountableConditions()->create([
+        'discountable_type' => $productA->getMorphClass(),
+        'discountable_id' => $productA->id,
+    ]);
+
+    $discount->discountableRewards()->create([
+        'discountable_type' => $productB->getMorphClass(),
+        'discountable_id' => $productB->id,
+        'type' => 'reward',
+    ]);
+
+    $cart->calculate();
+
+    $rewardLines = CartLine::where('cart_id', $cart->id)
+        ->where('purchasable_id', $purchasableB->id)
+        ->get();
+
+    // Three of one thing is one line of three, not three lines of one.
+    expect($rewardLines)->toHaveCount(1);
+    expect($rewardLines->first()->quantity)->toEqual(3);
+});
+
+test('can leave a reward line the shopper added at their own quantity', function () {
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $channel = Channel::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'code' => 'GBP',
+    ]);
+
+    $cart = Cart::factory()->create([
+        'channel_id' => $channel->id,
+        'currency_id' => $currency->id,
+    ]);
+
+    $productA = Product::factory()->create();
+    $productB = Product::factory()->create();
+
+    $purchasableA = ProductVariant::factory()->create([
+        'product_id' => $productA->id,
+    ]);
+    $purchasableB = ProductVariant::factory()->create([
+        'product_id' => $productB->id,
+    ]);
+
+    foreach ([$purchasableA, $purchasableB] as $purchasable) {
+        Price::factory()->create([
+            'price' => 1000, // £10
+            'min_quantity' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => $purchasable->getMorphClass(),
+            'priceable_id' => $purchasable->id,
+        ]);
+    }
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableA->getMorphClass(),
+        'purchasable_id' => $purchasableA->id,
+        'quantity' => 1,
+    ]);
+
+    // The shopper already put the reward product in the cart themselves.
+    $cart->lines()->create([
+        'purchasable_type' => $purchasableB->getMorphClass(),
+        'purchasable_id' => $purchasableB->id,
+        'quantity' => 1,
+    ]);
+
+    $discount = Discount::factory()->create([
+        'type' => BuyXGetY::class,
+        'name' => 'Test Product Discount',
+        'data' => [
+            'min_qty' => 1,
+            'reward_qty' => 3,
+            'automatically_add_rewards' => true,
+        ],
+    ]);
+
+    $discount->customerGroups()->sync([
+        $customerGroup->id => [
+            'enabled' => true,
+            'starts_at' => now(),
+        ],
+    ]);
+
+    $discount->channels()->sync([
+        $channel->id => [
+            'enabled' => true,
+            'starts_at' => now()->subHour(),
+        ],
+    ]);
+
+    $discount->discountableConditions()->create([
+        'discountable_type' => $productA->getMorphClass(),
+        'discountable_id' => $productA->id,
+    ]);
+
+    $discount->discountableRewards()->create([
+        'discountable_type' => $productB->getMorphClass(),
+        'discountable_id' => $productB->id,
+        'type' => 'reward',
+    ]);
+
+    $cart->calculate();
+
+    $rewardLines = CartLine::where('cart_id', $cart->id)
+        ->where('purchasable_id', $purchasableB->id)
+        ->get();
+
+    expect($rewardLines)->toHaveCount(1);
+    expect($rewardLines->first()->quantity)->toEqual(1);
+});


### PR DESCRIPTION
A "buy one, get three free" promotion puts three separate lines in the cart, each
of quantity one, for the same product.

### What happens now

- A reward quantity of three produces three cart lines rather than one line of
  three.
- The cart shows the same product three times over, which reads as a bug to the
  shopper and to whoever is packing the order.
- It scales with the reward quantity: `reward_qty` of ten is ten lines.
- Totals are right, so nothing catches it — only the line count is wrong.

### What should happen

- Three of one product is one line with a quantity of three.

### Why

The loop asks whether the reward is already in the cart before adding it:

```php
$rewardLine = $cart->lines->first(function ($line) use ($purchasable) {
    return $line->purchasable->id == $purchasable->id;
});
```

`$cart->lines` is the loaded collection, and the line built just below is made
with `$cart->lines()->make(...)` and saved — it never joins that collection. So
on the next pass through the loop the check finds nothing again, and builds
another line.

### The fix

Keep the reward lines this run has added, keyed by purchasable, and consult that
alongside `$cart->lines`. A second unit of a reward already added raises the
quantity on that line instead of opening another, and its `subTotal` and `total`
are recalculated from the new quantity so the existing discount cap still
resolves to a fully discounted line.

A line the **shopper** put in the cart is deliberately untouched: it is still
found by the existing check, still discounted, and its quantity is left at
whatever they chose. Only lines this run created accumulate. There is a test for
each of the two paths.

Not changed here: the added lines are still absent from `$cart->lines` for the
rest of the calculation, so later pipeline stages do not see them until the cart
is reloaded. Pushing them into the collection would fix that too, but it changes
what `CalculateTax` and `Calculate` total within the same request — a wider
change than this defect needs, and better judged on its own.

### Tests

`tests/core/Unit/DiscountTypes/BuyXGetYTest.php`:

- **can add a multi quantity reward as a single line** — `reward_qty` of three
  on a qualifying cart. Fails on `1.x` with
  `Failed asserting that actual size 3 matches expected size 1`, and asserts the
  surviving line carries a quantity of three.
- **can leave a reward line the shopper added at their own quantity** — the
  shopper already holds the reward product; their line stays at the quantity they
  chose. Passes before and after, pinning the distinction the fix relies on.