### PR TITLE
fix: check maintainer status via the permission API

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -82,11 +82,20 @@ jobs:
           gh pr view "$PR_NUMBER" \
             --json number,title,body,author,baseRefName,headRefOid,isDraft,additions,deletions,changedFiles,labels \
             > pr.json
+          # Payload author_association reports org members with private
+          # membership as CONTRIBUTOR, so ask the permission API instead.
+          author=$(jq -r .author.login pr.json)
+          perm=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$author/permission" --jq .permission 2>/dev/null || echo "none")
+          case "$perm" in
+            admin|maintain|write) maintainer=true ;;
+            *) maintainer=false ;;
+          esac
           {
             echo "base=$(jq -r .baseRefName pr.json)"
             echo "draft=$(jq -r .isDraft pr.json)"
             echo "changed=$(jq -r '.additions + .deletions' pr.json)"
             echo "files=$(jq -r .changedFiles pr.json)"
+            echo "maintainer=$maintainer"
           } >> "$GITHUB_OUTPUT"
 
       - name: Decide whether to review
@@ -96,7 +105,7 @@ jobs:
           CHANGED: ${{ steps.pr.outputs.changed }}
           FILES: ${{ steps.pr.outputs.files }}
           EVENT: ${{ github.event_name }}
-          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          MAINTAINER: ${{ steps.pr.outputs.maintainer }}
         run: |
           # Drafts are labelled but never reviewed automatically, so parking work
           # in draft form buys a contributor nothing. A maintainer can still force
@@ -106,7 +115,7 @@ jobs:
           # bot reviews first so contributors fix things before a maintainer
           # looks, and that ordering is meaningless when the author IS the
           # maintainer. Explicit requests (@claude review, dispatch) still work.
-          if [ "$EVENT" = "pull_request_target" ] && { [ "$AUTHOR_ASSOC" = "OWNER" ] || [ "$AUTHOR_ASSOC" = "MEMBER" ] || [ "$AUTHOR_ASSOC" = "COLLABORATOR" ]; }; then
+          if [ "$EVENT" = "pull_request_target" ] && [ "$MAINTAINER" = "true" ]; then
             reason=maintainer
           elif [ "$DRAFT" = "true" ] && [ "$EVENT" = "pull_request_target" ]; then
             reason=draft

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -132,9 +132,15 @@ jobs:
 
             // Maintainers get the tier label (useful for scanning) but not the
             // issue-gate nudge — the gate exists to save contributors wasted
-            // effort, and maintainers answer to no such gate.
-            const isMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR']
-              .includes(context.payload.pull_request.author_association)
+            // effort, and maintainers answer to no such gate. Checked via the
+            // permission API: the webhook payload's author_association reports
+            // org members with private membership as CONTRIBUTOR.
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: issue.owner,
+              repo: issue.repo,
+              username: livePr.user.login,
+            })
+            const isMaintainer = ['admin', 'maintain', 'write'].includes(perm.permission)
 
             core.summary.addHeading('PR triage', 3)
             core.summary.addRaw(`Proposed tier: \`${triage.tier}\` — ${triage.reason}\n\n`)


### PR DESCRIPTION
The payload's `author_association` reports org members with private membership as `CONTRIBUTOR`, so the exemption never fired for exactly the people it was for. Both workflows now query the collaborator-permission endpoint instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)