### PR TITLE
fix(stripe): handle a missing order in ProcessStripeWebhook

### DIFF
--- a/packages/stripe/src/Jobs/ProcessStripeWebhook.php
+++ b/packages/stripe/src/Jobs/ProcessStripeWebhook.php
@@ -43,7 +43,7 @@ class ProcessStripeWebhook implements ShouldQueue
         if ($this->orderId) {
             $order = Order::find($this->orderId);
 
-            if ($order->placed_at) {
+            if ($order?->placed_at) {
                 return;
             }
         }

--- a/tests/stripe/Unit/Jobs/ProcessStripeWebbookTest.php
+++ b/tests/stripe/Unit/Jobs/ProcessStripeWebbookTest.php
@@ -16,3 +16,13 @@ it('will dispatch event if payment intent has no found cart or order', function 
         CartMissingForIntent::class,
     );
 });
+
+it('will dispatch event if the order id in the intent metadata no longer exists', function () {
+    Event::fake();
+
+    ProcessStripeWebhook::dispatchSync('PI_FOOBAR', '999999');
+
+    Event::assertDispatched(
+        CartMissingForIntent::class,
+    );
+});


### PR DESCRIPTION
## What

`Lunar\Stripe\Jobs\ProcessStripeWebhook::handle()` dereferences the result of `Order::find($this->orderId)` without a null check:

```php
if ($this->orderId) {
    $order = Order::find($this->orderId);

    if ($order->placed_at) {
        return;
    }
}
```

When the webhook's intent metadata carries an `order_id` whose order no longer exists (deleted, pruned, or otherwise gone by the time the webhook lands), `Order::find()` returns `null` and the job fails with:

```
ErrorException: Attempt to read property "placed_at" on null
```

The job never reaches the orphan handling immediately below it — the `if (! $order)` cart lookup via `StripePaymentIntent` / `Cart.meta->payment_intent`, and the `CartMissingForIntent::dispatch()` fallback — so the webhook is retried until it exhausts its attempts instead of being handled.

## Why this fix

The path below already treats `$order === null` as a supported state (`if (! $order)` looks up the cart; `if (! $cart && ! $order)` dispatches `CartMissingForIntent`). The only thing standing between a missing order and that handling is the unguarded `placed_at` read, so the fix is a null-safe access:

```php
if ($order?->placed_at) {
```

Nothing else changes: a placed order still returns early, an unplaced order still authorizes against the order, and a missing order now falls through to the cart lookup / `CartMissingForIntent` event exactly as a null `orderId` does today.

## Tests

Added a case to `tests/stripe/Unit/Jobs/ProcessStripeWebbookTest.php` that dispatches the job with a non-existent order id and asserts `CartMissingForIntent` is dispatched. It fails on `1.x` with the `ErrorException` above and passes with the fix. The full `stripe` test suite passes locally (49 tests).

## Branches

The same line is present on both `1.x` and `2.x` (`packages/stripe/src/Jobs/ProcessStripeWebhook.php` line 46 on each tip as of 2026-08-29). This PR targets `1.x` per the contributing guide; it applies cleanly to `2.x` as well, so it is a candidate for `needs-forward-port`.

This is a small isolated bug fix, so no issue was opened first, per the "Non-trivial changes need acceptance first" section of CONTRIBUTING.md. Happy to open one if you would prefer the paper trail.
