### PR TITLE
Stop the panel install-command test writing to shared Testbench state

### DIFF
--- a/tests/panel/Feature/Console/InstallPanelCommandTest.php
+++ b/tests/panel/Feature/Console/InstallPanelCommandTest.php
@@ -1,22 +1,82 @@
 <?php
 
-use Illuminate\Support\Facades\File;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\ServiceProvider;
+use Lunar\Panel\PanelServiceProvider;
 use Lunar\Tests\Panel\TestCase;
 
 uses(TestCase::class);
 
+/**
+ * The install command is asserted through the publish tags it invokes and the
+ * mappings the provider registers for them, rather than by running a real
+ * vendor:publish.
+ *
+ * A real publish writes into the Testbench skeleton that every parallel process
+ * shares, and the config directory there is globbed and `require`d by Testbench's
+ * LoadConfiguration on every app boot. A process that published the file and then
+ * cleaned it up left a window in which another process globbed the path, then
+ * failed to require it — a bootstrap failure surfacing in whichever unrelated test
+ * that process happened to be running.
+ */
+beforeEach(function () {
+    $this->publishCalls = collect();
+
+    // Replaces the framework's command of the same name in the console registry.
+    Artisan::command('vendor:publish {--tag=*} {--force} {--provider=} {--all}', function () {
+        test()->publishCalls->push([
+            'tags' => Arr::wrap($this->option('tag')),
+            'force' => (bool) $this->option('force'),
+        ]);
+
+        return 0;
+    });
+});
+
 it('publishes the panel config and reports the panel url', function () {
-    $configTarget = config_path('lunar/panel.php');
-    File::delete($configTarget);
+    $this->artisan('lunar:panel:install')
+        ->expectsOutputToContain('Installing the Lunar panel...')
+        ->expectsOutputToContain(url(config('lunar.panel.path', 'lunar')))
+        ->assertSuccessful();
 
-    try {
-        $this->artisan('lunar:panel:install')->assertSuccessful();
+    expect($this->publishCalls->pluck('tags')->flatten()->all())
+        ->toBe(['panel-config', 'panel-all-assets']);
+});
 
-        expect(File::exists($configTarget))->toBeTrue();
-    } finally {
-        // vendor:publish writes into the shared testbench skeleton; remove
-        // everything the command created so other suites see a clean slate.
-        File::delete($configTarget);
-        File::deleteDirectory(public_path('vendor/lunar-panel'));
-    }
+it('force-publishes the assets so a stale build is replaced', function () {
+    $this->artisan('lunar:panel:install')->assertSuccessful();
+
+    $assets = $this->publishCalls->first(fn (array $call) => in_array('panel-all-assets', $call['tags'], true));
+
+    expect($assets['force'])->toBeTrue();
+});
+
+/**
+ * ServiceProvider::$publishGroups is static and accumulates for the lifetime of the
+ * process, so an add-on registering into the same tag earlier in the run shows up
+ * here. These assert the panel's own entries are registered, not that nothing else
+ * is — the latter would depend on test ordering.
+ */
+it('maps the panel-config tag at the published config path', function () {
+    $paths = ServiceProvider::pathsToPublish(PanelServiceProvider::class, 'panel-config');
+
+    expect(array_values($paths))->toContain(config_path('lunar/panel.php'));
+    expect(collect(array_keys($paths))->contains(
+        fn (string $source) => str_ends_with($source, '/config/panel.php')
+    ))->toBeTrue();
+});
+
+it('maps the panel-all-assets tag at the published asset paths', function () {
+    $paths = ServiceProvider::pathsToPublish(PanelServiceProvider::class, 'panel-all-assets');
+
+    expect(array_values($paths))
+        ->toContain(public_path('vendor/lunar-panel/build'))
+        ->toContain(public_path('vendor/lunar-panel/favicons'));
+});
+
+it('leaves the shared Testbench config directory untouched', function () {
+    $this->artisan('lunar:panel:install')->assertSuccessful();
+
+    expect(file_exists(config_path('lunar/panel.php')))->toBeFalse();
 });


### PR DESCRIPTION
Fixes an intermittent CI failure in the `panel` suite. Surfaced on #2678, where `panel - PHP 8.4 - L13.*` failed on a commit touching no panel files; a re-run of the identical commit passed.

## The failure

```
FAILED Tests\panel\Feature\Collections\CollectionUrlTest > it re-…   Error
Failed opening required '.../testbench-core/laravel/config/lunar/panel.php'
  at vendor/orchestra/testbench-core/src/Bootstrap/LoadConfiguration.php:89
```

`CollectionUrlTest` is incidental — it died during app bootstrap, not on an assertion. Any test can be the victim.

## Cause

`InstallPanelCommandTest` ran a real `vendor:publish`, which writes into the Testbench skeleton that **every parallel process shares**, then deleted the file again in a `finally`. That directory is empty by default, so the file existed only for the lifetime of that one test.

Testbench globs that directory and then `require`s each path it found:

```php
->transform(fn ($path, $key) => $this->resolveConfigurationFile($path, $key))
)->each(static function ($path, $key) use ($config) {
    $config->set($key, require $path);   // line 89
```

A process that globbed while the file existed and reached the `require` after the `finally` deleted it fails to boot.

## The fix

The command is asserted through the publish tags it invokes and the mappings the provider registers for them, with `vendor:publish` replaced in the console registry so nothing touches shared state.

This covers **more** than before. The old test only checked that the config file appeared; it never checked the assets were published at all, nor that they are force-published so a stale build is replaced. There is also a guard test asserting the shared config directory stays untouched — verified load-bearing by removing the stub, which reproduces the original write.

## A second, self-inflicted flake found while testing

My first attempt asserted the publish mappings with exact equality. That failed intermittently: `ServiceProvider::$publishGroups` is **static** and accumulates for the process lifetime, so an add-on test registering into `panel-all-assets` earlier in the same process leaked a third entry in, depending on ordering. The assertions now check the panel's own entries are registered rather than that nothing else is. Worth knowing about for any future test that reads those statics.

## Verification

- 12 consecutive parallel runs of the `panel` suite (4 processes, matching CI), all green, with the shared skeleton config directory empty afterwards.
- Full local sweep: core 1253, admin 261, panel 749, filament 73, shipping 103, stripe 48, search 28, upgrade 85 — plus PHPStan and Pint.

I did **not** reproduce the original bootstrap race locally before fixing it — it needs two processes to overlap in a narrow window. The mechanism is read off the stack trace and the code, and the fix is confirmed to remove the shared write that triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)