### PR TITLE
fix(upgrade): add product_associations.sort reconcile step

### DIFF
--- a/packages/upgrade/database/migrations/2026_06_01_000015_add_product_association_sort.php
+++ b/packages/upgrade/database/migrations/2026_06_01_000015_add_product_association_sort.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Lunar\Core\Database\Migration;
+
+/**
+ * v1 → v2 upgrade data step (spec 0057): add `product_associations.sort`.
+ *
+ * v2 gives product associations an explicit, drag-reorderable position, and
+ * `Product::associations()` orders by it (`->orderBy('sort')->orderBy('id')`).
+ * The create-table baseline adds the column for fresh installs, but no upgrade
+ * step added it for existing databases — so on an upgraded store every read of
+ * the relation (opening a product in the panel, resolving cross-sells on the
+ * storefront) fails with `SQLSTATE[42S22] Unknown column 'sort'`. Existing rows
+ * take the column default (0), keeping their current order until a merchant
+ * reorders them.
+ *
+ * Guarded so re-runs and already-v2 databases are no-ops. There is no `down()`:
+ * upgrade-package data migrations are one-way — recover from a backup if an
+ * upgrade fails rather than attempting to reverse a data move.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $table = $this->prefix.'product_associations';
+
+        if (! Schema::hasTable($table) || Schema::hasColumn($table, 'sort')) {
+            return;
+        }
+
+        Schema::table($table, function ($blueprint) {
+            $blueprint->unsignedInteger('sort')->default(0);
+        });
+    }
+};

--- a/packages/upgrade/database/migrations/2026_06_01_000016_add_product_association_sort.php
+++ b/packages/upgrade/database/migrations/2026_06_01_000016_add_product_association_sort.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Lunar\Core\Database\Migration;
 
 /**
- * v1 → v2 upgrade data step (spec 0057): add `product_associations.sort`.
+ * v1 → v2 upgrade data step: add `product_associations.sort`.
  *
  * v2 gives product associations an explicit, drag-reorderable position, and
  * `Product::associations()` orders by it (`->orderBy('sort')->orderBy('id')`).

--- a/tests/upgrade/Feature/AddProductAssociationSortTest.php
+++ b/tests/upgrade/Feature/AddProductAssociationSortTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Tests\Upgrade\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * Isolated prefix so this stands up its own throwaway schema without touching
+ * the shared lunar_* tables.
+ */
+const ASSOC_SORT_UPG_PREFIX = 'upgassoc_';
+
+beforeEach(function () {
+    config(['lunar.database.table_prefix' => ASSOC_SORT_UPG_PREFIX]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists(ASSOC_SORT_UPG_PREFIX.'product_associations');
+});
+
+function productAssociationSortMigration(): object
+{
+    $path = glob(dirname(__DIR__, 3).'/packages/upgrade/database/migrations/*add_product_association_sort.php');
+
+    return require $path[0];
+}
+
+/**
+ * Stand up the v1-shaped `product_associations` table: no `sort` column.
+ */
+function simulateV1ProductAssociationRows(): void
+{
+    Schema::create(ASSOC_SORT_UPG_PREFIX.'product_associations', function (Blueprint $table) {
+        $table->id();
+        $table->foreignId('product_parent_id');
+        $table->foreignId('product_target_id');
+        $table->string('type');
+        $table->timestamps();
+    });
+
+    DB::table(ASSOC_SORT_UPG_PREFIX.'product_associations')->insert([
+        ['id' => 1, 'product_parent_id' => 1, 'product_target_id' => 2, 'type' => 'cross-sell', 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 2, 'product_parent_id' => 1, 'product_target_id' => 3, 'type' => 'up-sell', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+}
+
+test('it adds the sort column and defaults existing rows to zero', function () {
+    simulateV1ProductAssociationRows();
+
+    productAssociationSortMigration()->up();
+
+    $table = ASSOC_SORT_UPG_PREFIX.'product_associations';
+
+    expect(Schema::hasColumn($table, 'sort'))->toBeTrue()
+        ->and(DB::table($table)->where('sort', 0)->count())->toBe(2);
+});
+
+test('it is a no-op when the sort column already exists', function () {
+    simulateV1ProductAssociationRows();
+
+    productAssociationSortMigration()->up();
+
+    $before = DB::table(ASSOC_SORT_UPG_PREFIX.'product_associations')->orderBy('id')->get();
+
+    productAssociationSortMigration()->up();
+
+    expect(DB::table(ASSOC_SORT_UPG_PREFIX.'product_associations')->orderBy('id')->get())->toEqual($before);
+});


### PR DESCRIPTION
## Summary

Fixes #2649 . Adds the missing `lunar:upgrade` step for `product_associations.sort`.

v2 gave product associations an explicit, drag-reorderable position: #2578 added a `sort` column to the `product_associations` create-table baseline and made `Product::associations()` order by it (`->orderBy('sort')->orderBy('id')`). But that change touched only `packages/core` and shipped no upgrade migration — so on any database created before it, the column is absent, and every read of the relation (opening a product in the admin panel, resolving cross-/up-sells on the storefront) throws `SQLSTATE[42S22] Unknown column 'sort' in 'order clause'`.

## Changes

- Adds `packages/upgrade/database/migrations/2026_06_01_000015_add_product_association_sort.php`. It adds `product_associations.sort` (`unsignedInteger('sort')->default(0)`) to match the create-table baseline, so the upgraded schema matches a fresh install.

- Existing rows take the column default (`0`), preserving their current order until a merchant reorders them.

- Guarded on the presence of the table and the absence of the `sort` column, so re-runs and already-v2 databases are no-ops.


## Tests

Adds `tests/upgrade/Feature/AddProductAssociationSortTest.php`: stands up a v1-shaped `product_associations` table (no `sort`), asserts the migration adds the column and defaults existing rows to `0`, plus a no-op case when the column already exists.
