### PR TITLE
fix(core): reconcile order line refunded quantity

### DIFF
--- a/packages/core/database/migrations/2026_01_01_000073_add_refunded_quantity_to_order_lines_table.php
+++ b/packages/core/database/migrations/2026_01_01_000073_add_refunded_quantity_to_order_lines_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Core\Database\Migration;
+
+/**
+ * Reconcile databases that ran the v2 order-lines baseline before line-item
+ * refunds added the refunded quantity rollup to that existing migration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $table = $this->prefix.'order_lines';
+
+        if (! Schema::hasTable($table) || Schema::hasColumn($table, 'refunded_quantity')) {
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $table) {
+            $table->unsignedInteger('refunded_quantity')
+                ->default(0)
+                ->comment('Rollup of refund_lines.quantity for this line');
+        });
+    }
+
+    public function down(): void
+    {
+        // The flat baseline owns this column, so reconciliation must not remove it.
+    }
+};

--- a/tests/core/Unit/OrderLineRefundedQuantityMigrationTest.php
+++ b/tests/core/Unit/OrderLineRefundedQuantityMigrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Lunar\Tests\Core\TestCase;
+
+uses(TestCase::class)->group('migrations', 'cross-db');
+
+const REFUNDED_QUANTITY_PREFIX = 'refundqty_';
+
+beforeEach(function () {
+    config(['lunar.database.table_prefix' => REFUNDED_QUANTITY_PREFIX]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists(REFUNDED_QUANTITY_PREFIX.'order_lines');
+});
+
+function refundedQuantityMigration(): object
+{
+    $path = glob(dirname(__DIR__, 3).'/packages/core/database/migrations/*add_refunded_quantity_to_order_lines_table.php');
+
+    return require $path[0];
+}
+
+function createExistingOrderLinesTable(bool $withRefundedQuantity = false): void
+{
+    Schema::create(REFUNDED_QUANTITY_PREFIX.'order_lines', function (Blueprint $table) use ($withRefundedQuantity) {
+        $table->id();
+        $table->unsignedInteger('quantity');
+
+        if ($withRefundedQuantity) {
+            $table->unsignedInteger('refunded_quantity')->default(0);
+        }
+    });
+}
+
+test('it adds refunded quantity and preserves existing order lines', function () {
+    createExistingOrderLinesTable();
+
+    DB::table(REFUNDED_QUANTITY_PREFIX.'order_lines')->insert([
+        'id' => 1,
+        'quantity' => 3,
+    ]);
+
+    $migration = refundedQuantityMigration();
+    $migration->up();
+    $migration->up();
+
+    $line = DB::table(REFUNDED_QUANTITY_PREFIX.'order_lines')->find(1);
+
+    expect(Schema::hasColumn(REFUNDED_QUANTITY_PREFIX.'order_lines', 'refunded_quantity'))->toBeTrue()
+        ->and($line->quantity)->toBe(3)
+        ->and($line->refunded_quantity)->toBe(0);
+
+    $migration->down();
+
+    expect(Schema::hasColumn(REFUNDED_QUANTITY_PREFIX.'order_lines', 'refunded_quantity'))->toBeTrue();
+});
+
+test('it is a no-op when refunded quantity already exists', function () {
+    createExistingOrderLinesTable(withRefundedQuantity: true);
+
+    DB::table(REFUNDED_QUANTITY_PREFIX.'order_lines')->insert([
+        'id' => 1,
+        'quantity' => 3,
+        'refunded_quantity' => 2,
+    ]);
+
+    refundedQuantityMigration()->up();
+
+    expect(DB::table(REFUNDED_QUANTITY_PREFIX.'order_lines')->value('refunded_quantity'))->toBe(2);
+});
+
+test('it is a no-op when the order lines table does not exist', function () {
+    $migration = refundedQuantityMigration();
+
+    $migration->up();
+    $migration->down();
+
+    expect(Schema::hasTable(REFUNDED_QUANTITY_PREFIX.'order_lines'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Fixes #2709.

Adds a guarded core migration to reconcile
`order_lines.refunded_quantity` on existing Lunar 2.x databases.

The line-item refund work added this column to the order-lines create-table
baseline. Databases that had already recorded that migration did not rerun it,
so they could receive `refund_lines` while still lacking the rollup column.

When those databases processed a line-item refund, Lunar could complete the
payment driver's refund call and then fail while persisting the line allocation
because `RefundOrder` increments the missing column.

## Changes

- adds a prefix-aware reconciliation migration after `refund_lines`;
- safely no-ops when the table is absent or the column already exists;
- adds an unsigned `refunded_quantity` column with a default of `0`;
- preserves existing order-line records;
- uses a non-destructive rollback because the flat baseline owns the column.

## Tests

- verifies the column is added and existing rows default to zero;
- verifies repeated execution is safe;
- verifies already-current and missing-table schemas are no-ops;
- verifies core migrations still roll back and re-apply;
- verifies existing line-item refund behavior remains green.

## Scope

This PR is limited to Lunar's provider-independent schema reconciliation. It
does not change provider behavior, refund transaction boundaries, ledger
attribution, replay semantics, `RefundRequest`, or historical allocation data.