### PR TITLE
Ignore a postcode tax zone that scores no match

### DIFF
--- a/packages/core/src/Actions/Taxes/GetTaxZonePostcode.php
+++ b/packages/core/src/Actions/Taxes/GetTaxZonePostcode.php
@@ -34,11 +34,16 @@ class GetTaxZonePostcode
         })->sort(fn ($current, $next) => $current['matches'] < $next['matches'])->first();
 
         // Give up, use default...
-        if (! $match) {
+        //
+        // $match is an array, so it is truthy even when nothing matched - the
+        // score inside it is what says whether this zone applies at all. Without
+        // checking it, a zone sharing only the postcode's first character wins,
+        // and GetTaxZone returns before it ever reaches state or country.
+        if (! $match || ! $match['matches']) {
             return null;
         }
 
-        return $match ? $match['postcode'] : null;
+        return $match['postcode'];
     }
 
     /**

--- a/tests/core/Unit/Actions/Taxes/GetTaxZonePostcodeTest.php
+++ b/tests/core/Unit/Actions/Taxes/GetTaxZonePostcodeTest.php
@@ -94,3 +94,29 @@ test('can match using wildcards', function () {
         }
     }
 });
+
+test('can not match a postcode that only shares a first character', function () {
+    TaxZonePostcode::factory()->create([
+        'postcode' => 'S1 2AB',
+    ]);
+
+    // Shares the letter S and nothing else. The candidate list is built from the
+    // first character alone, so this zone is considered and scores zero.
+    $postcode = app(GetTaxZonePostcode::class)->execute('SW1A 0AA');
+
+    expect($postcode)->toBeNull();
+});
+
+test('can still match a wildcard when a non-matching zone shares the first character', function () {
+    TaxZonePostcode::factory()->create([
+        'postcode' => 'S1 2AB',
+    ]);
+
+    $wildcard = TaxZonePostcode::factory()->create([
+        'postcode' => 'SW*',
+    ]);
+
+    $postcode = app(GetTaxZonePostcode::class)->execute('SW1A 0AA');
+
+    expect($postcode?->id)->toEqual($wildcard->id);
+});


### PR DESCRIPTION
Fixes #2683.

The same code is unchanged on `2.x`, so this wants a forward port.

A customer shipping to the UAE with postcode `SW1A 0AA` is charged a Sheffield
rate, because the store happens to have a zone on `S1 2AB`.

### The fix

`$match` is the array `['postcode' => …, 'matches' => 0]`, which is truthy even
when nothing matched — so the "give up" branch below it was unreachable. The
guard now reads the score inside it, which is the value that says whether the
zone applies at all.

Nothing else changes: the candidate query, the wildcard scoring and the sort are
all untouched, so a zone that does match still wins exactly as before.

### Tests

`tests/core/Unit/Actions/Taxes/GetTaxZonePostcodeTest.php`:

- **can not match a postcode that only shares a first character** — a store with
  a single `S1 2AB` zone, asked for `SW1A 0AA`. Fails on `1.x`, which returns the
  `S1 2AB` row.
- **can still match a wildcard when a non-matching zone shares the first
  character** — `S1 2AB` and `SW*` together; `SW*` still wins. Passes before and
  after, and is the guard that the fix rejects non-matches rather than weakening
  matching.
