### PR TITLE
test(stripe): pin StoreChargesTest currency to stop a random flake

### DIFF
--- a/tests/stripe/Unit/Actions/StoreChargesTest.php
+++ b/tests/stripe/Unit/Actions/StoreChargesTest.php
@@ -8,7 +8,13 @@ use Lunar\Tests\Stripe\Utils\CartBuilder;
 uses(TestCase::class);
 
 it('can store successful charge', function () {
-    $cart = CartBuilder::build();
+    // Pin a two-decimal currency: the factory's random faker code can land on
+    // a currency Stripe scales differently (JPY, HUF, ...), which makes the
+    // stored amount diverge from the raw charge fixture amount.
+    $cart = CartBuilder::build(currencyParams: [
+        'code' => 'USD',
+        'decimal_places' => 2,
+    ]);
 
     $order = $cart->createOrder();
 


### PR DESCRIPTION
`CurrencyFactory` uses a random faker currency code with `decimal_places` pinned at 2. Since #2601, `StoreCharges` converts Stripe amounts per-currency, so when faker rolls a code on Stripe's zero-decimal or special lists (JPY, HUF, …) the stored transaction amount legitimately diverges from the raw charge fixture amount — and `StoreChargesTest`'s raw equality assertion fails at random. It just took down an unrelated PR's CI run (#2643's stripe job).

Pin the cart to USD/2dp so the test is deterministic. The per-currency conversion behaviour is already covered by the HUF-pinned tests in `StripePaymentTypeTest` and the unit tests in `StripeManagerTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)