### PR TITLE
Add flat-rate and free-shipping options to table-rate shipping method drivers (#2617)

### DIFF
--- a/packages/table-rate-shipping/resources/lang/ar/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/ar/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'قياسي',
                 'collection' => 'استلام من المتجر',
+                'flat-rate' => 'سعر ثابت',
+                'free-shipping' => 'شحن مجاني',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'قياسي',
                 'collection' => 'استلام من المتجر',
+                'flat-rate' => 'سعر ثابت',
+                'free-shipping' => 'شحن مجاني',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/bg/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/bg/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Стандартен',
                 'collection' => 'Колекция',
+                'flat-rate' => 'Фиксирана цена',
+                'free-shipping' => 'Безплатна доставка',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Стандартен',
                 'collection' => 'Колекция',
+                'flat-rate' => 'Фиксирана цена',
+                'free-shipping' => 'Безплатна доставка',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/en/shippingmethod.php
@@ -46,6 +46,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Collection',
+                'flat-rate' => 'Flat Rate',
+                'free-shipping' => 'Free Shipping',
             ],
         ],
         'stock_available' => [
@@ -74,6 +76,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Collection',
+                'flat-rate' => 'Flat Rate',
+                'free-shipping' => 'Free Shipping',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/es/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/es/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Estándar',
                 'collection' => 'Recogida',
+                'flat-rate' => 'Tarifa plana',
+                'free-shipping' => 'Envío gratuito',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Estándar',
                 'collection' => 'Recogida',
+                'flat-rate' => 'Tarifa plana',
+                'free-shipping' => 'Envío gratuito',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/fa/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/fa/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'استاندارد',
                 'collection' => 'تحویل حضوری',
+                'flat-rate' => 'نرخ ثابت',
+                'free-shipping' => 'ارسال رایگان',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'استاندارد',
                 'collection' => 'تحویل حضوری',
+                'flat-rate' => 'نرخ ثابت',
+                'free-shipping' => 'ارسال رایگان',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/fr/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/fr/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Collecte',
+                'flat-rate' => 'Forfaitaire',
+                'free-shipping' => 'Livraison gratuite',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Collecte',
+                'flat-rate' => 'Forfaitaire',
+                'free-shipping' => 'Livraison gratuite',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/hr/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/hr/shippingmethod.php
@@ -46,6 +46,8 @@ return [
             'options' => [
                 'ship-by' => 'Standardno',
                 'collection' => 'Preuzimanje',
+                'flat-rate' => 'Fiksna cijena',
+                'free-shipping' => 'Besplatna dostava',
             ],
         ],
         'stock_available' => [
@@ -74,6 +76,8 @@ return [
             'options' => [
                 'ship-by' => 'Standardno',
                 'collection' => 'Preuzimanje',
+                'flat-rate' => 'Fiksna cijena',
+                'free-shipping' => 'Besplatna dostava',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/hu/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/hu/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Házhozszállítás',
                 'collection' => 'Személyes átvétel',
+                'flat-rate' => 'Átalánydíjas',
+                'free-shipping' => 'Ingyenes szállítás',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Házhozszállítás',
                 'collection' => 'Személyes átvétel',
+                'flat-rate' => 'Átalánydíjas',
+                'free-shipping' => 'Ingyenes szállítás',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/mn/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/mn/shippingmethod.php
@@ -46,6 +46,8 @@ return [
             'options' => [
                 'ship-by' => 'Стандарт',
                 'collection' => 'Цуглуулга',
+                'flat-rate' => 'Тогтмол үнэ',
+                'free-shipping' => 'Үнэгүй хүргэлт',
             ],
         ],
         'stock_available' => [
@@ -74,6 +76,8 @@ return [
             'options' => [
                 'ship-by' => 'Стандарт',
                 'collection' => 'Цуглуулга',
+                'flat-rate' => 'Тогтмол үнэ',
+                'free-shipping' => 'Үнэгүй хүргэлт',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/pl/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/pl/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Odbiór osobisty',
+                'flat-rate' => 'Stała stawka',
+                'free-shipping' => 'Darmowa dostawa',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Odbiór osobisty',
+                'flat-rate' => 'Stała stawka',
+                'free-shipping' => 'Darmowa dostawa',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/pt_BR/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/pt_BR/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Padrão',
                 'collection' => 'Coleta',
+                'flat-rate' => 'Taxa fixa',
+                'free-shipping' => 'Frete grátis',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Padrão',
                 'collection' => 'Coleta',
+                'flat-rate' => 'Taxa fixa',
+                'free-shipping' => 'Frete grátis',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/ro/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/ro/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Ridicare',
+                'flat-rate' => 'Tarif fix',
+                'free-shipping' => 'Livrare gratuită',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Standard',
                 'collection' => 'Ridicare',
+                'flat-rate' => 'Tarif fix',
+                'free-shipping' => 'Livrare gratuită',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/tr/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/tr/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Standart',
                 'collection' => 'Mağazadan Teslim Alma',
+                'flat-rate' => 'Sabit Ücret',
+                'free-shipping' => 'Ücretsiz Kargo',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Standart',
                 'collection' => 'Mağazadan Teslim Alma',
+                'flat-rate' => 'Sabit Ücret',
+                'free-shipping' => 'Ücretsiz Kargo',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/resources/lang/vi/shippingmethod.php
+++ b/packages/table-rate-shipping/resources/lang/vi/shippingmethod.php
@@ -28,6 +28,8 @@ return [
             'options' => [
                 'ship-by' => 'Tiêu chuẩn',
                 'collection' => 'Nhận tại cửa hàng',
+                'flat-rate' => 'Đồng giá',
+                'free-shipping' => 'Miễn phí vận chuyển',
             ],
         ],
         'stock_available' => [
@@ -46,6 +48,8 @@ return [
             'options' => [
                 'ship-by' => 'Tiêu chuẩn',
                 'collection' => 'Nhận tại cửa hàng',
+                'flat-rate' => 'Đồng giá',
+                'free-shipping' => 'Miễn phí vận chuyển',
             ],
         ],
     ],

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -19,6 +19,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Lunar\Admin\Support\Resources\BaseResource;
 use Lunar\Facades\Converter;
+use Lunar\Shipping\Facades\Shipping;
 use Lunar\Shipping\Filament\Resources\ShippingMethodResource\Pages;
 use Lunar\Shipping\Filament\Resources\ShippingMethodResource\Widgets\AvailabilityScheduleWidget;
 use Lunar\Shipping\Models\Contracts\ShippingMethod;
@@ -208,14 +209,16 @@ class ShippingMethodResource extends BaseResource
     {
         return Forms\Components\Select::make('driver')
             ->label(__('lunarpanel.shipping::shippingmethod.form.driver.label'))
-            ->options([
-                'ship-by' => __('lunarpanel.shipping::shippingmethod.form.driver.options.ship-by'),
-                'collection' => __('lunarpanel.shipping::shippingmethod.form.driver.options.collection'),
-                'flat-rate' => __('lunarpanel.shipping::shippingmethod.form.driver.options.flat-rate'),
-                'free-shipping' => __('lunarpanel.shipping::shippingmethod.form.driver.options.free-shipping'),
-            ])
+            ->options(static::getDriverOptions())
             ->default('ship-by')
             ->required();
+    }
+
+    protected static function getDriverOptions(): array
+    {
+        return Shipping::getSupportedDrivers()->keys()->mapWithKeys(
+            fn ($driver) => [$driver => __("lunarpanel.shipping::shippingmethod.form.driver.options.{$driver}")]
+        )->all();
     }
 
     public static function getDefaultTable(Table $table): Table

--- a/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
+++ b/packages/table-rate-shipping/src/Filament/Resources/ShippingMethodResource.php
@@ -211,6 +211,8 @@ class ShippingMethodResource extends BaseResource
             ->options([
                 'ship-by' => __('lunarpanel.shipping::shippingmethod.form.driver.options.ship-by'),
                 'collection' => __('lunarpanel.shipping::shippingmethod.form.driver.options.collection'),
+                'flat-rate' => __('lunarpanel.shipping::shippingmethod.form.driver.options.flat-rate'),
+                'free-shipping' => __('lunarpanel.shipping::shippingmethod.form.driver.options.free-shipping'),
             ])
             ->default('ship-by')
             ->required();

--- a/tests/shipping/Unit/Managers/ShippingMethodLocaleParityTest.php
+++ b/tests/shipping/Unit/Managers/ShippingMethodLocaleParityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Lunar\Tests\Shipping\TestCase;
+
+uses(TestCase::class)->group('shipping', 'shipping-locale-parity');
+
+test('every locale exposes the same driver options in shippingmethod translations', function () {
+    $langPath = dirname(__DIR__, 4).'/packages/table-rate-shipping/resources/lang';
+
+    $files = glob($langPath.'/*/shippingmethod.php');
+
+    expect($files)->not->toBeEmpty();
+
+    $referenceLocale = null;
+    $referenceFormOptions = null;
+    $referenceTableOptions = null;
+
+    foreach ($files as $file) {
+        $locale = basename(dirname($file));
+        $translations = require $file;
+
+        $formOptions = array_keys($translations['form']['driver']['options'] ?? []);
+        $tableOptions = array_keys($translations['table']['driver']['options'] ?? []);
+
+        sort($formOptions);
+        sort($tableOptions);
+
+        if ($referenceLocale === null) {
+            $referenceLocale = $locale;
+            $referenceFormOptions = $formOptions;
+            $referenceTableOptions = $tableOptions;
+
+            continue;
+        }
+
+        expect($formOptions)
+            ->toBe($referenceFormOptions, "Locale [{$locale}] form.driver.options keys do not match [{$referenceLocale}].");
+
+        expect($tableOptions)
+            ->toBe($referenceTableOptions, "Locale [{$locale}] table.driver.options keys do not match [{$referenceLocale}].");
+    }
+});
+
+test('every locale includes the flat-rate and free-shipping driver options', function () {
+    $langPath = dirname(__DIR__, 4).'/packages/table-rate-shipping/resources/lang';
+
+    $files = glob($langPath.'/*/shippingmethod.php');
+
+    foreach ($files as $file) {
+        $locale = basename(dirname($file));
+        $translations = require $file;
+
+        expect($translations['form']['driver']['options'] ?? [])
+            ->toHaveKeys(['flat-rate', 'free-shipping'], "Locale [{$locale}] is missing form.driver.options entries.");
+
+        expect($translations['table']['driver']['options'] ?? [])
+            ->toHaveKeys(['flat-rate', 'free-shipping'], "Locale [{$locale}] is missing table.driver.options entries.");
+    }
+});


### PR DESCRIPTION
The table-rate-shipping method picker in Filament only listed two of the four registered shipping drivers (`ShipBy` and `Collection`), so `FlatRate` and `FreeShipping` weren't selectable even though both drivers exist and work fine once assigned some other way. Closes #2617.

The Filament resource now builds its options from `Shipping::getSupportedDrivers()` instead of a hardcoded list, so any driver registered via `Shipping::extend()` shows up automatically going forward. Added translations for `flat-rate`/`free-shipping` across all 14 shipped locales (a few had been missed in an earlier pass), and a test that asserts every locale's `shippingmethod.php` exposes the same driver-option keys, so a future locale gap fails CI instead of silently falling back to English.

Couldn't run the suite locally (no PHP in this environment), so I read through `ShippingManager` and the built-in drivers carefully to confirm none of them have side effects on instantiation before switching the form options to build from the manager dynamically.