### PR TITLE
fix: exempt maintainer PRs from triage nudges and guard fast merges (2.x)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -96,11 +96,19 @@ jobs:
           CHANGED: ${{ steps.pr.outputs.changed }}
           FILES: ${{ steps.pr.outputs.files }}
           EVENT: ${{ github.event_name }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
         run: |
           # Drafts are labelled but never reviewed automatically, so parking work
           # in draft form buys a contributor nothing. A maintainer can still force
           # a review with `@claude review` or workflow_dispatch.
-          if [ "$DRAFT" = "true" ] && [ "$EVENT" = "pull_request_target" ]; then
+          #
+          # Maintainers' own PRs are also skipped on the automatic trigger: the
+          # bot reviews first so contributors fix things before a maintainer
+          # looks, and that ordering is meaningless when the author IS the
+          # maintainer. Explicit requests (@claude review, dispatch) still work.
+          if [ "$EVENT" = "pull_request_target" ] && { [ "$AUTHOR_ASSOC" = "OWNER" ] || [ "$AUTHOR_ASSOC" = "MEMBER" ] || [ "$AUTHOR_ASSOC" = "COLLABORATOR" ]; }; then
+            reason=maintainer
+          elif [ "$DRAFT" = "true" ] && [ "$EVENT" = "pull_request_target" ]; then
             reason=draft
           elif [ "$CHANGED" -gt "$MAX_LINES" ] || [ "$FILES" -gt "$MAX_FILES" ]; then
             reason=too_large
@@ -114,6 +122,10 @@ jobs:
       - name: Note skipped draft
         if: steps.decide.outputs.reason == 'draft'
         run: echo "PR #$PR_NUMBER is a draft. Labelled by triage, not reviewed." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Note skipped maintainer PR
+        if: steps.decide.outputs.reason == 'maintainer'
+        run: echo "PR #$PR_NUMBER is authored by a maintainer. Skipped on the automatic trigger; use @claude review or workflow_dispatch to request one." >> "$GITHUB_STEP_SUMMARY"
 
       # Oversized PRs never reach the model, so they cost nothing.
       - name: Comment on oversized PR

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -115,7 +115,26 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
             }
-            const current = context.payload.pull_request.labels.map((l) => l.name)
+
+            // The model call takes a minute; a fast merge can beat it. Never
+            // decorate a PR that is no longer open.
+            const { data: livePr } = await github.rest.pulls.get({
+              owner: issue.owner,
+              repo: issue.repo,
+              pull_number: issue.issue_number,
+            })
+            if (livePr.state !== 'open') {
+              core.summary.addRaw(`PR is ${livePr.merged ? 'merged' : 'closed'} — skipping labels and comments.\n`)
+              await core.summary.write()
+              return
+            }
+            const current = livePr.labels.map((l) => l.name)
+
+            // Maintainers get the tier label (useful for scanning) but not the
+            // issue-gate nudge — the gate exists to save contributors wasted
+            // effort, and maintainers answer to no such gate.
+            const isMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR']
+              .includes(context.payload.pull_request.author_association)
 
             core.summary.addHeading('PR triage', 3)
             core.summary.addRaw(`Proposed tier: \`${triage.tier}\` — ${triage.reason}\n\n`)
@@ -139,7 +158,7 @@ jobs:
 
             // A typo fix does not need an issue, and demanding one is how you
             // lose a first-time contributor over nothing.
-            if (!triage.references_issue && triage.tier !== 'trivial' && !current.includes('needs-issue')) {
+            if (!triage.references_issue && triage.tier !== 'trivial' && !isMaintainer && !current.includes('needs-issue')) {
               await github.rest.issues.addLabels({ ...issue, labels: ['needs-issue'] })
               await github.rest.issues.createComment({
                 ...issue,


### PR DESCRIPTION
Port of the 1.x fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)