### PR TITLE
fix(core): register a model observer once for a replaced model

### DIFF
--- a/packages/core/src/Base/Traits/HasModelExtending.php
+++ b/packages/core/src/Base/Traits/HasModelExtending.php
@@ -5,6 +5,7 @@ namespace Lunar\Base\Traits;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Lunar\Base\BaseModel;
@@ -166,8 +167,66 @@ trait HasModelExtending
         }
 
         foreach (Arr::wrap($classes) as $class) {
+            if (static::observerIsAlreadyRegistered($instance, $class)) {
+                continue;
+            }
+
             $instance->registerObserver($class);
         }
+    }
+
+    /**
+     * Whether the given observer already listens to every event it would be registered for.
+     *
+     * Model events are dispatched twice for a replaced model: under its own class name, and
+     * under the Lunar model it replaces (see fireModelEvent()). Both classes boot their traits,
+     * so an observer registered from a trait boot - Scout's ModelObserver, for one - would be
+     * attached to both names and run twice for a single save.
+     */
+    protected static function observerIsAlreadyRegistered(Model $instance, object|string $class): bool
+    {
+        if (! static::$dispatcher instanceof Dispatcher) {
+            return false;
+        }
+
+        $observer = is_object($class) ? $class::class : $class;
+
+        $events = array_filter(
+            $instance->getObservableEvents(),
+            fn (string $event) => method_exists($class, $event)
+        );
+
+        if ($events === []) {
+            return false;
+        }
+
+        $modelClasses = array_unique([
+            $instance::class,
+            static::lunarModelClass($instance::class),
+        ]);
+
+        $listeners = static::$dispatcher->getRawListeners();
+
+        foreach ($events as $event) {
+            $registered = array_merge(...array_map(
+                fn (string $modelClass) => (array) ($listeners["eloquent.{$event}: {$modelClass}"] ?? []),
+                $modelClasses
+            ));
+
+            if (! in_array("{$observer}@{$event}", $registered, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The Lunar model a replacement re-dispatches its events under.
+     */
+    protected static function lunarModelClass(string $modelClass): string
+    {
+        return str_replace('Contracts\\', '', ModelManifest::guessContractClass($modelClass));
     }
 
     /**
@@ -178,7 +237,7 @@ trait HasModelExtending
         // Fire the actual models events
         $result = parent::fireModelEvent($event, $halt);
 
-        $lunarClass = str_replace('Contracts\\', '', ModelManifest::guessContractClass(static::class));
+        $lunarClass = static::lunarModelClass(static::class);
 
         if ($lunarClass == static::class) {
             return $result;

--- a/tests/core/Stubs/TestOrderObserver.php
+++ b/tests/core/Stubs/TestOrderObserver.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lunar\Tests\Core\Stubs;
+
+use Lunar\Models\Contracts\Order;
+
+class TestOrderObserver
+{
+    public static int $created = 0;
+
+    public function created(Order $order): void
+    {
+        static::$created++;
+    }
+}

--- a/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
+++ b/tests/core/Unit/Base/Traits/HasModelExtendingTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Scout\Jobs\MakeSearchable;
 use Lunar\Facades\ModelManifest;
 use Lunar\Models\Order;
 use Lunar\Models\Product;
@@ -10,6 +12,7 @@ use Lunar\Models\ProductOption;
 use Lunar\Tests\Core\Stubs\Models\Custom\CustomProduct;
 use Lunar\Tests\Core\Stubs\Models\Custom\DeepCustomProduct;
 use Lunar\Tests\Core\Stubs\Models\CustomOrder;
+use Lunar\Tests\Core\Stubs\TestOrderObserver;
 use Lunar\Tests\Core\Unit\Base\Extendable\ExtendableTestCase;
 
 uses(ExtendableTestCase::class)->group('model_extending');
@@ -119,4 +122,38 @@ test('multi-level extended model returns correct table name without prefix dupli
 
     // Ensure prefix is not duplicated
     expect($deepCustomProduct->getTable())->not->toContain(config('lunar.database.table_prefix').config('lunar.database.table_prefix'));
+});
+
+test('observers registered by a trait boot only run once for a replaced model', function () {
+    ModelManifest::replace(
+        Lunar\Models\Contracts\Order::class,
+        Lunar\Tests\Core\Stubs\Models\Order::class
+    );
+
+    // Both the Lunar model and its replacement boot their traits, and Scout registers its
+    // observer from `bootSearchable()`. Model events are dispatched under both class names, so
+    // the observer has to be registered for one of them only.
+    config(['scout.queue' => true]);
+
+    Queue::fake();
+
+    Lunar\Tests\Core\Stubs\Models\Order::factory()->create();
+
+    Queue::assertPushed(MakeSearchable::class, 1);
+});
+
+test('an observer registered on both the lunar model and its replacement runs once', function () {
+    ModelManifest::replace(
+        Lunar\Models\Contracts\Order::class,
+        Lunar\Tests\Core\Stubs\Models\Order::class
+    );
+
+    TestOrderObserver::$created = 0;
+
+    Order::observe(TestOrderObserver::class);
+    Lunar\Tests\Core\Stubs\Models\Order::observe(TestOrderObserver::class);
+
+    Lunar\Tests\Core\Stubs\Models\Order::factory()->create();
+
+    expect(TestOrderObserver::$created)->toBe(1);
 });


### PR DESCRIPTION
Closes #2722

### The bug

When a model is replaced through `ModelManifest::replace()`, an observer registered by a trait
boot is attached to both the replacement and the Lunar model it replaces, and therefore runs
twice for a single save.

`fireModelEvent()` dispatches each event under the concrete class *and* under the Lunar model.
Both classes boot their traits — the Lunar model is booted by `observe()` itself (`new static`),
which `LunarServiceProvider::registerObservers()` calls on the Lunar classes — so Laravel
Scout's `Searchable::bootSearchable()` registers `ModelObserver` under both names, and nothing
deduplicates them.

Measured: one `create()` on a replaced model pushes two `MakeSearchable` jobs. In our shop a
single Mollie checkout queued ten of them for one unpaid draft order, because the
order-creation pipeline saves the order five times. `spatie/laravel-activitylog` writes two
`activity_log` rows per save for the same reason (`Lunar\Models\Product` sidesteps it with
`$enableLoggingModelsEvents = false`).

### The fix

`observe()` skips an observer class that already listens, under either the resolved model's
class name or the Lunar model's, to *every* event `registerObserver()` would attach it to (same
`method_exists()` filter). The double dispatch is left alone, so observers registered against
the Lunar model keep working as documented. An observer with no matching event is handed to
`registerObserver()` untouched, so an unknown observer still throws Eloquent's *Unable to find
observer* exception.

The expression that resolves the Lunar model for a replacement already lived in
`fireModelEvent()`; it is now `lunarModelClass()` and shared by both call sites.

Two points I'd rather you decided than assumed:

- `Model::observe(SomeObserver::class)` called twice on the same class now registers once. That
  is the same duplicate this fixes, but it is a behaviour change against vanilla Eloquent.
- Should the fix instead prevent the Lunar model from booting at all when a replacement is
  registered? That removes the duplicate at its source, but only when `ModelManifest::replace()`
  runs before any `observe()` call on those models, so it does not hold in every boot order.

### Tests

`tests/core/Unit/Base/Traits/HasModelExtendingTest.php`, both failing on `1.x` today:

- *observers registered by a trait boot only run once for a replaced model* — one `create()` on
  a replaced model must queue one `MakeSearchable` job (currently *pushed 2 times instead of 1*).
  The same `create()` on a model that is not replaced already queues one, so the duplication is
  specific to replacement.
- *an observer registered on both the lunar model and its replacement runs once* — covers the
  failure mode the fix could introduce (an observer silently never registered) together with the
  documented forwarding of observers registered against the Lunar model. Uses a new
  `tests/core/Stubs/TestOrderObserver.php`.

Pint and PHPStan pass on the changed files; `tests/core` is green.

### Forward port

`main` rewrote the trait so that `registerModelEvent()` and `fireModelEvent()` both canonicalise
the event name; the two boots then register onto the *same* event name, so from reading the code
the `2.x` line looks affected too. I have not reproduced it there — flagging it for
`needs-forward-port` rather than claiming it.
