### PR TITLE
Match cart lines on the purchasable type when merging carts

### DIFF
--- a/packages/core/src/Actions/Carts/MergeCart.php
+++ b/packages/core/src/Actions/Carts/MergeCart.php
@@ -24,7 +24,12 @@ class MergeCart
             $source->lines->map(function ($line) use ($target) {
                 return [
                     'target' => $target->lines->first(function ($targetLine) use ($line) {
-                        return $targetLine->purchasable_id == $line->purchasable_id &&
+                        // The type is half of what identifies a purchasable:
+                        // ids of different purchasable types are independent
+                        // sequences and collide as a matter of course. This is
+                        // the same comparison GetExistingCartLine makes.
+                        return $targetLine->purchasable_type == $line->purchasable_type &&
+                        $targetLine->purchasable_id == $line->purchasable_id &&
                         json_encode($targetLine->meta) == json_encode($line->meta);
                     }),
                     'source' => $line,

--- a/tests/core/Stubs/TestGiftCard.php
+++ b/tests/core/Stubs/TestGiftCard.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Lunar\Base\Purchasable;
+use Lunar\DataTypes\Price;
+use Lunar\Models\Currency;
+use Lunar\Models\TaxClass;
+
+/**
+ * A second Purchasable model, of the kind Lunar documents as supported.
+ *
+ * Some behaviour is only observable with two purchasable types in play, because
+ * their primary keys are independent sequences and collide as a matter of
+ * course — gift card 1 and product variant 1 both exist.
+ */
+class TestGiftCard extends Model implements Purchasable
+{
+    protected $table = 'test_gift_cards';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function getPrice(): Price
+    {
+        return new Price(500, Currency::getDefault(), 1);
+    }
+
+    public function getPrices(): Collection
+    {
+        return collect([$this->getPrice()]);
+    }
+
+    public function getUnitQuantity(): int
+    {
+        return 1;
+    }
+
+    public function getTaxClass(): TaxClass
+    {
+        return TaxClass::first() ?? TaxClass::factory()->create();
+    }
+
+    public function getTaxReference(): ?string
+    {
+        return null;
+    }
+
+    public function getType(): string
+    {
+        return 'digital';
+    }
+
+    public function getDescription(): string
+    {
+        return $this->name ?? 'Gift card';
+    }
+
+    public function getOption(): string
+    {
+        return '';
+    }
+
+    public function getOptions(): Collection
+    {
+        return collect();
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'GIFTCARD-'.$this->id;
+    }
+
+    public function isShippable(): bool
+    {
+        return false;
+    }
+
+    public function getThumbnail(): mixed
+    {
+        return null;
+    }
+
+    public function canBeFulfilledAtQuantity(int $quantity): bool
+    {
+        return true;
+    }
+
+    public function isPurchasable(): bool
+    {
+        return true;
+    }
+
+    public function getTotalInventory(): int
+    {
+        return PHP_INT_MAX;
+    }
+}

--- a/tests/core/Unit/Actions/Carts/MergeCartTest.php
+++ b/tests/core/Unit/Actions/Carts/MergeCartTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Lunar\Actions\Carts\MergeCart;
 use Lunar\Models\Cart;
 use Lunar\Models\Currency;
@@ -9,6 +11,7 @@ use Lunar\Models\Price;
 use Lunar\Models\ProductVariant;
 use Lunar\Models\TaxClass;
 use Lunar\Models\TaxRateAmount;
+use Lunar\Tests\Core\Stubs\TestGiftCard;
 use Lunar\Tests\Core\TestCase;
 
 uses(TestCase::class);
@@ -161,4 +164,67 @@ test('can handle merging of lines with different metas', function () {
 
     expect($cartB->merged_id)->toEqual($cartA->id);
     expect($cartA->lines)->toHaveCount(3);
+});
+
+test('can merge lines of different purchasable types that share an id', function () {
+    if (! Schema::hasTable('test_gift_cards')) {
+        Schema::create('test_gift_cards', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+        });
+    }
+
+    $currency = Currency::factory()->create([
+        'decimal_places' => 2,
+        'default' => true,
+    ]);
+
+    TaxClass::factory()->create([
+        'default' => true,
+    ]);
+
+    $variant = ProductVariant::factory()->create();
+
+    Price::factory()->create([
+        'price' => 100,
+        'min_quantity' => 1,
+        'currency_id' => $currency->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'priceable_id' => $variant->id,
+    ]);
+
+    // The id collision two purchasable tables produce on their own.
+    $giftCard = TestGiftCard::create(['name' => 'Gift card']);
+    TestGiftCard::query()->where('id', $giftCard->id)->update(['id' => $variant->id]);
+    $giftCard = TestGiftCard::find($variant->id);
+
+    $target = Cart::factory()->create(['currency_id' => $currency->id]);
+    $source = Cart::factory()->create(['currency_id' => $currency->id]);
+
+    $target->lines()->create([
+        'purchasable_type' => $variant->getMorphClass(),
+        'purchasable_id' => $variant->id,
+        'quantity' => 1,
+    ]);
+
+    $source->lines()->create([
+        'purchasable_type' => $giftCard->getMorphClass(),
+        'purchasable_id' => $giftCard->id,
+        'quantity' => 4,
+    ]);
+
+    (new MergeCart)->execute($target, $source);
+
+    $lines = $target->refresh()->lines()->get()
+        ->map(fn ($line) => $line->purchasable_type.' x'.$line->quantity)
+        ->sort()
+        ->values()
+        ->all();
+
+    // Two different products, so two lines - the gift card must not be folded
+    // into the variant that happens to share its id.
+    expect($lines)->toEqual([
+        TestGiftCard::class.' x4',
+        $variant->getMorphClass().' x1',
+    ]);
 });


### PR DESCRIPTION
A shopper puts four gift cards in their basket as a guest, then logs in. The
gift cards are gone, and the one shampoo they already had is now five.

Fixes #2682.

The same code is unchanged on `2.x`, so this wants a forward port.

### What happens now

- Merging a guest cart into an account cart decides two lines are the same item
  from the purchasable **id** and the meta.
- Ids of different purchasable types are independent sequences, so gift card 1
  and product variant 1 both exist. Nothing coordinates them, and nothing needs
  to.
- When they collide, the source line is never created in the target cart and an
  unrelated line absorbs its quantity.
- The source cart is stamped `merged_id` immediately after, so the lost item
  cannot be recovered. No exception, nothing in the log.

### What should happen

- Two lines are the same item only when the type and the id both match.

### Why

`MergeCart` compares the id and the meta, and never the type:

```php
return $targetLine->purchasable_id == $line->purchasable_id &&
json_encode($targetLine->meta) == json_encode($line->meta);
```

`GetExistingCartLine` — Lunar's other answer to "is this the same line?" —
does compare it, via `wherePurchasableType()`. The two disagree about what makes
two lines equal, and only one of them can be right.

### The fix

Compare `purchasable_type` as well, which is the comparison
`GetExistingCartLine` already makes. Nothing else changes: the branch that
creates a missing line already writes the type correctly, so once the match is
right the rest of the method behaves.

### Tests

`tests/core/Unit/Actions/Carts/MergeCartTest.php`:

- **can merge lines of different purchasable types that share an id** — an
  account cart with one variant, a guest cart with four gift cards carrying the
  same id, merged. Fails on `1.x` with:

  ```
  -    0 => 'Lunar\Tests\Core\Stubs\TestGiftCard x4'
  -    1 => 'product_variant x1'
  +    0 => 'product_variant x5'
  ```

The defect is only observable with two purchasable types in play, and the suite
has no Eloquent purchasable — `TestPurchasable` is a plain class and cannot be
the target of a morph. So the test adds `TestGiftCard`, a minimal model
implementing `Purchasable`, and creates its table in the test. It is the sort of
custom purchasable the docs invite — a gift card, a bundle, a subscription.

