### PR TITLE
fix: accept a linked Discussion as satisfying the PR acceptance gate

### DIFF
--- a/.claude/triage-rules.md
+++ b/.claude/triage-rules.md
@@ -81,14 +81,21 @@ splits it across `packages/{admin,panel,filament}` and adds `packages/demo-data`
 `packages/upgrade` and `packages/panel-addon-example`. Treat `panel` and
 `filament` exactly as you would treat `admin`.
 
-## Missing issue reference
+## Missing issue or Discussion reference
 
-If the body does not reference an issue — no `#123`, no `Fixes`/`Closes`/`Refs`
-link to an issue in this repo — apply `needs-issue` and post one short comment
-pointing at the "Non-trivial changes need an accepted issue first" section of
-`CONTRIBUTING.md`.
+This repo only accepts bug reports as issues; feature requests and enhancements
+live in GitHub Discussions. Either one satisfies the gate. Set `references_issue`
+to true when the body references **any** of:
 
-Skip this for `trivial` PRs. A typo fix does not need an issue, and asking for one
+- an issue in this repo (`#123`, or a `Fixes`/`Closes`/`Refs` link), or
+- a GitHub Discussion in this repo
+  (a link like `https://github.com/lunarphp/lunar/discussions/1234`).
+
+If neither is present, apply `needs-issue` and post one short comment pointing at
+the acceptance section of `CONTRIBUTING.md`. Never tell a feature PR to open an
+issue — the issue forms will not accept one; features go to Discussions.
+
+Skip this for `trivial` PRs. A typo fix does not need sign-off, and asking for it
 is the kind of friction that loses a contributor over nothing.
 
 ## Output

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -144,11 +144,11 @@ jobs:
               await github.rest.issues.createComment({
                 ...issue,
                 body: [
-                  "Thanks for the PR! I couldn't find a linked issue in the description.",
+                  "Thanks for the PR! I couldn't find a linked issue or Discussion in the description.",
                   '',
-                  'For anything beyond a typo or small isolated fix, we ask that an issue is opened and accepted before the PR — see [Non-trivial changes need an accepted issue first](https://github.com/lunarphp/lunar/blob/HEAD/CONTRIBUTING.md#non-trivial-changes-need-an-accepted-issue-first). It exists so you never spend a weekend on an approach we were always going to turn down.',
+                  'For anything beyond a typo or small isolated fix, we ask that the change is accepted before the PR is opened — for **bug fixes** that means a linked [issue](https://github.com/lunarphp/lunar/issues), and for **features or enhancements** a linked [Discussion](https://github.com/lunarphp/lunar/discussions) (features are not tracked as issues in this repo). See [Non-trivial changes need acceptance first](https://github.com/lunarphp/lunar/blob/HEAD/CONTRIBUTING.md#non-trivial-changes-need-acceptance-first). It exists so you never spend a weekend on an approach we were always going to turn down.',
                   '',
-                  "If there is an issue and I missed it, just link it here and ignore me — I'm a bot and this is advisory.",
+                  "If there is one and I missed it, just link it here and ignore me — I'm a bot and this is advisory.",
                 ].join('\n'),
               })
               core.summary.addRaw('Applied `needs-issue` and commented.\n')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,22 @@ handle contributions so you don't waste effort on work we can't merge.
 
 ## Before you open a pull request
 
-### Non-trivial changes need an accepted issue first
+### Non-trivial changes need acceptance first
 
 If your change is anything more than a typo, a doc fix, or a small isolated bug
-fix, open an issue and wait for a maintainer to accept it before you write the
-code.
+fix, get it accepted before you write the code:
 
-PRs that arrive without an accepted issue may be closed without a full review.
+- **Bug fixes** — open an issue with the bug form and wait for a maintainer to
+  confirm it.
+- **Features and enhancements** — open a
+  [Discussion](https://github.com/lunarphp/lunar/discussions/new/choose) and wait
+  for a maintainer to accept the direction. Feature requests are not tracked as
+  issues in this repo.
+
+Link the issue or Discussion in your PR description.
+
+PRs that arrive without an accepted issue or Discussion may be closed without a
+full review.
 This isn't gatekeeping — it exists so you don't spend a weekend on an approach we
 were always going to say no to. A short issue costs you ten minutes and can save
 you a lot more than that.


### PR DESCRIPTION
The repo only accepts bugs as issues — features go to Discussions — but the needs-issue automation told every non-trivial PR to open an issue. Spotted by Glenn during rollout. The gate now accepts an issue **or** a Discussion link, and the bot comment routes bug fixes vs features to the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)