### PR TITLE
fix(shipping): evaluate weight tiers in the method's configured weight_unit

### DIFF
--- a/packages/table-rate-shipping/resources/lang/ar/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/ar/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'الحد الأدنى للوزن',
-                        'helper_text' => 'أدخل الوزن بالكيلوغرام',
+                        'helper_text' => 'أدخل الوزن بوحدة :unit',
                     ],
                     'price' => [
                         'label' => 'السعر',

--- a/packages/table-rate-shipping/resources/lang/bg/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/bg/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Мин. тегло',
-                        'helper_text' => 'Въведете теглото в килограми',
+                        'helper_text' => 'Въведете теглото в :unit',
                     ],
                     'price' => [
                         'label' => 'Цена',

--- a/packages/table-rate-shipping/resources/lang/en/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/en/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Min. Weight',
-                        'helper_text' => 'Enter weight in kilograms',
+                        'helper_text' => 'Enter weight in :unit',
                     ],
                     'price' => [
                         'label' => 'Price',

--- a/packages/table-rate-shipping/resources/lang/es/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/es/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Peso Mín.',
-                        'helper_text' => 'Introduce el peso en kilogramos',
+                        'helper_text' => 'Introduce el peso en :unit',
                     ],
                     'price' => [
                         'label' => 'Precio',

--- a/packages/table-rate-shipping/resources/lang/fa/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/fa/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'حداقل وزن',
-                        'helper_text' => 'وزن را به کیلوگرم وارد کنید',
+                        'helper_text' => 'وزن را به :unit وارد کنید',
                     ],
                     'price' => [
                         'label' => 'قیمت',

--- a/packages/table-rate-shipping/resources/lang/fr/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/fr/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Poids Min.',
-                        'helper_text' => 'Saisir le poids en kilogrammes',
+                        'helper_text' => 'Saisir le poids en :unit',
                     ],
                     'price' => [
                         'label' => 'Prix',

--- a/packages/table-rate-shipping/resources/lang/hr/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/hr/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Min. težina',
-                        'helper_text' => 'Unesite težinu u kilogramima',
+                        'helper_text' => 'Unesite težinu u :unit',
                     ],
                     'price' => [
                         'label' => 'Cijena',

--- a/packages/table-rate-shipping/resources/lang/hu/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/hu/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Min. súly',
-                        'helper_text' => 'Adja meg a súlyt kilogrammban',
+                        'helper_text' => 'Adja meg a súlyt :unit egységben',
                     ],
                     'price' => [
                         'label' => 'Ár',

--- a/packages/table-rate-shipping/resources/lang/mn/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/mn/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Хамгийн бага жин',
-                        'helper_text' => 'Жинг килограммаар оруулна уу',
+                        'helper_text' => 'Жинг :unit-ээр оруулна уу',
                     ],
                     'price' => [
                         'label' => 'Үнэ',

--- a/packages/table-rate-shipping/resources/lang/pl/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/pl/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Min. Waga',
-                        'helper_text' => 'Podaj wagę w kilogramach',
+                        'helper_text' => 'Podaj wagę w :unit',
                     ],
                     'price' => [
                         'label' => 'Cena',

--- a/packages/table-rate-shipping/resources/lang/pt_BR/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/pt_BR/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Peso mín.',
-                        'helper_text' => 'Insira o peso em quilogramas',
+                        'helper_text' => 'Insira o peso em :unit',
                     ],
                     'price' => [
                         'label' => 'Preço',

--- a/packages/table-rate-shipping/resources/lang/ro/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/ro/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Greutate min.',
-                        'helper_text' => 'Introduceți greutatea în kilograme',
+                        'helper_text' => 'Introduceți greutatea în :unit',
                     ],
                     'price' => [
                         'label' => 'Preț',

--- a/packages/table-rate-shipping/resources/lang/tr/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/tr/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'Min. Ağırlık',
-                        'helper_text' => 'Ağırlığı kilogram olarak girin',
+                        'helper_text' => 'Ağırlığı :unit olarak girin',
                     ],
                     'price' => [
                         'label' => 'Fiyat',

--- a/packages/table-rate-shipping/resources/lang/vi/relationmanagers.php
+++ b/packages/table-rate-shipping/resources/lang/vi/relationmanagers.php
@@ -39,7 +39,7 @@ return [
                     ],
                     'min_weight' => [
                         'label' => 'K.lượng T.thiểu',
-                        'helper_text' => 'Nhập trọng lượng theo kilôgam',
+                        'helper_text' => 'Nhập trọng lượng theo :unit',
                     ],
                     'price' => [
                         'label' => 'Giá',

--- a/packages/table-rate-shipping/src/Drivers/ShippingMethods/ShipBy.php
+++ b/packages/table-rate-shipping/src/Drivers/ShippingMethods/ShipBy.php
@@ -71,8 +71,12 @@ class ShipBy implements ShippingRateInterface
         $tier = $subTotal;
 
         if ($chargeBy == 'weight') {
+            // Tiers are stored raw in the method's weight unit; each line's
+            // weight converts from its own purchasable unit.
+            $weightUnit = $shippingMethod->weight_unit ?: 'kg';
+
             $tier = $cart->lines->sum(
-                fn ($line) => $line->purchasable->weight->to('weight.kg')->convert()->getValue() * $line->quantity
+                fn ($line) => $line->purchasable->weight->to("weight.{$weightUnit}")->convert()->getValue() * $line->quantity
             );
         }
 

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource/Pages/ManageShippingRates.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingZoneResource/Pages/ManageShippingRates.php
@@ -122,12 +122,20 @@ class ManageShippingRates extends ManageRelatedRecords
                             : __('lunarpanel.shipping::relationmanagers.shipping_rates.form.prices.repeater.min_spend.label')
                         )
                         ->helperText(fn (Get $get) => static::isWeightCharge($get)
-                            ? __('lunarpanel.shipping::relationmanagers.shipping_rates.form.prices.repeater.min_weight.helper_text')
+                            ? __('lunarpanel.shipping::relationmanagers.shipping_rates.form.prices.repeater.min_weight.helper_text', [
+                                'unit' => static::getShippingWeightUnit($get('../../shipping_method_id')),
+                            ])
                             : null
                         )
                         // Unit symbol — intentionally not translated.
-                        ->suffix(fn (Get $get) => static::isWeightCharge($get) ? 'kg' : null)
+                        ->suffix(fn (Get $get) => static::isWeightCharge($get)
+                            ? static::getShippingWeightUnit($get('../../shipping_method_id'))
+                            : null
+                        )
                         ->numeric()
+                        // Weight tiers are stored as raw integers in the method's
+                        // weight unit — reject decimals instead of truncating them.
+                        ->rules(fn (Get $get) => static::isWeightCharge($get) ? ['integer'] : [])
                         ->required(),
                 ])->afterStateHydrated(
                     static function (Forms\Components\Repeater $component, ?Model $record = null): void {
@@ -228,6 +236,19 @@ class ManageShippingRates extends ManageRelatedRecords
     private static function isWeightCharge(Get $get): bool
     {
         return static::getShippingChargeBy($get('../../shipping_method_id')) === 'weight';
+    }
+
+    private static function getShippingWeightUnit(ShippingMethodContract|int|null $method): string
+    {
+        if (blank($method)) {
+            return 'kg';
+        }
+
+        if (! $method instanceof ShippingMethodContract) {
+            $method = ShippingMethod::find($method);
+        }
+
+        return $method?->weight_unit ?: 'kg';
     }
 
     protected static function saveShippingRate(?ShippingRate $shippingRate = null, array $data = []): void

--- a/tests/shipping/Unit/Drivers/ShippingMethods/ShipByTest.php
+++ b/tests/shipping/Unit/Drivers/ShippingMethods/ShipByTest.php
@@ -581,3 +581,80 @@ test('total cart weight across multiple lines with different units is summed in 
     expect($option)->toBeInstanceOf(ShippingOption::class)
         ->and($option->price->value)->toEqual(400);
 });
+
+test('weight tiers are evaluated in the shipping method configured weight_unit', function () {
+    $currency = Currency::factory()->create(['default' => true]);
+    TaxClass::factory()->create(['default' => true]);
+
+    $shippingZone = ShippingZone::factory()->create(['type' => 'countries']);
+
+    // Grams give merchants sub-kilogram tier precision with raw integer storage.
+    $shippingMethod = ShippingMethod::factory()->create([
+        'driver' => 'ship-by',
+        'data' => ['charge_by' => 'weight'],
+        'weight_unit' => 'g',
+    ]);
+
+    $shippingRate = ShippingRate::factory()->create([
+        'shipping_method_id' => $shippingMethod->id,
+        'shipping_zone_id' => $shippingZone->id,
+    ]);
+
+    $shippingRate->prices()->createMany([
+        ['price' => 1000, 'min_quantity' => 1, 'currency_id' => $currency->id],
+        ['price' => 600, 'min_quantity' => 500, 'currency_id' => $currency->id],
+        ['price' => 200, 'min_quantity' => 1000, 'currency_id' => $currency->id],
+    ]);
+
+    $makeCart = function (array $lines) use ($currency): Cart {
+        $cart = Cart::factory()->create(['currency_id' => $currency->id]);
+
+        foreach ($lines as [$weightValue, $weightUnit]) {
+            $variant = ProductVariant::factory()->create([
+                'weight_value' => $weightValue,
+                'weight_unit' => $weightUnit,
+            ]);
+            $variant->stock = 100;
+
+            Price::factory()->create([
+                'price' => 500,
+                'min_quantity' => 1,
+                'currency_id' => $currency->id,
+                'priceable_type' => $variant->getMorphClass(),
+                'priceable_id' => $variant->id,
+            ]);
+
+            $cart->lines()->create([
+                'purchasable_type' => $variant->getMorphClass(),
+                'purchasable_id' => $variant->id,
+                'quantity' => 1,
+            ]);
+        }
+
+        return $cart->calculate();
+    };
+
+    // 300g cart sits below the 500g tier.
+    $option = (new ShipBy)->resolve(new ShippingOptionRequest(
+        shippingRate: $shippingRate,
+        cart: $makeCart([[0.3, 'kg']]),
+    ));
+    expect($option)->toBeInstanceOf(ShippingOption::class)
+        ->and($option->price->value)->toEqual(1000);
+
+    // A 0.5kg product converts to 500g and matches the 500g tier exactly.
+    $option = (new ShipBy)->resolve(new ShippingOptionRequest(
+        shippingRate: $shippingRate,
+        cart: $makeCart([[0.5, 'kg']]),
+    ));
+    expect($option)->toBeInstanceOf(ShippingOption::class)
+        ->and($option->price->value)->toEqual(600);
+
+    // Mixed units: 0.4kg + 600g = 1000g hits the top tier.
+    $option = (new ShipBy)->resolve(new ShippingOptionRequest(
+        shippingRate: $shippingRate,
+        cart: $makeCart([[0.4, 'kg'], [600.0, 'g']]),
+    ));
+    expect($option)->toBeInstanceOf(ShippingOption::class)
+        ->and($option->price->value)->toEqual(200);
+});


### PR DESCRIPTION
## Problem

Two genuine gaps in weight-based table-rate shipping, diagnosed by @zalito12 in #2514 / #2515:

1. `ShipBy` hardcodes `weight.kg` when summing cart weight, ignoring the `weight_unit` column #2435 added to shipping methods — mixed-unit catalogues and non-kg merchants get wrong tier maths.
2. Weight tiers are raw integers (per #2382's convention), so sub-kilogram thresholds like 2.5 kg can't be expressed — the admin form silently truncates `2.5` to `2`.

## Approach

Keep #2382's raw-integer storage convention (no migration, no data risk) and make the *unit* do the work:

- `ShipBy` converts each line's weight from its own purchasable unit into the method's configured `weight_unit` (default `kg`) before tier matching — mirroring what `ShippingRateResolver` already does for min/max weight constraints.
- A merchant needing sub-kilogram precision configures the method in grams: integer tiers of `500` / `1000` are exact, and existing kg-based methods (null `weight_unit`) behave exactly as before.
- The admin tier form shows the configured unit in the suffix and helper text (all 14 locales updated with a `:unit` placeholder), and rejects decimal weight tiers with a visible validation error instead of silently truncating.

This supersedes #2515, which fixed the same two gaps but by reverting to the ×100 storage scale that #2382 had just migrated away from — without a companion migration, that would have mispriced every existing raw-kg tier. Credit to @zalito12 for identifying both underlying issues.

## Testing

- New driver test: tiers evaluated in grams, exact-boundary matching, and a mixed-unit cart (0.4 kg + 600 g) hitting the right tier.
- Existing weight tests untouched and green — full shipping suite 99 passed; Pint and PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)