### PR TITLE
feat(repo): publish npm packages via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -3,11 +3,20 @@ name: publish-npm
 # Publishes the add-on-facing npm packages (@lunarphp/panel and
 # @lunarphp/panel-vite-plugin) alongside the Composer monorepo split.
 # Skips any version already on the registry, so tags that don't bump the
-# npm package versions pass without churn. Requires the NPM_TOKEN secret.
+# npm package versions pass without churn.
+#
+# Authenticates via npm trusted publishing (OIDC) — no NPM_TOKEN secret.
+# Each package registers this repo + workflow filename as its trusted
+# publisher on npmjs.com; the id-token permission lets the job mint the
+# short-lived credential, and --provenance attests the build.
 
 on:
   push:
     tags: "*"
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -26,7 +35,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+
+      # Node 22 bundles npm 10.x; trusted publishing needs npm >= 11.5.1.
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
 
       # Two installs, matching tests.yml: the workspace root links the
       # publishable packages; packages/panel (which generates the
@@ -44,7 +56,5 @@ jobs:
           if npm view "${{ matrix.package }}@${version}" version > /dev/null 2>&1; then
             echo "${{ matrix.package }}@${version} already published, skipping."
           else
-            npm publish --workspace ${{ matrix.package }} --access public
+            npm publish --workspace ${{ matrix.package }} --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/panel/resources/package/LICENSE.md
+++ b/packages/panel/resources/package/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) LunarPHP Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/panel/resources/package/README.md
+++ b/packages/panel/resources/package/README.md
@@ -1,0 +1,43 @@
+# @lunarphp/panel-vite-plugin
+
+Vite plugin for compiling [Lunar](https://lunarphp.io) panel add-on bundles.
+
+The [`lunarphp/panel`](https://github.com/lunarphp/lunar) admin panel loads add-on JavaScript at runtime as IIFE bundles that share the panel's runtime. This plugin configures that build: it compiles your add-on entry to a single IIFE, externalises `vue`, `@inertiajs/vue3`, `vue-i18n`, and [`@lunarphp/panel`](https://www.npmjs.com/package/@lunarphp/panel) to the globals the panel publishes at startup (so your bundle ships no duplicate framework code and shares the panel's Vue, Inertia, and i18n instances), and places the build manifest where Laravel's Vite integration expects it.
+
+## Installation
+
+```sh
+npm install --save-dev @lunarphp/panel-vite-plugin @lunarphp/panel
+```
+
+## Usage
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import lunarPanelPlugin from '@lunarphp/panel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        vue(),
+        lunarPanelPlugin({ name: 'MyPanelAddon' }),
+    ],
+    build: {
+        outDir: 'build',
+        rollupOptions: {
+            input: 'resources/js/addon.ts',
+        },
+    },
+});
+```
+
+`name` sets the global variable your IIFE bundle is assigned to (default `LunarPanelAddon`).
+
+## Documentation
+
+See the [panel add-on example](https://github.com/lunarphp/lunar/tree/2.x/packages/panel-addon-example) for a full, tested walkthrough of building an add-on, and the [Lunar documentation](https://docs.lunarphp.io) for the panel itself.
+
+## License
+
+MIT. See [LICENSE.md](LICENSE.md).

--- a/packages/panel/resources/package/package.json
+++ b/packages/panel/resources/package/package.json
@@ -4,6 +4,11 @@
     "type": "module",
     "description": "Vite plugin for compiling lunarphp/panel add-on bundles as IIFEs sharing the panel's Vue runtime.",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lunarphp/lunar.git",
+        "directory": "packages/panel/resources/package"
+    },
     "main": "vite-plugin.js",
     "exports": {
         ".": "./vite-plugin.js"

--- a/packages/panel/resources/panel-package/LICENSE.md
+++ b/packages/panel/resources/panel-package/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) LunarPHP Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/panel/resources/panel-package/README.md
+++ b/packages/panel/resources/panel-package/README.md
@@ -1,0 +1,33 @@
+# @lunarphp/panel
+
+Layout and page-chrome components for building [Lunar](https://lunarphp.io) panel add-on pages.
+
+The [`lunarphp/panel`](https://github.com/lunarphp/lunar) Composer package is Lunar's first-party admin panel (Inertia.js + Vue 3). Add-on packages extend it at runtime — pages, navigation, table columns, actions, screen sections — without the host app recompiling any JavaScript. This npm package is the component surface those add-on pages build with: `PageHeader`, `SettingsShell`, `DataTable`, form inputs, overlays, charts, and the rest of the exported set.
+
+## Installation
+
+```sh
+npm install --save-dev @lunarphp/panel @lunarphp/panel-vite-plugin
+```
+
+## Usage
+
+Import components as usual in your add-on's Vue pages:
+
+```vue
+<script setup lang="ts">
+import { PageHeader, DataTable, Button } from '@lunarphp/panel';
+</script>
+```
+
+At build time, [`@lunarphp/panel-vite-plugin`](https://www.npmjs.com/package/@lunarphp/panel-vite-plugin) externalises the `@lunarphp/panel` import to the panel's runtime global, so your bundle shares the panel's Vue instance and component implementations — this package contributes type declarations and editor support during development, not duplicated runtime code.
+
+The panel applies its `PanelLayout` shell to add-on pages automatically; a page supplies only its own `PageHeader` (or `SettingsShell`) and content.
+
+## Documentation
+
+See the [panel add-on example](https://github.com/lunarphp/lunar/tree/2.x/packages/panel-addon-example) for a full, tested walkthrough of building an add-on, and the [Lunar documentation](https://docs.lunarphp.io) for the panel itself.
+
+## License
+
+MIT. See [LICENSE.md](LICENSE.md).

--- a/packages/panel/resources/panel-package/package.json
+++ b/packages/panel/resources/panel-package/package.json
@@ -4,6 +4,11 @@
     "type": "module",
     "description": "Panel layout and page-chrome components for building lunarphp/panel add-on pages.",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lunarphp/lunar.git",
+        "directory": "packages/panel/resources/panel-package"
+    },
     "main": "index.js",
     "module": "index.js",
     "types": "dist/ui.d.ts",


### PR DESCRIPTION
## What

Prepares the first npm publish of `@lunarphp/panel` and `@lunarphp/panel-vite-plugin` using [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) instead of an `NPM_TOKEN` secret — no long-lived registry credential to rotate (granular tokens now cap at 90 days) or leak.

- `publish_npm.yml`: add `id-token: write` / `contents: read` permissions, upgrade npm in the job (Node 22 bundles npm 10.x; OIDC needs >= 11.5.1), remove the `NODE_AUTH_TOKEN` / `registry-url` wiring, publish with `--provenance`. The skip-if-version-already-published guard is unchanged.
- Both publishable `package.json`s gain a `repository` field (with `directory`) — required for provenance verification.
- Both packages gain a README (accurate to the current plugin behaviour and `ui.ts` surface) and the MIT `LICENSE.md`, so the registry pages aren't blank on first publish. Verified via `npm pack --dry-run` that both land in the tarballs.

## Bootstrapping (manual, after merge)

Trusted publishing can't create a brand-new package, so the first publish is done once, locally, with an interactive `npm login` (no automation token):

1. `npm install` at the monorepo root and in `packages/panel`, then `npm publish --workspace @lunarphp/panel --access public` and the same for `@lunarphp/panel-vite-plugin`.
2. On npmjs.com, for each package: Settings → Trusted Publisher → GitHub Actions → org `lunarphp`, repo `lunar`, workflow `publish_npm.yml` (no environment).
3. Every subsequent tag/release publishes token-lessly via this workflow when a version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)