### PR TITLE
Fail loudly when attribute data cannot be encoded

### DIFF
--- a/packages/core/src/Base/Casts/AsAttributeData.php
+++ b/packages/core/src/Base/Casts/AsAttributeData.php
@@ -53,7 +53,12 @@ class AsAttributeData implements Castable
                     ];
                 }
 
-                return [$key => json_encode($data)];
+                // JSON_THROW_ON_ERROR, because json_encode() reports failure by
+                // returning false - on a value that is not valid UTF-8, or that
+                // exceeds max depth. Bound into the update, that false is stored
+                // as 0, which both destroys the attributes the row already held
+                // and leaves it unreadable, since get() cannot iterate an int.
+                return [$key => json_encode($data, JSON_THROW_ON_ERROR)];
             }
         };
     }

--- a/tests/core/Unit/Base/Casts/AsAttributeDataTest.php
+++ b/tests/core/Unit/Base/Casts/AsAttributeDataTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Lunar\FieldTypes\TranslatedText;
+use Lunar\Models\Product;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+test('can not overwrite attribute data with an unencodable value', function () {
+    $product = Product::factory()->create([
+        'attribute_data' => collect([
+            'name' => new TranslatedText(['en' => 'A name worth keeping']),
+        ]),
+    ]);
+
+    $before = DB::table('lunar_products')->where('id', $product->id)->value('attribute_data');
+
+    // A single 0xE4 byte - "a" with an umlaut, as Latin-1 writes it. Any feed
+    // that is not UTF-8 produces these. The cast runs on assignment, so this
+    // never reaches the database at all.
+    expect(function () use ($product) {
+        $product->attribute_data = collect([
+            'name' => new TranslatedText(['en' => "Sh\xE4mpoo"]),
+        ]);
+
+        $product->save();
+    })->toThrow(JsonException::class);
+
+    $after = DB::table('lunar_products')->where('id', $product->id)->value('attribute_data');
+
+    // The point is not that it failed, but that it failed without taking the
+    // existing attributes with it.
+    expect($after)->toEqual($before);
+
+    expect(Product::find($product->id)->translateAttribute('name'))
+        ->toEqual('A name worth keeping');
+});
+
+test('can store attribute data containing multibyte characters', function () {
+    $product = Product::factory()->create([
+        'attribute_data' => collect([
+            'name' => new TranslatedText(['en' => 'Crème brûlée · 日本語 · emoji 🧴']),
+        ]),
+    ]);
+
+    expect(Product::find($product->id)->translateAttribute('name'))
+        ->toEqual('Crème brûlée · 日本語 · emoji 🧴');
+});


### PR DESCRIPTION
Fixes #2685.

The same code is on `2.x` at `Casts/AsAttributeData.php`, so this wants a forward
port.

One byte from a Latin-1 product feed replaces the whole of `attribute_data` with
`0`, taking every attribute on the record with it.

### The fix

`json_encode()` reports failure by returning `false`, and that `false` was bound
straight into the update. Encoding now uses `JSON_THROW_ON_ERROR`, so a value
that cannot be represented fails the write instead of overwriting what was
already there.

The cast runs on assignment, so the bad value never reaches the database — which
also means this is not a new failure mode for callers: on `1.x` the save already
threw, just after writing.

Nothing else changes, and `get()` is untouched.

### Tests

`tests/core/Unit/Base/Casts/AsAttributeDataTest.php`:

- **can not overwrite attribute data with an unencodable value** — a product with
  a name, then a write carrying a single `0xE4` byte. Asserts the write throws
  *and* that the stored column and the readable name are exactly what they were.
  On `1.x` the column is `0` afterwards and the product can no longer be loaded.
- **can store attribute data containing multibyte characters** — accented text,
  Japanese and an emoji all still round-trip. Passes before and after; it is the
  guard that the fix rejects unencodable bytes rather than non-ASCII ones.
