### PR TITLE
Replace a republished shipping option, and reset the manifest per cart

### DIFF
--- a/packages/core/src/Base/ShippingManifest.php
+++ b/packages/core/src/Base/ShippingManifest.php
@@ -23,6 +23,11 @@ class ShippingManifest implements ShippingManifestInterface
     protected bool $resolving = false;
 
     /**
+     * The cart the options currently in the manifest were resolved for.
+     */
+    protected ?int $resolvedFor = null;
+
+    /**
      * Initiate the class.
      */
     public function __construct()
@@ -35,13 +40,18 @@ class ShippingManifest implements ShippingManifestInterface
      */
     public function addOption(ShippingOption $option)
     {
-        $exists = $this->options->first(function ($opt) use ($option) {
-            return $opt->getIdentifier() == $option->getIdentifier();
-        });
+        // Publishing an identifier that is already here replaces it. Skipping
+        // instead meant the first price ever computed for an identifier was the
+        // only one that counted: a modifier re-pricing the same option for a
+        // changed destination or basket had its answer discarded.
+        $index = $this->options->search(
+            fn ($opt) => $opt->getIdentifier() == $option->getIdentifier()
+        );
 
-        // Does this option already exist?
-        if (! $exists) {
+        if ($index === false) {
             $this->options->push($option);
+        } else {
+            $this->options->put($index, $option);
         }
 
         return $this;
@@ -88,6 +98,17 @@ class ShippingManifest implements ShippingManifestInterface
         if ($this->resolving) {
             return $this->options;
         }
+
+        // The manifest is a singleton, so in any process that handles more than
+        // one cart - a queue job, a console command, an Octane worker - options
+        // priced for the last cart are still here. Start clean when the cart
+        // changes; options added for THIS cart, including any published before
+        // the first resolve, are left alone.
+        if ($this->resolvedFor !== null && $this->resolvedFor !== $cart->id) {
+            $this->options = collect();
+        }
+
+        $this->resolvedFor = $cart->id;
 
         $this->resolving = true;
 

--- a/tests/core/Unit/Base/ShippingManifestTest.php
+++ b/tests/core/Unit/Base/ShippingManifestTest.php
@@ -285,3 +285,67 @@ test('can not re-enter shipping modifiers while resolving options', function () 
     // a single calculate runs the modifiers twice. Neither run may re-enter.
     expect(TestRecursiveShippingModifier::$calls)->toEqual(2);
 });
+
+test('can replace an option that is published again', function () {
+    $taxClass = TaxClass::factory()->create();
+
+    $option = fn (int $price) => new ShippingOption(
+        name: 'Standard delivery',
+        description: 'Standard delivery',
+        identifier: 'STANDARD',
+        price: new Price($price, $this->cart->currency, 1),
+        taxClass: $taxClass
+    );
+
+    ShippingManifest::addOption($option(500));
+    ShippingManifest::addOption($option(2500));
+
+    // One option, at the price it was last published with - a modifier
+    // re-pricing for a changed destination must not be ignored.
+    expect(ShippingManifest::getOptions($this->cart))->toHaveCount(1);
+    expect(ShippingManifest::getOptions($this->cart)->first()->price->value)->toEqual(2500);
+});
+
+test('can not offer one cart the options priced for another', function () {
+    $taxClass = TaxClass::factory()->create();
+
+    ShippingManifest::addOption(
+        new ShippingOption(
+            name: 'Standard delivery',
+            description: 'Standard delivery',
+            identifier: 'STANDARD',
+            price: new Price(500, $this->cart->currency, 1),
+            taxClass: $taxClass
+        )
+    );
+
+    expect(ShippingManifest::getOptions($this->cart))->toHaveCount(1);
+
+    // The next cart in the same process - a queue job, a console command, an
+    // Octane worker - must not inherit them.
+    $other = Cart::factory()->create([
+        'currency_id' => $this->cart->currency_id,
+    ]);
+
+    expect(ShippingManifest::getOptions($other))->toHaveCount(0);
+});
+
+test('can keep options published for the cart being resolved', function () {
+    $taxClass = TaxClass::factory()->create();
+
+    ShippingManifest::addOption(
+        new ShippingOption(
+            name: 'Standard delivery',
+            description: 'Standard delivery',
+            identifier: 'STANDARD',
+            price: new Price(500, $this->cart->currency, 1),
+            taxClass: $taxClass
+        )
+    );
+
+    // Publishing straight onto the manifest, rather than from inside a
+    // modifier, is how much of the suite sets shipping up. Resolving the same
+    // cart must not discard it.
+    expect(ShippingManifest::getOptions($this->cart))->toHaveCount(1);
+    expect(ShippingManifest::getOptions($this->cart))->toHaveCount(1);
+});


### PR DESCRIPTION
Fixes #2691.

The same code is on `2.x` at `Manifests/ShippingManifest.php`, so this wants a
forward port.

A modifier that re-prices an option has its answer discarded, and in any process
handling more than one cart the next cart is offered the last one's options.

### The fix

Two changes, one for each half of it.

`addOption()` **replaces** an option whose identifier is already present instead
of returning without doing anything. That is what makes a re-priced option stick.

`getOptions()` starts with a clean collection **when the cart being resolved
changes**. Resetting unconditionally would have been simpler, but much of the
suite publishes straight onto the manifest rather than from inside a modifier —
`tests/Pest.php`, `tests/stripe/Utils/CartBuilder.php` and seven others — and
that usage is legitimate. Resetting on a change of cart leaves it working while
still giving each cart a manifest of its own. There is a test pinning that.

In shipped code the only caller of `addOption()` is `table-rate-shipping`'s
modifier, so nothing outside the tests depends on the old behaviour.

### Tests

`tests/core/Unit/Base/ShippingManifestTest.php`:

- **can replace an option that is published again** — the same identifier at
  500 then 2500. Fails on `1.x` with
  `Failed asserting that 500 matches expected 2500`.
- **can not offer one cart the options priced for another** — a second cart in
  the same process. Fails on `1.x` with
  `Failed asserting that actual size 1 matches expected size 0`.
- **can keep options published for the cart being resolved** — an option added
  directly, then two resolves of that same cart. Passes before and after, and is
  the guard that this does not break the way the suite sets shipping up.
