### PR TITLE
fix(admin): trim whitespace from panel form input

### DIFF
--- a/packages/admin/src/LunarPanelManager.php
+++ b/packages/admin/src/LunarPanelManager.php
@@ -5,6 +5,9 @@ namespace Lunar\Admin;
 use Closure;
 use Filament\Auth\MultiFactor\App\AppAuthentication;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -192,6 +195,11 @@ class LunarPanelManager
         Section::configureUsing(fn (Section $section) => $section->columnSpanFull());
         Grid::configureUsing(fn (Grid $grid) => $grid->columnSpanFull());
         Fieldset::configureUsing(fn (Fieldset $fieldset) => $fieldset->columnSpanFull());
+
+        // Livewire skips the TrimStrings middleware, so trim at the form layer instead.
+        TextInput::configureUsing(fn (TextInput $input) => $input->trim());
+        Textarea::configureUsing(fn (Textarea $textarea) => $textarea->trim());
+        TagsInput::configureUsing(fn (TagsInput $tagsInput) => $tagsInput->trim());
 
         return $this;
     }

--- a/tests/admin/Feature/Filament/Panel/TrimsFormInputTest.php
+++ b/tests/admin/Feature/Filament/Panel/TrimsFormInputTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Livewire\Livewire;
+use Lunar\Admin\Filament\Resources\ProductTypeResource;
+use Lunar\Models\ProductType;
+use Lunar\Tests\Admin\Feature\Filament\TestCase;
+
+uses(TestCase::class)
+    ->group('panel');
+
+/**
+ * Livewire skips Laravel's TrimStrings middleware, so the panel registers
+ * Filament's trim() globally for free-text fields instead.
+ */
+it('configures free-text form fields to trim input', function () {
+    expect(TextInput::make('test')->isTrimmed())->toBeTrue()
+        ->and(Textarea::make('test')->isTrimmed())->toBeTrue()
+        ->and(TagsInput::make('test')->isTrimmed())->toBeTrue();
+});
+
+it('trims whitespace from form input before saving', function () {
+    Livewire::actingAs($this->makeStaff(admin: true), 'staff')
+        ->test(ProductTypeResource\Pages\CreateProductType::class)
+        ->fillForm([
+            'name' => '  Padded Name  ',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(ProductType::class, [
+        'name' => 'Padded Name',
+    ]);
+});


### PR DESCRIPTION
## Problem

Livewire deliberately skips Laravel's `TrimStrings` middleware (`HandleRequests::skipRequestPayloadTamperingMiddleware`) — trimming live-bound payloads mid-request would corrupt component state. The side effect is that values entered through the admin panel are persisted with leading/trailing whitespace intact (e.g. `"  size  "` as an option handle).

Fixes #1664.

## Approach

Filament v4 ships a first-class solution for exactly this ([filamentphp/filament#16706](https://github.com/filamentphp/filament/pull/16706)): a `trim()` method on free-text fields, with the global form documented as the equivalent of the `TrimStrings` middleware. This PR registers it when the Lunar panel boots:

```php
TextInput::configureUsing(fn (TextInput $input) => $input->trim());
Textarea::configureUsing(fn (Textarea $textarea) => $textarea->trim());
TagsInput::configureUsing(fn (TagsInput $tagsInput) => $tagsInput->trim());
```

`configureUsing()` applies down the class hierarchy, so Lunar's own components extending these (`TranslatedText`, `TranslatedTextInput`, `TextInputSelectAffix`, `Tags`) are covered automatically.

This supersedes #2612's sibling PR #2504, which solved the same issue by overriding `setAttribute()` on `BaseModel`. That worked, but applied to every write path (jobs, imports, seeders, third-party packages extending `BaseModel`) rather than just the form input that motivated it — and with 2.x moving the admin to Inertia.js (where `TrimStrings` middleware applies normally), the gap this fixes is specific to the Livewire/Filament admin, so the fix belongs at that layer. Credit to @bpotmalnik for the diagnosis and the original fix, and to @wychoong for suggesting the form-layer approach.

## Out of scope

Translated attribute fields (`attribute_data`) dehydrate as FieldType objects rather than strings, so they aren't trimmed by this change — note they weren't trimmed by the `BaseModel::setAttribute()` approach either (`is_string()` fails for those values on both paths). If trimming translated attributes matters, that's a follow-up in the field-type synthesizers.

## Testing

- Component-level: asserts `TextInput`, `Textarea` and `TagsInput` all report `isTrimmed()` once the panel is registered.
- End-to-end: fills a resource create form with `"  Padded Name  "` through Livewire and asserts the persisted row is trimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)