### PR TITLE
fix(tests): isolate the media disk per parallel worker

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Lunar\Tests;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 use function Orchestra\Testbench\after_resolving;
@@ -11,6 +12,8 @@ use function Orchestra\Testbench\default_migration_path;
 class TestCase extends BaseTestCase
 {
     private static bool $databasePrepared = false;
+
+    private static bool $storagePrepared = false;
 
     protected function setUp(): void
     {
@@ -21,11 +24,34 @@ class TestCase extends BaseTestCase
     {
         Model::preventLazyLoading();
 
+        $this->configureStorage($app);
+
         match (env('DB_DRIVER', 'sqlite')) {
             'mysql' => $this->configureMysql($app),
             'pgsql' => $this->configurePgsql($app),
             default => $this->configureSqlite($app),
         };
+    }
+
+    // Media tests write real files, and media ids restart at 1 in every worker's
+    // database — so on a shared root one worker deleting `public/1` can fail
+    // another worker's upload mid-write. Give each worker its own root.
+    private function configureStorage($app): void
+    {
+        $root = sys_get_temp_dir().'/lunar-test-storage-'.$this->workerToken();
+        $filesystem = new Filesystem;
+
+        // Once per process, so a previous run's files can't leak into assertions.
+        if (! static::$storagePrepared) {
+            $filesystem->deleteDirectory($root);
+            static::$storagePrepared = true;
+        }
+
+        $filesystem->ensureDirectoryExists($root.'/public');
+        $filesystem->ensureDirectoryExists($root.'/private');
+
+        $app['config']->set('filesystems.disks.public.root', $root.'/public');
+        $app['config']->set('filesystems.disks.local.root', $root.'/private');
     }
 
     private function configureSqlite($app): void


### PR DESCRIPTION
Fixes the flaky `core` suite failure currently red on #2654, which has nothing to do with that PR.

## The failure

```
FAILED  Tests\core\Unit\Actions\Media\UpdateMediaTest… DiskCannotBeAccessed
Disk named `public` cannot be accessed
  at tests/core/Unit/Actions/Media/UpdateMediaTest.php:17
```

Only one of the two `core` jobs failed, and only on that run — `2.x` itself was green an hour earlier on the same code. So it's a race, not a regression.

## Why it happens

Media tests write **real** files. Nothing calls `Storage::fake()`, so `addMedia()` goes to Testbench's `public` disk, rooted at the one shared `vendor/orchestra/testbench-core/laravel/storage/app/public`. Every parallel worker uses that same path.

Media ids restart at 1 in each worker's own SQLite database, so the directory names collide across processes. Two tests in the *same* suite fight over `public/1`:

- `DeleteMediaTest` — `DeleteMedia` on media `1`, which has medialibrary remove `public/1`
- `UpdateMediaTest` — `beforeEach` adds media `1`, writing `public/1/one.jpg`

When the `deleteDirectory` lands between the writer's `mkdir` and its write, the local adapter can't write. The `public` disk ships `'throw' => false`, so `put()` returns `false` rather than raising, and medialibrary maps that to `DiskCannotBeAccessed`.

Measured, not assumed — two processes, one writing and one deleting the same directory through Laravel's local disk:

```
deleter: put() failures = 0
writer:  put() failures = 18     (of 4000)
```

A ~0.5% per-write failure rate across a suite with several media tests is exactly the "fails once a day" shape we're seeing. CI runs 4 processes; locally paratest uses 10, so it'll bite more often as the suite grows.

## The fix

Root the `public` and `local` disks at a per-worker temp directory, mirroring the per-worker SQLite file `tests/TestCase.php` already sets up for the same reason. Workers can no longer see each other's files, so the collision can't occur.

Cleared once per process, so a stale file from a previous run can't leak into an assertion either — same treatment the SQLite file already gets.

Side benefit: the suite stops leaving numbered media directories inside `vendor/`. Before this, `storage/app/public` accumulated `1/ 2/ 3/ 4/` after a run.

## Why not `Storage::fake()`

`Storage::fake('public')` roots at `storage/framework/testing/disks/public` — also a single shared path, and it *deletes that directory* on every call. Under parallel workers that trades this race for a worse one. Fixing the root in the base `TestCase` covers every suite at once and needs no per-test opt-in.

## Verified

All suites, parallel, as CI runs them: `core` (1213), `admin` (255), `panel` (745), `filament` (68), `shipping` (98), `stripe` (40), `search` (28), `upgrade` (83), `demo-data` (31) — all passing. Pint and PHPStan clean.

Confirmed the disk actually moves: after a media run, `vendor/…/storage/app/public` holds only its `.gitignore`, and the media directories appear under the per-worker temp root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)