### PR TITLE
fix(core): accept DateTimeImmutable in scheduling and scope methods

### DIFF
--- a/packages/core/src/Base/Traits/CanScheduleAvailability.php
+++ b/packages/core/src/Base/Traits/CanScheduleAvailability.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Base\Traits;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Lunar\Exceptions\SchedulingException;
@@ -22,8 +22,8 @@ trait CanScheduleAvailability
     protected function schedule(
         Relation $relation,
         mixed $models,
-        ?DateTime $starts = null,
-        ?DateTime $ends = null,
+        ?DateTimeInterface $starts = null,
+        ?DateTimeInterface $ends = null,
         array $pivotData = []
     ): void {
         // Convert to collection if it's an array

--- a/packages/core/src/Base/Traits/HasChannels.php
+++ b/packages/core/src/Base/Traits/HasChannels.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Base\Traits;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -51,7 +51,7 @@ trait HasChannels
         ])->withTimestamps();
     }
 
-    public function scheduleChannel($channel, ?DateTime $startsAt = null, ?DateTime $endsAt = null)
+    public function scheduleChannel($channel, ?DateTimeInterface $startsAt = null, ?DateTimeInterface $endsAt = null)
     {
         if ($channel instanceof Model) {
             $channel = collect([$channel]);
@@ -94,7 +94,7 @@ trait HasChannels
      * @param  Builder  $query
      * @return Builder
      */
-    public function scopeChannel($query, ChannelContract|iterable|null $channel = null, ?DateTime $startsAt = null, ?DateTime $endsAt = null)
+    public function scopeChannel($query, ChannelContract|iterable|null $channel = null, ?DateTimeInterface $startsAt = null, ?DateTimeInterface $endsAt = null)
     {
         if (blank($channel)) {
             return $query;

--- a/packages/core/src/Base/Traits/HasCustomerGroups.php
+++ b/packages/core/src/Base/Traits/HasCustomerGroups.php
@@ -2,7 +2,7 @@
 
 namespace Lunar\Base\Traits;
 
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -50,8 +50,8 @@ trait HasCustomerGroups
      */
     public function scheduleCustomerGroup(
         $models,
-        ?DateTime $starts = null,
-        ?DateTime $ends = null,
+        ?DateTimeInterface $starts = null,
+        ?DateTimeInterface $ends = null,
         array $pivotData = []
     ) {
         $this->schedule(
@@ -94,7 +94,7 @@ trait HasCustomerGroups
     /**
      * Apply customer group scope.
      */
-    public function applyCustomerGroupScope(Builder $query, Collection $groupIds, DateTime $startsAt, DateTime $endsAt): Builder
+    public function applyCustomerGroupScope(Builder $query, Collection $groupIds, DateTimeInterface $startsAt, DateTimeInterface $endsAt): Builder
     {
         return $query->whereHas('customerGroups', function ($relation) use ($groupIds, $startsAt, $endsAt) {
             $relation->whereIn(
@@ -120,7 +120,7 @@ trait HasCustomerGroups
      * @param  CustomerGroupContract|string  $customerGroup
      * @return Builder
      */
-    public function scopeCustomerGroup($query, CustomerGroupContract|iterable|null $customerGroup = null, ?DateTime $startsAt = null, ?DateTime $endsAt = null)
+    public function scopeCustomerGroup($query, CustomerGroupContract|iterable|null $customerGroup = null, ?DateTimeInterface $startsAt = null, ?DateTimeInterface $endsAt = null)
     {
         if (blank($customerGroup)) {
             return $query;

--- a/tests/core/Unit/Base/Traits/HasChannelsTest.php
+++ b/tests/core/Unit/Base/Traits/HasChannelsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Models\Channel;
 use Lunar\Models\Product;
@@ -94,4 +95,26 @@ test('can scope results to a channel', function () {
     expect(Product::channel($channelA)->get())->toHaveCount(0);
 
     expect(Product::channel($channelA, $startsAt, $endsAt)->get())->toHaveCount(1);
+});
+
+test('can schedule and scope using immutable dates', function () {
+    $channel = Channel::factory()->create();
+
+    $product = Product::factory()->create();
+
+    $startsAt = CarbonImmutable::now()->addDay();
+    $endsAt = CarbonImmutable::now()->addDays(2);
+
+    $product->scheduleChannel($channel, $startsAt, $endsAt);
+
+    $this->assertDatabaseHas($product->channels()->getTable(), [
+        'channel_id' => $channel->id,
+        'channelable_type' => $product->getMorphClass(),
+        'channelable_id' => $product->id,
+        'starts_at' => $startsAt,
+        'ends_at' => $endsAt,
+        'enabled' => 1,
+    ]);
+
+    expect(Product::channel($channel, $startsAt, $endsAt)->get())->toHaveCount(1);
 });

--- a/tests/core/Unit/Base/Traits/HasCustomerGroupsTest.php
+++ b/tests/core/Unit/Base/Traits/HasCustomerGroupsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Lunar\Exceptions\SchedulingException;
 use Lunar\Models\Channel;
@@ -239,6 +240,29 @@ test('can scope results to a customer group', function () {
     expect(Product::customerGroup($groupA)->get())->toHaveCount(0);
 
     expect(Product::customerGroup($groupA, $startsAt, $endsAt)->get())->toHaveCount(1);
+});
+
+test('can schedule and scope using immutable dates', function () {
+    $group = CustomerGroup::factory()->create();
+
+    $product = Product::factory()->create();
+
+    $startsAt = CarbonImmutable::now()->addDay();
+    $endsAt = CarbonImmutable::now()->addDays(2);
+
+    $product->scheduleCustomerGroup($group, $startsAt, $endsAt);
+
+    $this->assertDatabaseHas(
+        'lunar_customer_group_product',
+        [
+            'customer_group_id' => $group->id,
+            'starts_at' => $startsAt,
+            'ends_at' => $endsAt,
+            'enabled' => 1,
+        ],
+    );
+
+    expect(Product::customerGroup($group, $startsAt, $endsAt)->get())->toHaveCount(1);
 });
 
 test('customer groups are synced on model creation', function () {


### PR DESCRIPTION
Backport of #2594 to `1.x`. Supersedes #2533.

## Problem

Apps that set `Date::use(CarbonImmutable::class)` get `CarbonImmutable` from `now()`, which is **not** a `DateTime` subclass. Any cart/discount calculation then throws:

```
TypeError: Product::applyCustomerGroupScope(): Argument #3 ($startsAt) must be of type DateTime, Carbon\CarbonImmutable given
```

This needs no unusual usage — `scopeCustomerGroup()` defaults its dates to `now()` internally, so simply viewing a published product's edit page is enough (see #2524).

## Fix

Widen the `DateTime` parameter typehints to `DateTimeInterface` across the three affected traits — the same change 2.x shipped in #2594:

| Trait | Sites |
|---|---|
| `Base/Traits/HasCustomerGroups.php` | `scheduleCustomerGroup()`, `applyCustomerGroupScope()`, `scopeCustomerGroup()` |
| `Base/Traits/HasChannels.php` | `scheduleChannel()`, `scopeChannel()` |
| `Base/Traits/CanScheduleAvailability.php` | `schedule()` |

## Why widen rather than coerce

#2533 fixed the same issue by calling `->toDateTime()` on the internal `now()` defaults. That fixes the reported symptom but not the cause:

- It leaves the caller-facing hints narrow, so `scopeCustomerGroup($group, CarbonImmutable::now())` still throws. Only a signature change fixes that.
- It silently changes the runtime type handed to `applyCustomerGroupScope()` from `Carbon` to native `DateTime`, so an override calling any Carbon method (`->isPast()`, `->diffForHumans()`) breaks at runtime rather than at load.
- It covers 1 of 3 affected traits, leaving `scopeChannel()`/`scheduleChannel()` broken.

Keeping `1.x` and `2.x` identically shaped here also avoids the two branches diverging again.

## Breaking change assessment

Widening a parameter type is contravariant, so:

- **All existing call sites keep working.** Anything passing `DateTime`/`Carbon` still type-checks.
- **Behaviourally inert.** These dates are only ever used as query bindings and pivot values; nothing mutates a parameter. Laravel matches on `DateTimeInterface` (`Connection::prepareBindings()`), so `CarbonImmutable` is formatted identically.
- **No contract changes.** None of these methods are declared in `Models/Contracts`.

The one break vector is a subclass of `Product`/`Discount`/`Collection` that *overrides* one of these six methods re-declaring `DateTime` — PHP fatals at class load with a message naming the fix. None of these are documented extension points and nothing in the repo overrides them, but it's worth a release note:

> `DateTime` parameter hints on the channel/customer-group scope and scheduling traits are now `DateTimeInterface`. If you override these methods in a custom model, widen your signature to match.

Landing inside the `1.5.0` beta cycle rather than as a patch on a shipped minor.

## Tests

Adds the two regression tests from #2594, passing `CarbonImmutable` into the schedule + scope methods of both traits. Both reproduce the issue on `1.x` before the fix:

```
FAILED  HasChannelsTest > can schedule and scope using immutable dates
  TypeError: Product::scheduleChannel(): Argument #2 ($startsAt) must be of type ?DateTime, Carbon\CarbonImmutable given

FAILED  HasCustomerGroupsTest > can schedule and scope using immutable dates
  TypeError: Product::scheduleCustomerGroup(): Argument #2 ($starts) must be of type ?DateTime, Carbon\CarbonImmutable given
```

After: `594 passed, 1 skipped` across `tests/core`. Pint and PHPStan clean.

Original report and `->toDateTime()` fix by @kevinjbecker in #2533.

Fixes #2524

🤖 Generated with [Claude Code](https://claude.com/claude-code)