### PR TITLE
Cache subTotalDiscounted on the cart (#2229)

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -77,6 +77,7 @@ class Cart extends BaseModel implements Contracts\Cart
      */
     public $cachableProperties = [
         'subTotal',
+        'subTotalDiscounted',
         'shippingSubTotal',
         'shippingTaxTotal',
         'shippingTotal',

--- a/tests/core/Unit/Models/CartTest.php
+++ b/tests/core/Unit/Models/CartTest.php
@@ -829,6 +829,77 @@ test('can create a discount breakdown', function () {
     expect($cart->discountBreakdown->first()->price->value)->toBe(10);
 });
 
+test('caches subTotalDiscounted for the same request', function () {
+    $currency = Currency::factory()->create();
+    $channel = Channel::factory()->create();
+
+    $customerGroup = CustomerGroup::factory()->create([
+        'default' => true,
+    ]);
+
+    $discount = Discount::factory()->create([
+        'type' => AmountOff::class,
+        'name' => 'Test Coupon',
+        'coupon' => 'valid-coupon',
+        'data' => [
+            'fixed_value' => false,
+            'percentage' => 10,
+        ],
+    ]);
+
+    $discount->channels()->sync([
+        $channel->id => [
+            'enabled' => true,
+            'starts_at' => now(),
+        ],
+    ]);
+
+    $discount->customerGroups()->sync([
+        $customerGroup->id => [
+            'enabled' => true,
+            'visible' => true,
+            'starts_at' => now(),
+        ],
+    ]);
+
+    $cart = Cart::create([
+        'currency_id' => $currency->id,
+        'channel_id' => $channel->id,
+    ]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->coupon_code = 'valid-coupon';
+
+    $cart->calculate();
+
+    expect($cart->subTotal->value)->toBe(100);
+    expect($cart->subTotalDiscounted->value)->toBe(90);
+
+    // Disable the discount without recalculating - a fresh fetch of the
+    // cart within the same request should still see the previously
+    // calculated, cached value rather than an uncalculated one.
+    $discount->channels()->sync([]);
+
+    $fresh = $cart->fresh();
+
+    expect($fresh->subTotalDiscounted->value)->toBe(90);
+});
+
 test('can validate fingerprint', function () {
     $currency = Currency::factory()->create();
     $channel = Channel::factory()->create();


### PR DESCRIPTION
Closes #2229.

`Cart::$cachableProperties` lists the dynamic totals that get cached in Blink for the rest of the request, but `subTotalDiscounted` was never added to it even though `Calculate` sets it every time the cart is calculated. So a fresh fetch of the cart within the same request (e.g. via `refresh()`/`retrieved`) restores `subTotal`, `total`, etc. from the cache but leaves `subTotalDiscounted` uncalculated, forcing a full recalculation just to get that one property.

Added `subTotalDiscounted` next to `subTotal` in the list and wrote a test that applies a coupon, calculates the cart, then disables the coupon and fetches a fresh instance of the same cart - it still sees the originally calculated discounted subtotal rather than an uncalculated one.

I also looked at `shippingBreakdown`, which has the same gap, but caching it exposes a pre-existing bug in `ApplyShipping`'s guard against re-setting the shipping address totals (`can get same draft order when cart does not change` starts failing). That felt out of scope for this fix, so I left it out and kept this PR to the one property the issue pointed at.

Ran `vendor/bin/pest tests/core/Unit/Models/CartTest.php` locally, all 32 pass (1 pre-existing skip).
