### PR TITLE
Add core discount actions and status scopes (spec 0072, slice 1)

### DIFF
--- a/packages/core/src/ActionServiceProvider.php
+++ b/packages/core/src/ActionServiceProvider.php
@@ -55,6 +55,9 @@ use Lunar\Core\Actions\Customers\LinkCustomerUser;
 use Lunar\Core\Actions\Customers\UnlinkCustomerUser;
 use Lunar\Core\Actions\Customers\UpdateCustomer;
 use Lunar\Core\Actions\Customers\UpdateCustomerAddress;
+use Lunar\Core\Actions\Discounts\CreateDiscount;
+use Lunar\Core\Actions\Discounts\DeleteDiscount;
+use Lunar\Core\Actions\Discounts\UpdateDiscount;
 use Lunar\Core\Actions\Fulfilment\AddFulfilmentTracking;
 use Lunar\Core\Actions\Fulfilment\CancelFulfilment;
 use Lunar\Core\Actions\Fulfilment\ChangeFulfilmentLocation;
@@ -286,6 +289,11 @@ class ActionServiceProvider extends ServiceProvider
         Contracts\Customers\UnlinksCustomerUser::class => UnlinkCustomerUser::class,
         Contracts\Customers\UpdatesCustomer::class => UpdateCustomer::class,
         Contracts\Customers\UpdatesCustomerAddress::class => UpdateCustomerAddress::class,
+
+        // Discounts
+        Contracts\Discounts\CreatesDiscount::class => CreateDiscount::class,
+        Contracts\Discounts\DeletesDiscount::class => DeleteDiscount::class,
+        Contracts\Discounts\UpdatesDiscount::class => UpdateDiscount::class,
 
         // Locations
         Contracts\Locations\CreatesLocation::class => CreateLocation::class,

--- a/packages/core/src/Actions/Discounts/CreateDiscount.php
+++ b/packages/core/src/Actions/Discounts/CreateDiscount.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lunar\Core\Actions\Discounts;
+
+use Lunar\Core\Contracts\Actions\Discounts\CreatesDiscount;
+use Lunar\Core\Models\Discount;
+
+/**
+ * Create a discount. Availability and targeting are configured afterwards
+ * through UpdatesDiscount, which is where the fan-out across the four
+ * targeting tables lives.
+ */
+class CreateDiscount implements CreatesDiscount
+{
+    public function execute(array $attributes): Discount
+    {
+        return Discount::create($attributes);
+    }
+}

--- a/packages/core/src/Actions/Discounts/DeleteDiscount.php
+++ b/packages/core/src/Actions/Discounts/DeleteDiscount.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Lunar\Core\Actions\Discounts;
+
+use Lunar\Core\Contracts\Actions\Discounts\DeletesDiscount;
+use Lunar\Core\Facades\DB;
+use Lunar\Core\Models\Discount;
+
+/**
+ * Delete a discount.
+ *
+ * Tearing down the targeting and availability pivots is DiscountObserver's
+ * job, so that every delete path gets it. The transaction is this action's
+ * addition: the observer's detaches and the delete itself are separate
+ * statements, and a discount left behind with its targeting already stripped
+ * would silently apply to the whole catalogue.
+ */
+class DeleteDiscount implements DeletesDiscount
+{
+    public function execute(Discount $discount): void
+    {
+        DB::transaction(function () use ($discount): void {
+            $discount->delete();
+        });
+    }
+}

--- a/packages/core/src/Actions/Discounts/UpdateDiscount.php
+++ b/packages/core/src/Actions/Discounts/UpdateDiscount.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Lunar\Core\Actions\Discounts;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Lunar\Core\Contracts\Actions\Discounts\UpdatesDiscount;
+use Lunar\Core\Exceptions\DiscountActionException;
+use Lunar\Core\Facades\DB;
+use Lunar\Core\Models\Collection;
+use Lunar\Core\Models\Discount;
+use Lunar\Core\Models\Discountable;
+use Lunar\Core\Models\Product;
+use Lunar\Core\Models\ProductVariant;
+
+/**
+ * Update a discount's attributes and, when given, sync its channel and
+ * customer-group availability and its targeting.
+ *
+ * Targeting is why this action exists. Core spreads it over four tables and
+ * which one an entity lands in depends on the bucket holding it, so callers
+ * pass one id map per bucket and this action does the routing.
+ */
+class UpdateDiscount implements UpdatesDiscount
+{
+    /**
+     * The kinds each bucket can target. Anything outside this map is a caller
+     * mistake rather than a new feature, so it raises instead of writing rows
+     * no discount type reads.
+     */
+    private const BUCKET_KINDS = [
+        'limitation' => ['products', 'variants', 'collections', 'brands', 'customers'],
+        'exclusion' => ['products', 'variants', 'collections', 'brands'],
+        'condition' => ['products', 'variants', 'collections'],
+        'reward' => ['products', 'variants', 'collections'],
+    ];
+
+    /**
+     * Buckets whose collections live on the collection_discount pivot. The
+     * line-targeting types read limitation and exclusion collections there,
+     * while BuyXGetY reads its condition and reward collections from
+     * discountables under a Collection morph.
+     */
+    private const PIVOT_COLLECTION_BUCKETS = ['limitation', 'exclusion'];
+
+    public function execute(
+        Discount $discount,
+        array $attributes,
+        ?array $channels = null,
+        ?array $customerGroups = null,
+        ?array $targets = null,
+    ): Discount {
+        if ($targets !== null) {
+            $this->guardTargets($targets);
+        }
+
+        return DB::transaction(function () use ($discount, $attributes, $channels, $customerGroups, $targets): Discount {
+            $discount->update($attributes);
+
+            if ($channels !== null) {
+                $discount->channels()->sync($channels);
+            }
+
+            if ($customerGroups !== null) {
+                $discount->customerGroups()->sync($customerGroups);
+            }
+
+            foreach ($targets ?? [] as $bucket => $ids) {
+                $this->syncBucket($discount, $bucket, $ids);
+            }
+
+            return $discount;
+        });
+    }
+
+    /**
+     * @param  array<string, array<string, int[]>>  $targets
+     *
+     * @throws DiscountActionException
+     */
+    private function guardTargets(array $targets): void
+    {
+        foreach ($targets as $bucket => $ids) {
+            if (! isset(self::BUCKET_KINDS[$bucket])) {
+                throw new DiscountActionException(
+                    "Unknown discount target bucket [{$bucket}]; expected one of ".implode(', ', array_keys(self::BUCKET_KINDS)).'.'
+                );
+            }
+
+            $unsupported = array_diff(array_keys($ids), self::BUCKET_KINDS[$bucket]);
+
+            if ($unsupported) {
+                throw new DiscountActionException(
+                    "The [{$bucket}] bucket cannot target ".implode(', ', $unsupported).'.'
+                );
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, int[]>  $ids
+     */
+    private function syncBucket(Discount $discount, string $bucket, array $ids): void
+    {
+        $morphs = [
+            'products' => Product::morphName(),
+            'variants' => ProductVariant::morphName(),
+        ];
+
+        $collectionsOnPivot = in_array($bucket, self::PIVOT_COLLECTION_BUCKETS, true);
+
+        if (! $collectionsOnPivot) {
+            $morphs['collections'] = Collection::morphName();
+        }
+
+        $discount->discountables()->where('type', $bucket)->delete();
+
+        $rows = [];
+
+        foreach ($morphs as $kind => $morph) {
+            foreach (array_unique($ids[$kind] ?? []) as $id) {
+                $rows[] = [
+                    'discount_id' => $discount->id,
+                    'discountable_type' => $morph,
+                    'discountable_id' => $id,
+                    'type' => $bucket,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ];
+            }
+        }
+
+        if ($rows) {
+            Discountable::insert($rows);
+        }
+
+        if ($collectionsOnPivot) {
+            $this->replacePivotBucket($discount->collections(), $bucket, $ids['collections'] ?? []);
+        }
+
+        if (in_array('brands', self::BUCKET_KINDS[$bucket], true)) {
+            $this->replacePivotBucket($discount->brands(), $bucket, $ids['brands'] ?? []);
+        }
+
+        if (in_array('customers', self::BUCKET_KINDS[$bucket], true)) {
+            $discount->customers()->sync(array_values(array_unique($ids['customers'] ?? [])));
+        }
+    }
+
+    /**
+     * Replace one bucket's rows on a type-discriminated pivot, leaving the
+     * other buckets in place.
+     *
+     * @param  int[]  $ids
+     */
+    private function replacePivotBucket(BelongsToMany $relation, string $bucket, array $ids): void
+    {
+        // detach() honours the wherePivot constraint while attach() ignores it,
+        // so one relation instance can safely do both.
+        $relation->wherePivot('type', $bucket)->detach();
+
+        $ids = array_values(array_unique($ids));
+
+        if ($ids) {
+            $relation->attach(array_fill_keys($ids, ['type' => $bucket]));
+        }
+    }
+}

--- a/packages/core/src/Contracts/Actions/Discounts/CreatesDiscount.php
+++ b/packages/core/src/Contracts/Actions/Discounts/CreatesDiscount.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lunar\Core\Contracts\Actions\Discounts;
+
+use Lunar\Core\Models\Discount;
+
+interface CreatesDiscount
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function execute(array $attributes): Discount;
+}

--- a/packages/core/src/Contracts/Actions/Discounts/DeletesDiscount.php
+++ b/packages/core/src/Contracts/Actions/Discounts/DeletesDiscount.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lunar\Core\Contracts\Actions\Discounts;
+
+use Lunar\Core\Models\Discount;
+
+interface DeletesDiscount
+{
+    public function execute(Discount $discount): void;
+}

--- a/packages/core/src/Contracts/Actions/Discounts/UpdatesDiscount.php
+++ b/packages/core/src/Contracts/Actions/Discounts/UpdatesDiscount.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Lunar\Core\Contracts\Actions\Discounts;
+
+use Lunar\Core\Exceptions\DiscountActionException;
+use Lunar\Core\Models\Discount;
+
+interface UpdatesDiscount
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  ?array<int, array{enabled?: bool, starts_at?: ?string, ends_at?: ?string}>  $channels  channel id keyed pivot rows; null leaves channel availability untouched
+     * @param  ?array<int, array{enabled?: bool, visible?: bool, starts_at?: ?string, ends_at?: ?string}>  $customerGroups  customer group id keyed pivot rows; null leaves group availability untouched
+     * @param  ?array{
+     *     limitation?: array{products?: int[], variants?: int[], collections?: int[], brands?: int[], customers?: int[]},
+     *     exclusion?: array{products?: int[], variants?: int[], collections?: int[], brands?: int[]},
+     *     condition?: array{products?: int[], variants?: int[], collections?: int[]},
+     *     reward?: array{products?: int[], variants?: int[], collections?: int[]},
+     * }  $targets  null leaves targeting untouched; a present bucket replaces that bucket
+     *              wholesale, so an omitted kind within it clears that kind
+     *
+     * @throws DiscountActionException when a bucket is unknown, or is given a kind it cannot target
+     */
+    public function execute(
+        Discount $discount,
+        array $attributes,
+        ?array $channels = null,
+        ?array $customerGroups = null,
+        ?array $targets = null,
+    ): Discount;
+}

--- a/packages/core/src/Exceptions/DiscountActionException.php
+++ b/packages/core/src/Exceptions/DiscountActionException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lunar\Core\Exceptions;
+
+class DiscountActionException extends LunarException
+{
+    //
+}

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -184,6 +184,42 @@ class Discount extends Base
             });
     }
 
+    /**
+     * The three scopes below complete scopeActive so that active, scheduled,
+     * expired and pending partition the table the way getStatusAttribute()
+     * partitions a single record: an end date in the past wins, then the start
+     * date decides. They follow scopeActive's boundary — a discount ending
+     * exactly now is expired — rather than the accessor's isPast(), so that no
+     * row falls outside all four.
+     *
+     * Pending only matches a null starts_at, which the baseline schema forbids.
+     * It is here to keep the four statuses exhaustive, not because a discount is
+     * expected to land there.
+     */
+    public function scopeExpired(Builder $query): Builder
+    {
+        return $query->whereNotNull('ends_at')
+            ->where('ends_at', '<=', now());
+    }
+
+    public function scopeScheduled(Builder $query): Builder
+    {
+        return $query->where('starts_at', '>', now())
+            ->where(function ($query) {
+                $query->whereNull('ends_at')
+                    ->orWhere('ends_at', '>', now());
+            });
+    }
+
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->whereNull('starts_at')
+            ->where(function ($query) {
+                $query->whereNull('ends_at')
+                    ->orWhere('ends_at', '>', now());
+            });
+    }
+
     public function scopeCollections(Builder $query, iterable $collectionIds = [], array|string $types = []): Builder
     {
         if (is_array($collectionIds)) {

--- a/packages/core/src/Observers/DiscountObserver.php
+++ b/packages/core/src/Observers/DiscountObserver.php
@@ -30,6 +30,7 @@ class DiscountObserver
     public function deleting(Discount $discount): void
     {
         $discount->brands()->detach();
+        $discount->channels()->detach();
         $discount->collections()->detach();
         $discount->customerGroups()->detach();
         $discount->customers()->detach();

--- a/specs/0072-panel-discounts-section.md
+++ b/specs/0072-panel-discounts-section.md
@@ -1,10 +1,10 @@
 # 0072 — Panel Discounts section
 
-- Status: proposed
+- Status: accepted
 - Author: Glenn Jacobs
 - Created: 2026-08-27
 - TODO item: Panel Discounts section — list, discount editing, targeting, availability and usage limits (spec 0072)
-- Depends on: [[0073-split-amount-off-discount-type]] (lands first, separate PR)
+- Depends on: [[0073-split-amount-off-discount-type]] (shipped)
 
 ## Problem
 
@@ -52,7 +52,7 @@ through `CouponString`), `type` (the discount-type class name), `starts_at` / `e
   | `limitation` | `discountables` | `collection_discount` | `brand_discount` | `customer_discount` |
   | `exclusion` | `discountables` | `collection_discount` | `brand_discount` | — |
   | `condition` (BuyXGetY) | `discountables` | `discountables` | — | — |
-  | `reward` (BuyXGetY) | `discountables` | — | — | — |
+  | `reward` (BuyXGetY) | `discountables` | `discountables` | — | — |
 
   Collections are the trap: the line-targeting types read them from the
   `collection_discount` pivot, while `BuyXGetY::apply()` reads them from `discountables`
@@ -133,14 +133,17 @@ collections live in two places.
  *   limitation: array{products: int[], variants: int[], collections: int[], brands: int[], customers: int[]},
  *   exclusion:  array{products: int[], variants: int[], collections: int[], brands: int[]},
  *   condition:  array{products: int[], variants: int[], collections: int[]},
- *   reward:     array{products: int[], variants: int[]},
+ *   reward:     array{products: int[], variants: int[], collections: int[]},
  * } $targets  null leaves targeting untouched; a present bucket replaces that bucket wholesale
  */
 ```
 
 The action is the only place that knows the routing table above. It writes in a
 transaction, syncing `discountables` per morph type and the three pivots, and it is the
-seam a consumer swaps to change targeting semantics.
+seam a consumer swaps to change targeting semantics. A bucket given a kind it cannot
+target — brands on a `condition`, say — raises rather than writing rows no discount type
+reads. `customer_discount` has no `type` column, so eligible customers hang off the
+`limitation` bucket alone.
 
 `Discount` also gains `scopeScheduled()`, `scopeExpired()` and `scopePending()` alongside
 the existing `scopeActive()`, so the derived status is filterable in SQL. The Filament table
@@ -376,6 +379,9 @@ it to 16.
 - **Breaking changes**: none. Everything here is additive; the breaking work is in 0073.
 - **Core public surface**: three new action contracts and implementations plus their
   `ActionServiceProvider::$actions` entries, and three new `Discount` scopes. Additive.
+- **Behaviour fix**: `DiscountObserver::deleting()` also detaches `channels()`, which it
+  missed while its `Product` and `Collection` siblings did not — deleting a discount was
+  orphaning its `channelables` rows on every delete path.
 - **Panel public surface**: `Lunar\Panel\Contracts\DiscountTypeForm`,
   `Section::discountTypeForms()`, and four new `ui.ts` exports.
 - **Permission**: reuses `sales:manage-discounts`; no manifest change.
@@ -428,7 +434,7 @@ it to 16.
 
 Prerequisite: [[0073-split-amount-off-discount-type]] merges first.
 
-- [ ] Slice 1 — Core actions: `Actions/Discounts/{CreateDiscount,UpdateDiscount,DeleteDiscount}`
+- [x] Slice 1 — Core actions: `Actions/Discounts/{CreateDiscount,UpdateDiscount,DeleteDiscount}`
       + contracts + `ActionServiceProvider` entries, with the `$targets` fan-out across
       `discountables` / `collection_discount` / `brand_discount` / `customer_discount`;
       `Discount` status scopes; tests.

--- a/specs/README.md
+++ b/specs/README.md
@@ -90,5 +90,5 @@ Each spec carries a `Status:` line in its frontmatter / header:
 | 0064 | Scoped service lifetimes for long-lived workers | implemented |
 | 0070 | First-party payment drivers: Stripe and PayPal | implemented |
 | 0071 | PayPal driver hardening | proposed    |
-| 0072 | Panel Discounts section | proposed    |
+| 0072 | Panel Discounts section | accepted    |
 | 0073 | Split `AmountOff` into `PercentageOff` and `FixedAmountOff` | implemented |

--- a/tests/core/Unit/Actions/Discounts/CreateDiscountTest.php
+++ b/tests/core/Unit/Actions/Discounts/CreateDiscountTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Core\Actions\Discounts\CreateDiscount;
+use Lunar\Core\DiscountTypes\PercentageOff;
+use Lunar\Core\Models\Discount;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+test('creates a discount with the given attributes', function () {
+    $discount = app(CreateDiscount::class)->execute([
+        'name' => 'Winter Sale',
+        'handle' => 'winter-sale',
+        'type' => PercentageOff::class,
+        'coupon' => 'WINTER',
+        'starts_at' => now(),
+        'data' => ['percentage' => 15],
+    ]);
+
+    expect($discount->exists)->toBeTrue();
+    expect(Discount::whereHandle('winter-sale')->count())->toBe(1);
+    expect($discount->name)->toBe('Winter Sale');
+    expect($discount->type)->toBe(PercentageOff::class);
+    expect($discount->coupon)->toBe('WINTER');
+    expect($discount->data)->toBe(['percentage' => 15]);
+});

--- a/tests/core/Unit/Actions/Discounts/DeleteDiscountTest.php
+++ b/tests/core/Unit/Actions/Discounts/DeleteDiscountTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Lunar\Core\Actions\Discounts\DeleteDiscount;
+use Lunar\Core\Models\Brand;
+use Lunar\Core\Models\Channel;
+use Lunar\Core\Models\Collection;
+use Lunar\Core\Models\Customer;
+use Lunar\Core\Models\CustomerGroup;
+use Lunar\Core\Models\Discount;
+use Lunar\Core\Models\Product;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+/**
+ * Row counts are read straight off the pivot tables. Going through the inverse
+ * relations would join back to lunar_discounts and hide orphaned rows, which is
+ * the failure these tests exist to catch.
+ */
+function pivotRowsFor(Discount $discount, string $table): int
+{
+    return DB::table(config('lunar.database.table_prefix').$table)
+        ->where('discount_id', $discount->id)
+        ->count();
+}
+
+test('deletes the discount', function () {
+    $discount = Discount::factory()->create();
+
+    app(DeleteDiscount::class)->execute($discount);
+
+    expect(Discount::find($discount->id))->toBeNull();
+});
+
+test('leaves no targeting or audience rows behind', function () {
+    Channel::factory()->create(['default' => true]);
+
+    $discount = Discount::factory()->create();
+
+    $discount->collections()->attach(Collection::factory()->create()->id, ['type' => 'limitation']);
+    $discount->brands()->attach(Brand::factory()->create()->id, ['type' => 'limitation']);
+    $discount->customers()->attach(Customer::factory()->create()->id);
+    $discount->customerGroups()->attach(CustomerGroup::factory()->create()->id, [
+        'enabled' => true,
+        'visible' => true,
+    ]);
+    $discount->discountables()->create([
+        'discountable_type' => Product::morphName(),
+        'discountable_id' => Product::factory()->create()->id,
+        'type' => 'limitation',
+    ]);
+
+    app(DeleteDiscount::class)->execute($discount);
+
+    expect(pivotRowsFor($discount, 'collection_discount'))->toBe(0);
+    expect(pivotRowsFor($discount, 'brand_discount'))->toBe(0);
+    expect(pivotRowsFor($discount, 'customer_discount'))->toBe(0);
+    expect(pivotRowsFor($discount, 'customer_group_discount'))->toBe(0);
+    expect(pivotRowsFor($discount, 'discountables'))->toBe(0);
+});
+
+test('leaves no channel availability rows behind', function () {
+    // channelables is a morph pivot with no foreign key, so nothing in the
+    // schema clears it — the discount's own teardown has to.
+    Channel::factory()->create(['default' => true]);
+
+    $discount = Discount::factory()->create();
+    $prefix = config('lunar.database.table_prefix');
+
+    $channelables = fn () => DB::table($prefix.'channelables')
+        ->where('channelable_type', Discount::morphName())
+        ->where('channelable_id', $discount->id)
+        ->count();
+
+    expect($channelables())->toBe(1);
+
+    app(DeleteDiscount::class)->execute($discount);
+
+    expect($channelables())->toBe(0);
+});

--- a/tests/core/Unit/Actions/Discounts/UpdateDiscountTest.php
+++ b/tests/core/Unit/Actions/Discounts/UpdateDiscountTest.php
@@ -1,0 +1,310 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Lunar\Core\Actions\Discounts\UpdateDiscount;
+use Lunar\Core\Exceptions\DiscountActionException;
+use Lunar\Core\Models\Brand;
+use Lunar\Core\Models\Channel;
+use Lunar\Core\Models\Collection;
+use Lunar\Core\Models\Customer;
+use Lunar\Core\Models\CustomerGroup;
+use Lunar\Core\Models\Discount;
+use Lunar\Core\Models\Discountable;
+use Lunar\Core\Models\Product;
+use Lunar\Core\Models\ProductVariant;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+/**
+ * @return array<string, int[]> the discountable rows for a bucket, keyed by morph name
+ */
+function discountablesFor(Discount $discount, string $bucket): array
+{
+    return Discountable::whereDiscountId($discount->id)
+        ->whereType($bucket)
+        ->get()
+        ->groupBy('discountable_type')
+        ->map(fn ($rows) => $rows->pluck('discountable_id')->sort()->values()->all())
+        ->all();
+}
+
+test('updates the given attributes', function () {
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [
+        'name' => 'Winter Sale',
+        'handle' => 'winter-sale',
+        'priority' => 5,
+        'stop' => true,
+        'data' => ['percentage' => 20],
+    ]);
+
+    $discount->refresh();
+
+    expect($discount->name)->toBe('Winter Sale');
+    expect($discount->handle)->toBe('winter-sale');
+    expect($discount->priority)->toBe(5);
+    expect((bool) $discount->stop)->toBeTrue();
+    expect($discount->data)->toBe(['percentage' => 20]);
+});
+
+test('syncs channel availability when given', function () {
+    $channel = Channel::factory()->create();
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], channels: [
+        $channel->id => [
+            'enabled' => true,
+            'starts_at' => now()->addDay(),
+            'ends_at' => null,
+        ],
+    ]);
+
+    $pivot = $discount->channels()->first()?->pivot;
+
+    expect((bool) $pivot->enabled)->toBeTrue();
+    expect($pivot->starts_at)->not->toBeNull();
+});
+
+test('syncs customer group availability when given', function () {
+    $group = CustomerGroup::factory()->create();
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], customerGroups: [
+        $group->id => [
+            'enabled' => true,
+            'visible' => false,
+            'starts_at' => null,
+            'ends_at' => null,
+        ],
+    ]);
+
+    $pivot = $discount->customerGroups()->first()?->pivot;
+
+    expect((bool) $pivot->enabled)->toBeTrue();
+    expect((bool) $pivot->visible)->toBeFalse();
+});
+
+test('null leaves availability and targeting untouched', function () {
+    $channel = Channel::factory()->create();
+    $collection = Collection::factory()->create();
+    $discount = Discount::factory()->create();
+
+    $discount->channels()->sync([
+        $channel->id => ['enabled' => true, 'starts_at' => null, 'ends_at' => null],
+    ]);
+    $discount->collections()->attach($collection->id, ['type' => 'limitation']);
+
+    app(UpdateDiscount::class)->execute($discount, ['name' => 'Renamed']);
+
+    expect((bool) $discount->channels()->first()->pivot->enabled)->toBeTrue();
+    expect($discount->collections()->count())->toBe(1);
+});
+
+test('routes limitation and exclusion collections to the collection_discount pivot', function () {
+    $limited = Collection::factory()->create();
+    $excluded = Collection::factory()->create();
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['collections' => [$limited->id]],
+        'exclusion' => ['collections' => [$excluded->id]],
+    ]);
+
+    $pivots = $discount->collections()->get()->mapWithKeys(
+        fn ($collection) => [$collection->pivot->type => $collection->id]
+    );
+
+    expect($pivots->all())->toEqual([
+        'limitation' => $limited->id,
+        'exclusion' => $excluded->id,
+    ]);
+    expect(Discountable::whereDiscountId($discount->id)->count())->toBe(0);
+});
+
+test('routes condition and reward collections to discountables', function () {
+    // BuyXGetY reads its condition and reward collections from the morph table,
+    // not the pivot the line-targeting types read.
+    $condition = Collection::factory()->create();
+    $reward = Collection::factory()->create();
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'condition' => ['collections' => [$condition->id]],
+        'reward' => ['collections' => [$reward->id]],
+    ]);
+
+    expect(discountablesFor($discount, 'condition'))->toBe([
+        Collection::morphName() => [$condition->id],
+    ]);
+    expect(discountablesFor($discount, 'reward'))->toBe([
+        Collection::morphName() => [$reward->id],
+    ]);
+    expect($discount->collections()->count())->toBe(0);
+});
+
+test('routes products and variants to discountables under their own morph', function () {
+    $product = Product::factory()->create();
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id]);
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['products' => [$product->id], 'variants' => [$variant->id]],
+    ]);
+
+    expect(discountablesFor($discount, 'limitation'))->toBe([
+        Product::morphName() => [$product->id],
+        ProductVariant::morphName() => [$variant->id],
+    ]);
+});
+
+test('routes brands to the brand_discount pivot with the bucket type', function () {
+    $limited = Brand::factory()->create();
+    $excluded = Brand::factory()->create();
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['brands' => [$limited->id]],
+        'exclusion' => ['brands' => [$excluded->id]],
+    ]);
+
+    $pivots = $discount->brands()->get()->mapWithKeys(
+        fn ($brand) => [$brand->pivot->type => $brand->id]
+    );
+
+    expect($pivots->all())->toEqual([
+        'limitation' => $limited->id,
+        'exclusion' => $excluded->id,
+    ]);
+});
+
+test('routes customers to the customer_discount pivot', function () {
+    $customer = Customer::factory()->create();
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['customers' => [$customer->id]],
+    ]);
+
+    expect($discount->customers()->get()->pluck('id')->all())->toBe([$customer->id]);
+});
+
+test('a present bucket replaces that bucket wholesale', function () {
+    $keptProduct = Product::factory()->create();
+    $droppedProduct = Product::factory()->create();
+    $droppedCollection = Collection::factory()->create();
+    $droppedCustomer = Customer::factory()->create();
+
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => [
+            'products' => [$droppedProduct->id],
+            'collections' => [$droppedCollection->id],
+            'customers' => [$droppedCustomer->id],
+        ],
+    ]);
+
+    // Only products this time: the kinds left out of a present bucket are cleared.
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['products' => [$keptProduct->id]],
+    ]);
+
+    expect(discountablesFor($discount, 'limitation'))->toBe([
+        Product::morphName() => [$keptProduct->id],
+    ]);
+    expect($discount->collections()->count())->toBe(0);
+    expect($discount->customers()->count())->toBe(0);
+});
+
+test('syncing one bucket leaves the other buckets alone', function () {
+    $limited = Collection::factory()->create();
+    $excluded = Collection::factory()->create();
+    $rewarded = Product::factory()->create();
+    $replacement = Collection::factory()->create();
+
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['collections' => [$limited->id]],
+        'exclusion' => ['collections' => [$excluded->id]],
+        'reward' => ['products' => [$rewarded->id]],
+    ]);
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'limitation' => ['collections' => [$replacement->id]],
+    ]);
+
+    $pivots = $discount->collections()->get()->mapWithKeys(
+        fn ($collection) => [$collection->pivot->type => $collection->id]
+    );
+
+    expect($pivots->all())->toEqual([
+        'limitation' => $replacement->id,
+        'exclusion' => $excluded->id,
+    ]);
+    expect(discountablesFor($discount, 'reward'))->toBe([
+        Product::morphName() => [$rewarded->id],
+    ]);
+});
+
+test('rejects an unknown target bucket', function () {
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'audience' => ['customers' => [1]],
+    ]);
+})->throws(DiscountActionException::class, 'Unknown discount target bucket [audience]');
+
+test('rejects a kind the bucket cannot target', function () {
+    $discount = Discount::factory()->create();
+
+    app(UpdateDiscount::class)->execute($discount, [], targets: [
+        'condition' => ['brands' => [1]],
+    ]);
+})->throws(DiscountActionException::class, 'The [condition] bucket cannot target brands');
+
+test('guards the payload before writing anything', function () {
+    $collection = Collection::factory()->create();
+    $discount = Discount::factory()->create();
+
+    try {
+        app(UpdateDiscount::class)->execute($discount, ['name' => 'Renamed'], targets: [
+            'limitation' => ['collections' => [$collection->id]],
+            'reward' => ['brands' => [1]],
+        ]);
+    } catch (DiscountActionException) {
+        // Expected — the assertions below are the point.
+    }
+
+    expect(Discount::find($discount->id)->name)->not->toBe('Renamed');
+    expect($discount->collections()->count())->toBe(0);
+});
+
+test('rolls the whole update back when a targeting write fails', function () {
+    $product = Product::factory()->create();
+    $collection = Collection::factory()->create();
+    $discount = Discount::factory()->create(['name' => 'Original']);
+
+    // The pivot write is the failure point. SQLite runs with foreign keys off
+    // here, so the constraint violation that would raise it on MySQL or
+    // Postgres has to be provoked directly.
+    DB::listen(function ($query) {
+        if (str_contains($query->sql, 'collection_discount')) {
+            throw new RuntimeException('pivot write failed');
+        }
+    });
+
+    expect(fn () => app(UpdateDiscount::class)->execute($discount, ['name' => 'Renamed'], targets: [
+        'limitation' => [
+            'products' => [$product->id],
+            'collections' => [$collection->id],
+        ],
+    ]))->toThrow(RuntimeException::class);
+
+    expect(Discount::find($discount->id)->name)->toBe('Original');
+    expect(Discountable::whereDiscountId($discount->id)->count())->toBe(0);
+});

--- a/tests/core/Unit/Models/DiscountTest.php
+++ b/tests/core/Unit/Models/DiscountTest.php
@@ -35,6 +35,57 @@ test('can apply usable scope', function () {
     ))->toBeNull();
 });
 
+test('status scopes partition the table the way the status accessor does', function () {
+    $active = Discount::factory()->create([
+        'starts_at' => now()->subDay(),
+        'ends_at' => now()->addDay(),
+    ]);
+
+    $openEnded = Discount::factory()->create([
+        'starts_at' => now()->subDay(),
+        'ends_at' => null,
+    ]);
+
+    $scheduled = Discount::factory()->create([
+        'starts_at' => now()->addDay(),
+        'ends_at' => null,
+    ]);
+
+    $expired = Discount::factory()->create([
+        'starts_at' => now()->subWeek(),
+        'ends_at' => now()->subDay(),
+    ]);
+
+    expect(Discount::active()->pluck('id')->all())->toEqualCanonicalizing([$active->id, $openEnded->id]);
+    expect(Discount::scheduled()->pluck('id')->all())->toBe([$scheduled->id]);
+    expect(Discount::expired()->pluck('id')->all())->toBe([$expired->id]);
+
+    expect($active->status)->toBe(Discount::ACTIVE);
+    expect($openEnded->status)->toBe(Discount::ACTIVE);
+    expect($scheduled->status)->toBe(Discount::SCHEDULED);
+    expect($expired->status)->toBe(Discount::EXPIRED);
+});
+
+test('an end date in the past beats a start date in the future', function () {
+    $discount = Discount::factory()->create([
+        'starts_at' => now()->addDay(),
+        'ends_at' => now()->subDay(),
+    ]);
+
+    expect(Discount::expired()->pluck('id')->all())->toBe([$discount->id]);
+    expect(Discount::scheduled()->count())->toBe(0);
+    expect($discount->status)->toBe(Discount::EXPIRED);
+});
+
+test('pending matches nothing while starts_at is required', function () {
+    // The column is NOT NULL in the baseline schema, so no discount can reach
+    // pending. The scope is here to keep the four statuses exhaustive.
+    Discount::factory()->create(['starts_at' => now()->subDay()]);
+    Discount::factory()->create(['starts_at' => now()->addDay()]);
+
+    expect(Discount::pending()->count())->toBe(0);
+});
+
 test('can apply collections scope', function () {
     $collectionA = Collection::factory()->create();
     $collectionB = Collection::factory()->create();


### PR DESCRIPTION
First slice of [spec 0072](https://github.com/lunarphp/lunar/blob/feat/0072-discount-actions/specs/0072-panel-discounts-section.md), now that 0073 has landed. Core only — no panel surface yet.

## What this adds

**`CreatesDiscount` / `UpdatesDiscount` / `DeletesDiscount`**, mirroring the Brands trio and registered in `ActionServiceProvider::$actions`. Discounts were the only panel-bound entity with nothing to delegate to.

**The targeting fan-out on `UpdatesDiscount`.** Core spreads targeting across four tables and which one an entity lands in depends on its bucket:

| Bucket | Products / variants | Collections | Brands | Customers |
| --- | --- | --- | --- | --- |
| `limitation` | `discountables` | `collection_discount` | `brand_discount` | `customer_discount` |
| `exclusion` | `discountables` | `collection_discount` | `brand_discount` | — |
| `condition` | `discountables` | `discountables` | — | — |
| `reward` | `discountables` | `discountables` | — | — |

Collections are the trap — the same conceptual "this collection" lives in two different tables depending on the bucket. Callers now pass one id map per bucket and the action routes it, in a transaction. A bucket present in the payload replaces that bucket wholesale; a bucket handed a kind it cannot target (brands on a `condition`, say) raises rather than writing rows no discount type reads.

**`scopeExpired()` / `scopeScheduled()` / `scopePending()`** so the derived status is filterable in SQL.

## Two spec corrections

Both verified against `BuyXGetY::apply()` rather than taken from the spec:

- **The `reward` bucket does target collections.** The spec's routing table and `$targets` shape both omitted them, but `apply()` matches `Collection::morphName()` in its reward-line filter and `processAutomaticRewards()` handles a collection reward explicitly. Filament never surfaced it, which is likely how it got missed. Fixed in the spec and implemented.
- **`customer_discount` has no `type` column**, so eligible customers can only hang off one bucket. They hang off `limitation`, matching `CustomerLimitationRelationManager`.

## A bug found on the way

`DiscountObserver::deleting()` detached every pivot except `channels()` — unlike its `Product` and `Collection` siblings, which both do. Every discount delete was orphaning its `channelables` rows. Fixed there rather than in the action, so all delete paths get it; `DeleteDiscount` is then just the transaction around it. The regression test is load-bearing — I removed the detach and confirmed it fails.

## On `scopePending`

Worth a look during review. `pending` only arises from a null `starts_at`, and the baseline schema declares that column `NOT NULL`, so the scope matches nothing and the accessor can only return `pending` at the exact boundary instant. I implemented it because the spec asks and it keeps the four statuses exhaustive, but it may be that `pending` is vestigial and the panel filter should offer three statuses, not four. Happy to drop it.

The new scopes also follow `scopeActive`'s inclusive boundary rather than the accessor's `isPast()`, so that the four partition the table and no row falls outside every filter. The cost is that a discount ending at exactly `now()` reads as expired by scope and active by accessor.

## Verification

- Core 1276 passed / 1 skipped, admin 262, panel 749, filament 73, shipping 103, stripe 48, search 28, upgrade 94.
- Cross-db group green against **both** MySQL and Postgres (108 passed), which matters here — the new scopes are date comparisons and the tests sit in that group.
- PHPStan `[OK] No errors`, Pint clean.

Spec 0072 moved `proposed` → `accepted` and slice 1 ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)