### PR TITLE
Fix hub product option mapping and new variant tax class (1.x)

### DIFF
--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -28,7 +28,7 @@ class MapVariantsToProductOptions
                 $valueDifference = array_diff_assoc($permutation, $variant['values']);
 
                 if (! count($valueDifference)) {
-                    return $variant;
+                    return true;
                 }
 
                 $amountMatched = count($permutation) - count($valueDifference);
@@ -36,12 +36,22 @@ class MapVariantsToProductOptions
                 return $amountMatched == count($variant['values']);
             });
 
-            $variant = $variants[$variantIndex] ?? null;
+            // search() returns false when nothing matches; PHP coerces false to index 0.
+            $variant = $variantIndex === false ? null : ($variants[$variantIndex] ?? null);
 
             $variantId = $variant['id'] ?? null;
             $sku = $variant['sku'] ?? null;
             $copiedFrom = null;
             $shouldFill = true;
+
+            if (! $variant && ! $fillMissing) {
+                $shouldFill = false;
+            }
+
+            // New option combinations still need tax_class_id on insert; copy a sibling.
+            if (! $variant && $fillMissing) {
+                $copiedFrom = collect($variants)->pluck('id')->first();
+            }
 
             if ($variant) {
                 // Does this variant already exist in our permutations?

--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -48,9 +48,9 @@ class MapVariantsToProductOptions
                 $shouldFill = false;
             }
 
-            // New option combinations still need tax_class_id on insert; copy a sibling.
+            // New option combinations still need tax_class_id on insert; copy the oldest sibling.
             if (! $variant && $fillMissing) {
-                $copiedFrom = collect($variants)->pluck('id')->first();
+                $copiedFrom = collect($variants)->min('id');
             }
 
             if ($variant) {

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -402,7 +402,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                     }
 
                     if (empty($variantData['variant_id']) && empty($variantData['copied_id'])) {
-                        $variantData['copied_id'] = $this->record->variants()->value('id');
+                        $variantData['copied_id'] = $this->record->variants()->orderBy('id')->value('id');
                     }
 
                     if (! empty($variantData['copied_id'])) {

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -401,6 +401,10 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                         $basePrice = $variant->basePrices->first();
                     }
 
+                    if (empty($variantData['variant_id']) && empty($variantData['copied_id'])) {
+                        $variantData['copied_id'] = $this->record->variants()->value('id');
+                    }
+
                     if (! empty($variantData['copied_id'])) {
                         $copiedVariant = ProductVariant::find(
                             $variantData['copied_id']

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
@@ -7,8 +7,9 @@ use Lunar\Models\Currency;
 use Lunar\Models\Language;
 use Lunar\Models\Product;
 use Lunar\Models\ProductVariant;
+use Lunar\Tests\Admin\Feature\Filament\TestCase;
 
-uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+uses(TestCase::class)
     ->group('resource.product.widgets');
 
 it('can save newly filled size and colour permutations', function () {

--- a/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
+++ b/tests/admin/Feature/Filament/Resources/ProductResource/Widgets/ProductOptionsWidgetTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use Livewire\Livewire;
+use Lunar\Admin\Actions\Products\MapVariantsToProductOptions;
+use Lunar\Admin\Filament\Resources\ProductResource\Widgets\ProductOptionsWidget;
+use Lunar\Models\Currency;
+use Lunar\Models\Language;
+use Lunar\Models\Product;
+use Lunar\Models\ProductVariant;
+
+uses(\Lunar\Tests\Admin\Feature\Filament\TestCase::class)
+    ->group('resource.product.widgets');
+
+it('can save newly filled size and colour permutations', function () {
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'default' => true,
+        'decimal_places' => 2,
+    ]);
+
+    $product = Product::factory()->create();
+    $variant = ProductVariant::factory()->create([
+        'product_id' => $product->id,
+        'sku' => 'SMALL-RED',
+        'stock' => 4,
+    ]);
+
+    $variant->prices()->create([
+        'price' => 1500,
+        'currency_id' => $currency->id,
+    ]);
+
+    $mapped = collect(MapVariantsToProductOptions::map(
+        [
+            'Size' => [
+                'Small',
+                'Large',
+            ],
+            'Colour' => [
+                'Red',
+                'Blue',
+            ],
+        ],
+        [
+            [
+                'id' => $variant->id,
+                'sku' => 'SMALL-RED',
+                'price' => 15,
+                'stock' => 4,
+                'values' => [
+                    'Size' => 'Small',
+                    'Colour' => 'Red',
+                ],
+            ],
+        ],
+    ))->map(function (array $row) {
+        $row['sku'] = $row['sku'] ?: collect($row['values'])->join('-');
+        $row['values'] = [];
+
+        return $row;
+    })->all();
+
+    $this->asStaff(admin: true);
+
+    Livewire::test(ProductOptionsWidget::class, [
+        'record' => $product->fresh(),
+    ])->set('variants', $mapped)
+        ->callAction('saveVariants')
+        ->assertHasNoErrors();
+
+    $variants = ProductVariant::query()
+        ->where('product_id', $product->id)
+        ->get();
+
+    expect($variants)->toHaveCount(4)
+        ->and($variants->pluck('tax_class_id')->unique()->all())->toBe([$variant->tax_class_id])
+        ->and($variants->pluck('sku'))->toContain('SMALL-RED');
+});
+
+it('can save a new size and colour permutation when copied_id is missing', function () {
+    Language::factory()->create([
+        'default' => true,
+    ]);
+
+    $currency = Currency::factory()->create([
+        'default' => true,
+        'decimal_places' => 2,
+    ]);
+
+    $product = Product::factory()->create();
+    $variant = ProductVariant::factory()->create([
+        'product_id' => $product->id,
+        'sku' => 'SMALL-RED',
+        'stock' => 4,
+    ]);
+
+    $variant->prices()->create([
+        'price' => 1500,
+        'currency_id' => $currency->id,
+    ]);
+
+    $this->asStaff(admin: true);
+
+    Livewire::test(ProductOptionsWidget::class, [
+        'record' => $product->fresh(),
+    ])->set('variants', [
+        [
+            'key' => 'existing',
+            'variant_id' => $variant->id,
+            'copied_id' => null,
+            'sku' => 'SMALL-RED',
+            'price' => 15,
+            'stock' => 4,
+            'values' => [],
+        ],
+        [
+            'key' => 'new',
+            'variant_id' => null,
+            'copied_id' => null,
+            'sku' => 'LARGE-BLUE',
+            'price' => 18,
+            'stock' => 0,
+            'values' => [],
+        ],
+    ])->callAction('saveVariants')
+        ->assertHasNoErrors();
+
+    $created = ProductVariant::query()
+        ->where('product_id', $product->id)
+        ->where('sku', 'LARGE-BLUE')
+        ->first();
+
+    expect($created)->not->toBeNull()
+        ->and($created->tax_class_id)->toBe($variant->tax_class_id)
+        ->and($created->stock)->toBe(0)
+        ->and($created->basePrices->first()?->price->value)->toBe(1800);
+});

--- a/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
+++ b/tests/admin/Unit/Actions/Products/MapVariantsToProductOptionsTest.php
@@ -78,3 +78,118 @@ it('can map variants given three sets of option values', function () {
 
     expect($result)->toHaveCount(4);
 });
+
+it('does not assign the first variant sku to unmatched sparse permutations', function () {
+    $optionValues = [
+        'Size' => [
+            'XS',
+            'L',
+        ],
+        'Colour' => [
+            'Navy',
+            'White',
+        ],
+        'Length' => [
+            'Long',
+            'Short',
+        ],
+        'Fit' => [
+            'Slim',
+        ],
+    ];
+
+    $variants = [
+        [
+            'id' => 1,
+            'sku' => 'TEE-L-NAVY-SHORT',
+            'price' => 0,
+            'stock' => 0,
+            'values' => [
+                'Size' => 'L',
+                'Colour' => 'Navy',
+                'Length' => 'Short',
+                'Fit' => 'Slim',
+            ],
+        ],
+        [
+            'id' => 2,
+            'sku' => 'TEE-XS-WHITE-LONG',
+            'price' => 0,
+            'stock' => 0,
+            'values' => [
+                'Size' => 'XS',
+                'Colour' => 'White',
+                'Length' => 'Long',
+                'Fit' => 'Slim',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: false);
+
+    expect($result)->toHaveCount(2);
+
+    $mappedBySku = collect($result)->keyBy('sku');
+
+    expect($mappedBySku['TEE-L-NAVY-SHORT']['values'])->toBe([
+        'Size' => 'L',
+        'Colour' => 'Navy',
+        'Length' => 'Short',
+        'Fit' => 'Slim',
+    ])->and($mappedBySku['TEE-XS-WHITE-LONG']['values'])->toBe([
+        'Size' => 'XS',
+        'Colour' => 'White',
+        'Length' => 'Long',
+        'Fit' => 'Slim',
+    ]);
+
+    // First cartesian permutation is XS/Navy/Long — must not steal the first variant SKU.
+    expect(
+        collect($result)->contains(fn (array $row) => $row['sku'] === 'TEE-L-NAVY-SHORT'
+            && $row['values']['Size'] === 'XS')
+    )->toBeFalse();
+});
+
+it('keeps unmatched permutations without binding the first variant when fillMissing is enabled', function () {
+    $optionValues = [
+        'Size' => [
+            'Small',
+            'Large',
+        ],
+        'Colour' => [
+            'Red',
+            'Blue',
+        ],
+    ];
+
+    $variants = [
+        [
+            'id' => 10,
+            'sku' => 'SMALL-RED',
+            'price' => 1,
+            'stock' => 5,
+            'values' => [
+                'Size' => 'Small',
+                'Colour' => 'Red',
+            ],
+        ],
+    ];
+
+    $result = MapVariantsToProductOptions::map($optionValues, $variants, fillMissing: true);
+
+    expect($result)->toHaveCount(4);
+
+    $exact = collect($result)->first(
+        fn (array $row) => $row['values'] === ['Size' => 'Small', 'Colour' => 'Red']
+    );
+
+    expect($exact['sku'])->toBe('SMALL-RED')
+        ->and($exact['variant_id'])->toBe(10)
+        ->and($exact['copied_id'])->toBeNull();
+
+    $unmatched = collect($result)
+        ->reject(fn (array $row) => $row['variant_id'] === 10);
+
+    expect($unmatched->pluck('sku')->all())->each->toBeNull();
+    expect($unmatched->pluck('copied_id')->unique()->all())->toBe([10]);
+});


### PR DESCRIPTION
Cherry-pick of #2609 (merged into `1.4`, the Filament v3 line) onto `1.x`, so the fix reaches the Filament v4 line too. Credit to @wychoong for the original fix.

## Summary

1. **Wrong SKU on unmatched permutations.** `collect()->search()` returns `false` when nothing matches, and PHP coerces `$variants[false]` to `$variants[0]`. Sparse matrices could show the first SKU under the wrong option labels. Unmatched rows are no longer bound to that first variant; with `fillMissing: false` they are skipped.
2. **New permutations fail to save.** A newly filled row has no `variant_id`; the bare insert violates `tax_class_id` NOT NULL. The mapper sets `copied_id` from an existing sibling so `saveVariants` can `replicate()` tax class and price, with a fallback in the widget when `copied_id` is missing on save.

On top of the cherry-pick, one refinement: both `copied_id` fallbacks now pick the **oldest sibling** (`min('id')` / `orderBy('id')`) instead of an unordered first row, so which tax class and price a filled-in permutation inherits is deterministic.

Supersedes #2611, which fixes the same mapper bug on `1.x` but leaves the save path crashing for rows with neither `variant_id` nor `copied_id`.

## Test plan
- Cherry-picked unit tests (`MapVariantsToProductOptionsTest`) and Livewire feature test (`ProductOptionsWidgetTest`) included; the touched hunks were byte-identical between `1.4` and `1.x`, so the pick applied cleanly.
- Pint (repo-pinned 1.17.0) passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)