### PR TITLE
fix: raise AI workflow turn caps above their design floor

### DIFF
--- a/.github/workflows/issue-digest.yml
+++ b/.github/workflows/issue-digest.yml
@@ -169,7 +169,7 @@ jobs:
             body; do not add a title or a date heading, one is added for you.
           claude_args: >-
             --model claude-sonnet-5
-            --max-turns 8
+            --max-turns 20
             --max-budget-usd 1.00
             --allowedTools "Read"
             --add-dir ${{ runner.temp }}/digest

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -72,7 +72,7 @@ jobs:
             commercial context for it.
           claude_args: >-
             --model claude-haiku-4-5
-            --max-turns 4
+            --max-turns 12
             --max-budget-usd 0.10
             --allowedTools "Read"
             --add-dir ${{ runner.temp }}/issue-context

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -258,7 +258,7 @@ jobs:
             you.
           claude_args: >-
             --model claude-sonnet-5
-            --max-turns 6
+            --max-turns 30
             --max-budget-usd 0.50
             --allowedTools "Read,Grep,Glob"
             --add-dir ${{ runner.temp }}/pr-context

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -86,7 +86,7 @@ jobs:
             no tools to do so, and a later step handles it.
           claude_args: >-
             --model claude-haiku-4-5
-            --max-turns 3
+            --max-turns 10
             --max-budget-usd 0.05
             --allowedTools "Read"
             --add-dir ${{ runner.temp }}/pr-context


### PR DESCRIPTION
First live triage run failed: `--max-turns 3` is below the number of file reads the workflow itself requires. The dollar budget (`--max-budget-usd`) and job timeout remain the binding cost controls; turn caps are raised to generous ceilings (triage 10, review 30, issue triage 12, digest 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)