### PR TITLE
Refuse a price that is a fraction of a minor unit

### DIFF
--- a/packages/core/src/Base/Casts/Price.php
+++ b/packages/core/src/Base/Casts/Price.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Validator;
 use Lunar\DataTypes\Price as PriceDataType;
+use Lunar\Exceptions\InvalidDataTypeValueException;
 use Lunar\Models\Currency;
 
 class Price implements CastsAttributes
@@ -54,8 +55,37 @@ class Price implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
+        // The column counts minor units and cannot hold a fraction of one, so a
+        // decimal is rounded by the database and silently becomes that many
+        // minor units - 12.99 is stored as 13. It cannot be converted here
+        // either: the cast has no way to tell whether a bare 12 means twelve
+        // minor units or twelve of the major unit, and guessing would multiply
+        // every correctly written price by the currency factor.
+        if (! is_null($value) && is_numeric($value) && (float) $value != (int) $value) {
+            throw new InvalidDataTypeValueException(
+                trim(sprintf(
+                    'Prices are stored as a whole number of minor units, so [%s] cannot be %s. %s',
+                    $key,
+                    $value,
+                    $this->suggestion($model, $value),
+                ))
+            );
+        }
+
         return [
             $key => $value,
         ];
+    }
+
+    /**
+     * The value the caller most likely meant, when the currency is known.
+     */
+    protected function suggestion($model, $value): string
+    {
+        $factor = $model->currency?->factor ?? Currency::getDefault()?->factor;
+
+        return $factor
+            ? sprintf('Did you mean %d?', (int) round($value * $factor))
+            : '';
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -100,7 +100,7 @@ function buildCart(array $cartParams = []): Cart
 
     $variant = ProductVariant::factory()->create()->each(function ($variant) use ($currency) {
         $variant->prices()->create([
-            'price' => 1.99,
+            'price' => 199,
             'currency_id' => $currency->id,
         ]);
     });

--- a/tests/core/Unit/Base/Casts/PriceTest.php
+++ b/tests/core/Unit/Base/Casts/PriceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Lunar\Exceptions\InvalidDataTypeValueException;
+use Lunar\Models\Currency;
+use Lunar\Models\Price;
+use Lunar\Models\ProductVariant;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+
+uses(RefreshDatabase::class);
+
+function priceFor(array $attributes = []): Price
+{
+    $currency = Currency::factory()->create(['decimal_places' => 2, 'default' => true]);
+    $variant = ProductVariant::factory()->create();
+
+    return Price::factory()->make(array_merge([
+        'currency_id' => $currency->id,
+        'priceable_id' => $variant->id,
+        'priceable_type' => $variant->getMorphClass(),
+        'min_quantity' => 1,
+    ], $attributes));
+}
+
+test('can not set a price to a fraction of a minor unit', function (string $key) {
+    // The column counts minor units, so 12.99 is not "twelve pounds ninety-nine"
+    // - it is twelve and a half of the smallest unit there is, which the column
+    // rounds away.
+    expect(fn () => priceFor([$key => 12.99]))
+        ->toThrow(InvalidDataTypeValueException::class);
+})->with(['price', 'compare_price']);
+
+test('can say what the price was probably meant to be', function () {
+    try {
+        priceFor(['price' => 12.99]);
+    } catch (InvalidDataTypeValueException $e) {
+        expect($e->getMessage())->toContain('1299');
+
+        return;
+    }
+
+    $this->fail('no exception was thrown');
+});
+
+test('can set a price to a whole number of minor units', function (int|float|string $given) {
+    $price = priceFor(['price' => $given]);
+    $price->save();
+
+    expect(DB::table('lunar_prices')->where('id', $price->id)->value('price'))
+        ->toEqual(1299);
+})->with([
+    'an integer' => 1299,
+    'an integral float' => 1299.0,
+    'a numeric string' => '1299',
+]);
+
+test('can leave a null compare price alone', function () {
+    $price = priceFor(['price' => 1299, 'compare_price' => null]);
+    $price->save();
+
+    expect(DB::table('lunar_prices')->where('id', $price->id)->value('compare_price'))->toBeNull();
+});

--- a/tests/core/Unit/Models/PriceTest.php
+++ b/tests/core/Unit/Models/PriceTest.php
@@ -71,7 +71,7 @@ function can_handle_non_int_values()
         'currency_id' => $currencyGBP->id,
         'priceable_id' => $variant->id,
         'priceable_type' => $variant->getMorphClass(),
-        'price' => 12.99,
+        'price' => 1299,
         'min_quantity' => 1,
     ]);
 
@@ -88,7 +88,7 @@ function can_handle_non_int_values()
         'currency_id' => $currencyUSD->id,
         'priceable_id' => $variant->id,
         'priceable_type' => $variant->getMorphClass(),
-        'price' => 12.995,
+        'price' => 12995,
         'min_quantity' => 1,
     ]);
 
@@ -150,8 +150,8 @@ test('compare price is cast correctly', function () {
         'currency_id' => $currency->id,
         'priceable_id' => $variant->id,
         'priceable_type' => $variant->getMorphClass(),
-        'price' => 12.99,
-        'compare_price' => 13.99,
+        'price' => 1299,
+        'compare_price' => 1399,
         'min_quantity' => 1,
     ]);
 

--- a/tests/stripe/Utils/CartBuilder.php
+++ b/tests/stripe/Utils/CartBuilder.php
@@ -53,7 +53,7 @@ class CartBuilder
 
         $variant = ProductVariant::factory()->create()->each(function ($variant) use ($currency) {
             $variant->prices()->create([
-                'price' => 1.99,
+                'price' => 199,
                 'currency_id' => $currency->id,
             ]);
         });


### PR DESCRIPTION
Fixes #2689.

`1.x` only — `2.x` has replaced this cast, and I have not checked its behaviour.

A price written as `12.99` is stored as `13`, and the column counts minor units,
so the product sells for AED 0.13.

### The fix

`set()` returned the value unchanged, so a decimal reached a `bigint` column and
was rounded. It now refuses a value that is not a whole number of minor units,
and says what was probably meant:

> Prices are stored as a whole number of minor units, so [price] cannot be 12.99.
> Did you mean 1299?

Refusing rather than converting is deliberate: the cast cannot tell whether a
bare `12` is twelve minor units or twelve of the major unit — both are in use —
and guessing would multiply every correctly-written price by the currency factor.
The documented contract is already an integer count of minor units, so this makes
the code agree with the docs rather than changing the contract.

`get()` is untouched.

### The existing tests

`PriceTest` passes a decimal in four places. Correcting those inputs to the
minor-unit equivalent leaves **every assertion in the file unchanged** — `->value`,
`->decimal` and `->formatted()` all still hold:

| line | was | now |
|---|---|---|
| 74 | `12.99` | `1299` |
| 91 | `12.995` (3dp currency) | `12995` |
| 153 | `12.99` | `1299` |
| 154 | `13.99` (compare_price) | `1399` |

They only appeared to work because the test asserts on the in-memory model and
never reloads it — `get()` strips non-digits, so `"12.99"` reads back as `1299`
in the request that wrote it, and `13` in every request after.

### Tests

`tests/core/Unit/Base/Casts/PriceTest.php`:

- **can not set a price to a fraction of a minor unit** — over `price` and
  `compare_price`.
- **can say what the price was probably meant to be** — the message carries
  `1299`, so the fix is actionable rather than just a refusal.
- **can set a price to a whole number of minor units** — an integer, an integral
  float and a numeric string all still store `1299`. Passes before and after, and
  is the guard that this rejects fractions rather than non-integers.
- **can leave a null compare price alone**.
