### PR TITLE
fix(repo): stop parsing npm pkg get output in the publish workflow

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -13,6 +13,10 @@ name: publish-npm
 on:
   push:
     tags: "*"
+  # Manual escape hatch: tag pushes run the workflow file at the tagged
+  # commit, so a workflow fix that lands after a tag can't help that tag.
+  # Dispatching runs this file from the chosen ref instead.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -24,9 +28,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - "@lunarphp/panel"
-          - "@lunarphp/panel-vite-plugin"
+        include:
+          - package: "@lunarphp/panel"
+            directory: packages/panel/resources/panel-package
+          - package: "@lunarphp/panel-vite-plugin"
+            directory: packages/panel/resources/package
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -50,9 +56,12 @@ jobs:
         run: npm install
         working-directory: packages/panel
 
+      # Read the version from package.json directly — npm 12 changed
+      # `npm pkg get` from JSON to plain-text output, so its shape can't
+      # be relied on across the npm@latest upgrade above.
       - name: Publish ${{ matrix.package }}
         run: |
-          version=$(npm pkg get version --workspace ${{ matrix.package }} | jq -r 'to_entries[0].value')
+          version=$(node -p "require('./${{ matrix.directory }}/package.json').version")
           if npm view "${{ matrix.package }}@${version}" version > /dev/null 2>&1; then
             echo "${{ matrix.package }}@${version} already published, skipping."
           else


### PR DESCRIPTION
## What

The `2.0.0-alpha.5` tag's `publish-npm` run failed on both packages with `jq: parse error: Invalid numeric literal at line 1, column 16`. Cause: the workflow's `npm install -g npm@latest` step now installs **npm 12**, which changed `npm pkg get`'s output from JSON (`{"@lunarphp/panel": "0.1.1"}`) to plain text (`@lunarphp/panel 0.1.1`) — reproduced locally with `npx npm@12`. Column 16 is exactly where the version starts after the package name.

- Carry each package's `directory` in the matrix and read the version with `node -p "require('./<dir>/package.json').version"` — no npm CLI output parsing to drift.
- Add `workflow_dispatch`: tag pushes run the workflow file at the tagged commit, so this fix can't retroactively help `2.0.0-alpha.5`. After merging, dispatch the workflow from `2.x` to publish the pending `0.1.1` (the skip-if-published guard makes the dispatch idempotent).

## Post-merge step

`gh workflow run publish_npm.yml --ref 2.x` — publishes `0.1.1` of both packages via OIDC.

(The tag's other failure — monorepo-split for `panel` and `panel-addon-example` — was the target repos not existing; they've been created and the failed legs re-run separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)