### PR TITLE
Test: maintainer exemption (will be closed)

### DIFF
--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -1,4 +1,5 @@
 <?php
+// Maintainer-exemption smoke test. This PR will be closed, not merged.
 
 namespace Lunar\Managers;
 

--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -1,4 +1,5 @@
 <?php
+
 // Maintainer-exemption smoke test. This PR will be closed, not merged.
 
 namespace Lunar\Managers;


### PR DESCRIPTION
Deliberately no issue or Discussion link — the bot should apply a tier label and stay silent, because the author has write access.