### PR TITLE
Copy the oldest sibling variant deterministically (1.4)

### DIFF
--- a/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
+++ b/packages/admin/src/Actions/Products/MapVariantsToProductOptions.php
@@ -48,9 +48,9 @@ class MapVariantsToProductOptions
                 $shouldFill = false;
             }
 
-            // New option combinations still need tax_class_id on insert; copy a sibling.
+            // New option combinations still need tax_class_id on insert; copy the oldest sibling.
             if (! $variant && $fillMissing) {
-                $copiedFrom = collect($variants)->pluck('id')->first();
+                $copiedFrom = collect($variants)->min('id');
             }
 
             if ($variant) {

--- a/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
+++ b/packages/admin/src/Filament/Resources/ProductResource/Widgets/ProductOptionsWidget.php
@@ -402,7 +402,7 @@ class ProductOptionsWidget extends BaseWidget implements HasActions, HasForms
                     }
 
                     if (empty($variantData['variant_id']) && empty($variantData['copied_id'])) {
-                        $variantData['copied_id'] = $this->record->variants()->value('id');
+                        $variantData['copied_id'] = $this->record->variants()->orderBy('id')->value('id');
                     }
 
                     if (! empty($variantData['copied_id'])) {


### PR DESCRIPTION
Back-port of the refinement that shipped with #2640 on `1.x`, keeping the two lines in parity.

The `copied_id` fallbacks introduced in #2609 picked whichever sibling came first with no ordering guarantee, so which tax class and price a filled-in permutation inherited was undefined. Both call sites now pin to the lowest variant id (the oldest sibling): `min('id')` in the mapper, `orderBy('id')->value('id')` in the widget guard.

No behavioral change for single-variant products; deterministic inheritance for products whose variants differ in tax class or price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)