### PR TITLE
fix(paypal): compare the amount guard at PayPal's precision

### DIFF
--- a/packages/paypal/src/PaypalPaymentType.php
+++ b/packages/paypal/src/PaypalPaymentType.php
@@ -167,6 +167,15 @@ class PaypalPaymentType extends AbstractPayment
             )
         );
 
+        // Compare at PayPal's precision for the currency — for one PayPal treats
+        // as zero-decimal, a subunit total can never be matched exactly, so
+        // holding PayPal to the raw minor-unit total would refuse every total
+        // that rounds down.
+        $expectedAmount = PaypalManager::fromPaypalAmount(
+            PaypalManager::toPaypalAmount($expectedAmount, $currency),
+            $currency,
+        );
+
         if ($paypalAmount < $expectedAmount) {
             return $this->fail('PayPal order amount does not cover the order total');
         }

--- a/tests/paypal/Unit/PaypalPaymentTypeTest.php
+++ b/tests/paypal/Unit/PaypalPaymentTypeTest.php
@@ -192,6 +192,43 @@ it('places the order when paypal covers more than the total', function () {
         ->and($cart->refresh()->completedOrder->placed_at)->not->toBeNull();
 });
 
+it('authorizes a zero-decimal currency total that rounds to a whole unit', function () {
+    $cart = CartBuilder::build(currencyParams: ['code' => 'HUF'])->calculate();
+
+    // PayPal only accepts whole HUF, so a 12.34 HUF total can never be matched
+    // exactly — the canonical PayPal amount is "12". The guard has to compare
+    // at PayPal's precision or every total that rounds down is unpayable.
+    $order = $cart->createOrder();
+    $order->update(['total' => 1234]);
+
+    PaypalFake::forCart($cart, ['amount' => '12']);
+
+    $response = (new PaypalPaymentType)->order($order)->withData([
+        'paypal_order_id' => '5O190127TN364715T',
+    ])->authorize();
+
+    expect($response->success)->toBeTrue()
+        ->and(Transaction::where('type', 'capture')->first()->amount)->toEqual(1200);
+});
+
+it('refuses a zero-decimal currency amount short by a whole unit', function () {
+    $cart = CartBuilder::build(currencyParams: ['code' => 'HUF'])->calculate();
+
+    $order = $cart->createOrder();
+    $order->update(['total' => 1234]);
+
+    PaypalFake::forCart($cart, ['amount' => '11']);
+
+    $response = (new PaypalPaymentType)->order($order)->withData([
+        'paypal_order_id' => '5O190127TN364715T',
+    ])->authorize();
+
+    expect($response->success)->toBeFalse()
+        ->and($response->message)->toEqual('PayPal order amount does not cover the order total');
+
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/capture'));
+});
+
 it('refuses to authorize when the paypal currency differs', function () {
     $cart = CartBuilder::build()->calculate();
 

--- a/tests/paypal/Utils/CartBuilder.php
+++ b/tests/paypal/Utils/CartBuilder.php
@@ -33,6 +33,9 @@ class CartBuilder
         $currency = (! $currencyParams ? Currency::query()->where('default', true)->first() : null)
             ?: Currency::factory()->create(array_merge([
                 'default' => true,
+                // Pinned — faker can roll HUF/JPY/TWD, which PayPal treats as
+                // zero-decimal, and the suite's amount assertions assume 2dp.
+                'code' => 'USD',
             ], $currencyParams));
 
         $taxClass = TaxClass::factory()->create();


### PR DESCRIPTION
## What

Fixes the flaky paypal suite seen in [this run](https://github.com/lunarphp/lunar/actions/runs/33253802592/job/99103938150), and the driver defect it exposed.

## Root cause

`CartBuilder` created its currency with faker's `currencyCode`, which occasionally rolls **HUF, JPY, or TWD** — currencies `PaypalManager` treats as zero-decimal at PayPal — while the factory always sets `decimal_places = 2`. `PaypalFake::forCart()` sizes the PayPal order with `toPaypalAmount(total)`, so a total like `1215` becomes `"12"`, which round-trips back as `1200`, and `assertOrderMatchesTotal()` refuses with "PayPal order amount does not cover the order total". `authorize()` fails silently, no capture transaction is written, and the test crashes reading `->meta` on `null`.

This is a real driver bug, not just test noise: a merchant running a zero-decimal PayPal currency at `decimal_places > 0` could never take payment for any total that rounds down to a whole unit — even when the PayPal order was sized by this package's own helper.

## Changes

- **`PaypalPaymentType::assertOrderMatchesTotal()`** — round-trips the expected total through `toPaypalAmount()`/`fromPaypalAmount()` before comparing, holding PayPal to the finest precision it can actually express for the currency. For two-decimal currencies the round-trip is an identity, so behaviour there is unchanged.
- **`tests/paypal/Utils/CartBuilder.php`** — pins the default currency code to USD; other assertions in the suite (the `'5.00'` refund body, the `1999` scaling test) also silently assumed a two-decimal currency and were flake-exposed the same way.
- **`tests/paypal/Unit/PaypalPaymentTypeTest.php`** — two regression tests: a 12.34 HUF order total authorizes against the canonical `"12"` PayPal amount (fails deterministically against the old guard), and an amount short by a whole unit is still refused before any capture call.

## Verification

- Paypal suite green across three parallel runs (73 passed), plus eight runs of a HUF-pinned repro with random totals.
- The new round-down regression test verified to fail against the pre-fix driver.
- Pint and PHPStan pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)