### PR TITLE
Reload nested cart relations after refresh (#2222)

### DIFF
--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -398,6 +398,23 @@ class Cart extends BaseModel implements Contracts\Cart
         return $this->calculate(force: true);
     }
 
+    /**
+     * Refresh the cart and reload the relations used during calculation.
+     *
+     * Eloquent's refresh() only reloads relations that are already loaded,
+     * and only one level deep, so nested relations configured in
+     * `lunar.cart.eager_load` (e.g. `lines.purchasable.prices.currency`) can
+     * end up only partially loaded after a refresh. Reloading them
+     * explicitly avoids a lazy load being triggered the next time the cart
+     * is calculated.
+     */
+    public function refreshForCalculation(): Cart
+    {
+        return $this->refresh()->load(
+            config('lunar.cart.eager_load', [])
+        );
+    }
+
     public function isCalculated(): bool
     {
         return ! blank($this->total) && $this->lines->every(
@@ -423,7 +440,7 @@ class Cart extends BaseModel implements Contracts\Cart
         return app(
             config('lunar.cart.actions.add_to_cart', AddOrUpdatePurchasable::class)
         )->execute($this, $purchasable, $quantity, $meta)
-            ->then(fn () => $refresh ? $this->refresh()->recalculate() : $this);
+            ->then(fn () => $refresh ? $this->refreshForCalculation()->recalculate() : $this);
     }
 
     public function addLines(iterable $lines): Cart
@@ -439,7 +456,7 @@ class Cart extends BaseModel implements Contracts\Cart
             });
         });
 
-        return $this->refresh()->recalculate();
+        return $this->refreshForCalculation()->recalculate();
     }
 
     public function remove(int $cartLineId, bool $refresh = true): Cart
@@ -454,7 +471,7 @@ class Cart extends BaseModel implements Contracts\Cart
         return app(
             config('lunar.cart.actions.remove_from_cart', RemovePurchasable::class)
         )->execute($this, $cartLineId)
-            ->then(fn () => $refresh ? $this->refresh()->recalculate() : $this);
+            ->then(fn () => $refresh ? $this->refreshForCalculation()->recalculate() : $this);
     }
 
     /**
@@ -474,7 +491,7 @@ class Cart extends BaseModel implements Contracts\Cart
         return app(
             config('lunar.cart.actions.update_cart_line', UpdateCartLine::class)
         )->execute($cartLineId, $quantity, $meta)
-            ->then(fn () => $refresh ? $this->refresh()->recalculate() : $this);
+            ->then(fn () => $refresh ? $this->refreshForCalculation()->recalculate() : $this);
     }
 
     public function updateLines(Collection $lines): Cart
@@ -490,14 +507,14 @@ class Cart extends BaseModel implements Contracts\Cart
             });
         });
 
-        return $this->refresh()->recalculate();
+        return $this->refreshForCalculation()->recalculate();
     }
 
     public function clear(): Cart
     {
         $this->lines()->delete();
 
-        return $this->refresh()->recalculate();
+        return $this->refreshForCalculation()->recalculate();
     }
 
     /**
@@ -518,7 +535,7 @@ class Cart extends BaseModel implements Contracts\Cart
         return app(
             config('lunar.cart.actions.associate_user', AssociateUser::class)
         )->execute($this, $user, $policy)
-            ->then(fn () => $refresh ? $this->refresh()->recalculate() : $this);
+            ->then(fn () => $refresh ? $this->refreshForCalculation()->recalculate() : $this);
     }
 
     public function setCustomer(Customer $customer): Cart
@@ -533,7 +550,7 @@ class Cart extends BaseModel implements Contracts\Cart
 
         $this->customer()->associate($customer)->save();
 
-        return $this->refresh()->recalculate();
+        return $this->refreshForCalculation()->recalculate();
     }
 
     public function addAddress(array|Addressable $address, string $type, bool $refresh = true): Cart
@@ -549,7 +566,7 @@ class Cart extends BaseModel implements Contracts\Cart
         return app(
             config('lunar.cart.actions.add_address', AddAddress::class)
         )->execute($this, $address, $type)
-            ->then(fn () => $refresh ? $this->refresh()->recalculate() : $this);
+            ->then(fn () => $refresh ? $this->refreshForCalculation()->recalculate() : $this);
     }
 
     public function setShippingAddress(array|Addressable $address, bool $clearTaxZone = true): Cart
@@ -578,7 +595,7 @@ class Cart extends BaseModel implements Contracts\Cart
         return app(
             config('lunar.cart.actions.set_shipping_option', SetShippingOption::class)
         )->execute($this, $option)
-            ->then(fn () => $refresh ? $this->refresh()->recalculate() : $this);
+            ->then(fn () => $refresh ? $this->refreshForCalculation()->recalculate() : $this);
     }
 
     public function getShippingOption(): ?ShippingOption
@@ -597,7 +614,7 @@ class Cart extends BaseModel implements Contracts\Cart
         bool $allowMultipleOrders = false,
         ?int $orderIdToUpdate = null
     ): Order {
-        $cart = $this->refresh()->recalculate();
+        $cart = $this->refreshForCalculation()->recalculate();
 
         foreach (config('lunar.cart.validators.order_create', [
             ValidateCartForOrderCreation::class,
@@ -707,6 +724,6 @@ class Cart extends BaseModel implements Contracts\Cart
 
         $this->save();
 
-        return $this->refresh()->recalculate();
+        return $this->refreshForCalculation()->recalculate();
     }
 }

--- a/tests/core/Unit/Models/CartTest.php
+++ b/tests/core/Unit/Models/CartTest.php
@@ -1360,3 +1360,76 @@ test('can retrieve cart lines in ascending id order', function () {
     expect($cart->load('lines')->lines->pluck('id')->all())
         ->toBe($expectedOrder);
 });
+
+test('refreshing the cart for calculation reloads nested relations dropped by a plain refresh', function () {
+    // Regression test for #2222: adding a second product to a cart in the
+    // same request used to throw a LazyLoadingException. Cart::add(),
+    // Cart::remove() etc. all called $this->refresh() before recalculating,
+    // but Eloquent's refresh() only reloads relations that are already
+    // loaded, and only one level deep. So a nested relation configured in
+    // lunar.cart.eager_load, such as lines.purchasable.prices, ended up
+    // dropped after a refresh and got lazy-loaded the next time the cart
+    // was calculated.
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasable = ProductVariant::factory()->create(['stock' => 1]);
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $purchasable->getMorphClass(),
+        'priceable_id' => $purchasable->id,
+    ]);
+
+    $cart->lines()->create([
+        'purchasable_type' => $purchasable->getMorphClass(),
+        'purchasable_id' => $purchasable->id,
+        'quantity' => 1,
+    ]);
+
+    $cart->load(config('lunar.cart.eager_load'));
+
+    // A plain Eloquent refresh() drops the nested relations.
+    $cart->refresh();
+    expect($cart->lines->first()->relationLoaded('purchasable'))->toBeFalse();
+
+    // refreshForCalculation() reapplies the full eager_load config, so the
+    // nested relations survive the refresh.
+    $refreshed = $cart->refreshForCalculation();
+    $line = $refreshed->lines->first();
+
+    expect($line->relationLoaded('purchasable'))->toBeTrue()
+        ->and($line->purchasable->relationLoaded('prices'))->toBeTrue()
+        ->and($line->purchasable->prices->first()->relationLoaded('currency'))->toBeTrue();
+});
+
+test('can add multiple purchasables to a cart without triggering lazy loading', function () {
+    $currency = Currency::factory()->create();
+
+    $cart = Cart::factory()->create([
+        'currency_id' => $currency->id,
+    ]);
+
+    $purchasableA = ProductVariant::factory()->create(['stock' => 1]);
+    $purchasableB = ProductVariant::factory()->create(['stock' => 1]);
+
+    foreach ([$purchasableA, $purchasableB] as $purchasable) {
+        Price::factory()->create([
+            'price' => 100,
+            'min_quantity' => 1,
+            'currency_id' => $currency->id,
+            'priceable_type' => $purchasable->getMorphClass(),
+            'priceable_id' => $purchasable->id,
+        ]);
+    }
+
+    $cart->add($purchasableA, 1);
+    $cart->add($purchasableB, 1);
+
+    expect($cart->lines)->toHaveCount(2);
+})->throwsNoExceptions();


### PR DESCRIPTION
Closes #2222.

The reporter's own diagnosis in the issue was spot on: `Cart::add()`, `remove()`, `updateLine()` and the other cart mutators all call `$this->refresh()` before recalculating, and Eloquent's `refresh()` only reloads relations that are already loaded, one level deep. So after the first add, `lines.purchasable.prices` (and the rest of the nested `lunar.cart.eager_load` config) gets dropped down to just `lines`, and the next calculation lazy-loads it. With lazy loading disabled that's the `LazyLoadingException` from adding a second product.

I added `Cart::refreshForCalculation()`, which refreshes the cart and then reapplies the full `eager_load` config, and swapped it in everywhere the old `refresh()->recalculate()` pattern was used. Made it public since it's a reasonable thing for anyone building custom cart flows to reuse.

I built on the failing test from #2221 (closed) rather than duplicating that diagnostic work — added a regression test that asserts the nested relations survive a refresh, plus the two-different-products-in-one-request scenario from that PR.

One thing worth flagging: I deliberately kept this scoped to the refresh mechanism the issue actually describes. While testing with `Model::preventLazyLoading()` turned on globally, adding a second product still eventually hits separate, unrelated lazy loads a few frames deeper in the pricing/tax calculation (`ProductVariant::taxClass`, then `TaxClass::taxRateAmounts`, then further into discounts). That matches what came up in #2221's thread - alecritson noted supporting `preventLazyLoading` app-wide would need a rethink of how pricing works, and closed that PR rather than patch around it. This PR doesn't attempt that; it just fixes the specific refresh bug reported here.

Ran `./vendor/bin/pint` and the full `core` test suite locally (Pest, sqlite) - all cart tests pass, 584 passed overall, the only failures are pre-existing environment gaps unrelated to this change (missing GD extension in my local PHP build, hit by `MediaObserverTest` and `HasMediaTraitTest`).
