### PR TITLE
chore(panel): bump npm packages to 0.1.1

### DIFF
--- a/packages/panel/resources/package/package.json
+++ b/packages/panel/resources/package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lunarphp/panel-vite-plugin",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "type": "module",
     "description": "Vite plugin for compiling lunarphp/panel add-on bundles as IIFEs sharing the panel's Vue runtime.",
     "license": "MIT",

--- a/packages/panel/resources/panel-package/package.json
+++ b/packages/panel/resources/panel-package/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lunarphp/panel",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "type": "module",
     "description": "Panel layout and page-chrome components for building lunarphp/panel add-on pages.",
     "license": "MIT",


### PR DESCRIPTION
## What

Bumps `@lunarphp/panel` and `@lunarphp/panel-vite-plugin` from `0.1.0` to `0.1.1`. No content changes.

## Why

`0.1.0` was published manually today; the OIDC trusted-publishing path in `publish_npm.yml` has never actually published. This bump makes the next release tag (`2.0.0-alpha.5`) run the full automated publish for both packages — provenance included — so the pipeline gets its first end-to-end validation on a version where nothing is at stake.

The example add-on's `^0.1.0` ranges resolve to `0.1.1` without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)