### PR TITLE
Read a non-attribute-set column as an empty attribute set

### DIFF
--- a/packages/core/src/Base/Casts/AsAttributeData.php
+++ b/packages/core/src/Base/Casts/AsAttributeData.php
@@ -27,6 +27,15 @@ class AsAttributeData implements Castable
 
                 $data = json_decode($attributes[$key], true);
 
+                // A json column accepts any JSON value, and rows reach here from
+                // imports, from other Lunar versions and from writes that failed.
+                // Anything that is not an attribute set is read as an empty one,
+                // rather than left to fail on the foreach below - one such row
+                // would otherwise throw for every listing that returns it.
+                if (! is_array($data)) {
+                    return new Collection;
+                }
+
                 $returnData = new Collection;
 
                 foreach ($data as $key => $item) {

--- a/tests/core/Unit/Base/Casts/AsAttributeDataReadTest.php
+++ b/tests/core/Unit/Base/Casts/AsAttributeDataReadTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Lunar\FieldTypes\TranslatedText;
+use Lunar\Models\Product;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+/**
+ * A json column accepts any JSON value, and rows arrive from imports, from other
+ * Lunar versions and from Lunar's own failed writes. None of them should stop a
+ * record being hydrated.
+ */
+test('can load a record whose attribute data is not an attribute set', function (string $stored) {
+    $product = Product::factory()->create([
+        'attribute_data' => collect([
+            'name' => new TranslatedText(['en' => 'A name']),
+        ]),
+    ]);
+
+    DB::table('lunar_products')->where('id', $product->id)->update(['attribute_data' => $stored]);
+
+    $loaded = Product::find($product->id);
+
+    expect($loaded->attribute_data)->toHaveCount(0);
+})->with([
+    'json null' => 'null',
+    'zero, as a failed encode leaves it' => '0',
+    'a json string' => '"abc"',
+    'a number' => '123',
+    'malformed json' => '{oops',
+]);
+
+test('can still load attribute data that is an attribute set', function () {
+    $product = Product::factory()->create([
+        'attribute_data' => collect([
+            'name' => new TranslatedText(['en' => 'A name']),
+        ]),
+    ]);
+
+    expect(Product::find($product->id)->translateAttribute('name'))->toEqual('A name');
+});


### PR DESCRIPTION
Fixes #2687.

`1.x` only — `2.x` already guards this, so no forward port.

A product whose `attribute_data` holds anything other than an attribute set
cannot be loaded: `Product::find()` throws, and so does every listing whose range
includes it.

### The fix

`get()` decoded the column and iterated the result without checking it was
iterable. It now reads anything that is not an array as an empty attribute set,
which is what `2.x` does.

`is_array()` rather than `2.x`'s `?: []`: both catch `null` and `0`, which are
the values that actually arise, and `is_array()` also catches a truthy scalar
that would otherwise reach the same `foreach`.

Rows reach this state through Lunar itself — a non-UTF-8 attribute value makes
`set()` store `0` (#2685), and `0` is one of the values `get()` cannot read.
Fixing that stops new ones, but the records already damaged stay unreadable, and
cannot be repaired through Lunar because Lunar cannot read them.

Touches the same file as #2686, which fixes the write side. No overlap in intent,
but whichever lands second wants a rebase.

### Tests

`tests/core/Unit/Base/Casts/AsAttributeDataReadTest.php`:

- **can load a record whose attribute data is not an attribute set** — a dataset
  over the five shapes the column can hold: `null`, `0`, `"abc"`, `123` and
  malformed JSON. All five throw on `1.x`.
- **can still load attribute data that is an attribute set** — passes before and
  after, and is the guard that the fix skips only non-attribute-sets.
