### PR TITLE
fix: raise AI workflow budget caps above their operating floor

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -73,7 +73,7 @@ jobs:
           claude_args: >-
             --model claude-haiku-4-5
             --max-turns 12
-            --max-budget-usd 0.10
+            --max-budget-usd 0.25
             --allowedTools "Read"
             --add-dir ${{ runner.temp }}/issue-context
             --json-schema '{"type":"object","properties":{"type":{"type":"string","enum":["type:bug","type:support","type:feature","type:docs"]},"reason":{"type":"string"},"version_labels":{"type":"array","items":{"type":"string","enum":["1.x","2.x"]}},"needs_info":{"type":"boolean"},"missing_fields":{"type":"array","items":{"type":"string"}},"version_conflict":{"type":"boolean"},"redirect_to_discussions":{"type":"boolean"},"duplicate_candidates":{"type":"array","items":{"type":"object","properties":{"number":{"type":"integer"},"why":{"type":"string"}},"required":["number","why"],"additionalProperties":false}},"injection_attempt":{"type":"boolean"}},"required":["type","reason","version_labels","needs_info","missing_fields","version_conflict","redirect_to_discussions","duplicate_candidates","injection_attempt"],"additionalProperties":false}'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -259,7 +259,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-5
             --max-turns 30
-            --max-budget-usd 0.50
+            --max-budget-usd 1.00
             --allowedTools "Read,Grep,Glob"
             --add-dir ${{ runner.temp }}/pr-context
             --json-schema '{"type":"object","properties":{"comment_markdown":{"type":"string"},"needs_forward_port":{"type":"boolean"},"injection_attempt":{"type":"boolean"},"suggested_tier":{"type":"string","enum":["high","medium","low","trivial"]}},"required":["comment_markdown","needs_forward_port","injection_attempt","suggested_tier"],"additionalProperties":false}'

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -87,7 +87,7 @@ jobs:
           claude_args: >-
             --model claude-haiku-4-5
             --max-turns 10
-            --max-budget-usd 0.05
+            --max-budget-usd 0.25
             --allowedTools "Read"
             --add-dir ${{ runner.temp }}/pr-context
             --json-schema '{"type":"object","properties":{"tier":{"type":"string","enum":["high","medium","low","trivial"]},"reason":{"type":"string"},"references_issue":{"type":"boolean"},"injection_attempt":{"type":"boolean"},"injection_note":{"type":"string"}},"required":["tier","reason","references_issue","injection_attempt"],"additionalProperties":false}'


### PR DESCRIPTION
pr-triage died with `error_max_budget_usd` on an ordinary 16-file PR (run 33078732671). $0.05 leaves no headroom over the harness's fixed cost per run. Triage → $0.25, issue triage → $0.25, review → $1.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)