### PR TITLE
ci: upgrade npm before installing the panel dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,6 +158,15 @@ jobs:
         with:
           node-version: 22
 
+      # npm 10 (bundled with Node 22) crashes with "Cannot read properties of
+      # null (reading 'edgesOut')" while resolving the panel's dependencies.
+      # vitest's peer range on vite makes npm inspect the latest vite, whose
+      # optional @vitejs/devtools peer leads back to vitest@* — a peer cycle
+      # that npm 10's resolver cannot handle since vitest 5.0.0 was published.
+      # npm 11 resolves it; drop this step once the job runs on Node 24.
+      - name: Upgrade npm
+        run: npm install -g npm@11
+
       # npm install, not ci: the repo gitignores package-lock.json, so ranges
       # resolve fresh each run (consistent with the daily full-matrix sweep).
       # Two installs: the workspace root links the publishable packages and


### PR DESCRIPTION
## Problem

The `panel JS - vitest, types, builds` job has failed on every 2.x-targeted branch since 3 September. It dies in the second `npm install` (inside `packages/panel`) before any test runs:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

## Cause

The panel's lock file is gitignored by design, so CI resolves version ranges fresh each run. vitest's peer range on vite (`^6 || ^7 || ^8`) makes npm inspect the latest vite 8, whose optional `@vitejs/devtools` peer chains through `@vitejs/devtools-vitest` to `vitest@*`. Since vitest 5.0.0 was published (2026-09-03 12:24 UTC, the first failing run was 19:04 UTC the same day) that edge resolves to a different major than the one being installed, and npm 10's peer-set loader crashes on the cycle.

Reproduced locally from a bare `package.json`:

| npm | Result |
|---|---|
| 10.9.x (bundled with Node 22) | crash |
| 10.9.x with `--legacy-peer-deps` | ok |
| 11.19.1 | ok |
| 12.0.2 | ok |
| 10.9.x with the existing lock file | ok (no fresh resolve) |

Pinning vitest to 4.1.10 does not help, so this is not a vitest 4.1.11 regression. npm `overrides` cannot target a direct dependency.

## Fix

Upgrade to npm 11 in the panel JS job before installing. Test, type-check and build still run on Node 22 as before. The step can be dropped once the job moves to Node 24, which bundles npm 11.

## Not changed

- The panel's lock file stays gitignored. Developers with the existing local lock are unaffected. A fresh clone hitting `npm install` in `packages/panel` on npm 10 will see the same crash until npm is upgraded.
- `--legacy-peer-deps` was rejected because it disables peer validation for the whole install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
