### PR TITLE
feat(panel): let an add-on build its own Tailwind CSS against the panel theme

### DIFF
--- a/packages/panel/resources/css/app.css
+++ b/packages/panel/resources/css/app.css
@@ -1,68 +1,10 @@
 @import 'tailwindcss';
 @import 'flag-icons/css/flag-icons.min.css';
 
+/* Shipped from the npm package so add-on builds can reference the same tokens. */
+@import '../panel-package/theme.css';
+
 @custom-variant dark (&:where(.dark, .dark *));
-
-@theme {
-  --color-ink-900: oklch(0.18 0.008 260);
-  --color-ink-700: oklch(0.32 0.008 260);
-  --color-ink-500: oklch(0.52 0.008 260);
-  --color-ink-400: oklch(0.62 0.008 260);
-  --color-ink-300: oklch(0.78 0.005 260);
-  --color-line: oklch(0.92 0.004 260);
-  --color-line-strong: oklch(0.86 0.006 260);
-  --color-paper: oklch(0.995 0.002 90);
-  --color-canvas: oklch(0.975 0.003 90);
-  --color-surface: oklch(1 0 0);
-  --color-surface-2: oklch(0.985 0.003 90);
-  --color-surface-3: oklch(0.96 0.004 260);
-  --color-active: oklch(0.95 0.006 260);
-  --color-paper-hover: oklch(0.92 0.005 90);
-  --color-sage: oklch(0.72 0.08 150);
-  --color-sage-ink: oklch(0.42 0.08 150);
-  --color-sage-soft: oklch(0.95 0.04 150);
-  --color-sage-border: oklch(0.86 0.06 150);
-  --color-danger: oklch(0.62 0.18 25);
-  --color-danger-soft: oklch(0.96 0.04 25);
-  --color-danger-border: oklch(0.86 0.08 25);
-  --color-warn: oklch(0.75 0.14 75);
-  --color-warn-ink: oklch(0.45 0.12 75);
-  --color-warn-soft: oklch(0.97 0.04 75);
-  --color-warn-border: oklch(0.88 0.08 75);
-
-  /* Chart palette: slot 1 is the brand hue (the icon blue, stepped into the
-     readable band); slots are assigned in fixed order and never cycled.
-     Values validated per the dataviz checks against both surfaces. */
-  --color-chart-1: oklch(0.60 0.13 228);
-  --color-chart-2: oklch(0.62 0.13 75);
-  --color-chart-3: oklch(0.60 0.11 165);
-  --color-chart-4: oklch(0.55 0.13 300);
-  --color-chart-1-soft: oklch(0.95 0.03 228);
-
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 10px;
-  --radius-xl: 14px;
-
-  --shadow-sm: 0 1px 2px rgba(17,24,39,0.04), 0 1px 1px rgba(17,24,39,0.02);
-  --shadow-md: 0 4px 10px -2px rgba(17,24,39,0.06), 0 2px 4px -2px rgba(17,24,39,0.04);
-  --shadow-lg: 0 10px 24px -8px rgba(17,24,39,0.12), 0 4px 8px -4px rgba(17,24,39,0.06);
-
-  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: "Geist Mono", ui-monospace, Menlo, monospace;
-
-  --animate-chip-in: chipIn 0.18s ease-out;
-  --animate-autosave-pulse: autosave-pulse 1.4s ease-out infinite;
-  --animate-shake: shake 0.36s cubic-bezier(.36,.07,.19,.97) both;
-  --animate-slide-in-right: slideInRight 0.24s cubic-bezier(0.32, 0.72, 0, 1);
-  --animate-slide-out-right: slideOutRight 0.18s cubic-bezier(0.32, 0, 0.67, 0);
-  --animate-overlay-in: overlayIn 0.2s ease-out;
-  --animate-overlay-out: overlayOut 0.15s ease-in;
-  --animate-dialog-in: dialogIn 0.18s cubic-bezier(0.32, 0.72, 0, 1);
-  --animate-dialog-out: dialogOut 0.14s cubic-bezier(0.32, 0, 0.67, 0);
-  --animate-palette-in: paletteIn 0.18s cubic-bezier(0.32, 0.72, 0, 1);
-  --animate-palette-out: paletteOut 0.13s cubic-bezier(0.32, 0, 0.67, 0);
-}
 
 .dark {
   --color-ink-900: oklch(0.96 0.004 260);

--- a/packages/panel/resources/panel-package/package.json
+++ b/packages/panel/resources/panel-package/package.json
@@ -16,11 +16,13 @@
         ".": {
             "types": "./dist/ui.d.ts",
             "default": "./index.js"
-        }
+        },
+        "./theme.css": "./theme.css"
     },
     "files": [
+        "dist",
         "index.js",
-        "dist"
+        "theme.css"
     ],
     "scripts": {
         "prepublishOnly": "npm --prefix ../.. run build:types"

--- a/packages/panel/resources/panel-package/theme.css
+++ b/packages/panel/resources/panel-package/theme.css
@@ -1,0 +1,85 @@
+/*
+ * The panel's design tokens, kept in the npm package so an add-on can pull
+ * them into its own Tailwind build.
+ *
+ * An add-on ships no copy of the panel's stylesheet: its bundle loads after
+ * the panel's, so anything it re-emits wins on document order and quietly
+ * restyles the panel around it. Importing this file with `theme(reference)`
+ * registers the tokens without emitting a single custom property, so the
+ * add-on's build generates `text-ink-400` and friends against the variables
+ * the panel has already put on the page:
+ *
+ *   @import 'tailwindcss/theme.css' theme(reference);
+ *   @import '@lunarphp/panel/theme.css' theme(reference);
+ *   @import 'tailwindcss/utilities.css';
+ *   @source './js';
+ *
+ * Nothing but `@theme` belongs here: Tailwind refuses a referenced import
+ * that contains anything else. An add-on wanting `dark:` variants declares
+ * `@custom-variant dark (&:where(.dark, .dark *));` in its own stylesheet,
+ * which matches the panel's and emits nothing by itself.
+ *
+ * The panel's own app.css imports it plainly, so these are emitted exactly
+ * once, from there.
+ */
+
+@theme {
+  --color-ink-900: oklch(0.18 0.008 260);
+  --color-ink-700: oklch(0.32 0.008 260);
+  --color-ink-500: oklch(0.52 0.008 260);
+  --color-ink-400: oklch(0.62 0.008 260);
+  --color-ink-300: oklch(0.78 0.005 260);
+  --color-line: oklch(0.92 0.004 260);
+  --color-line-strong: oklch(0.86 0.006 260);
+  --color-paper: oklch(0.995 0.002 90);
+  --color-canvas: oklch(0.975 0.003 90);
+  --color-surface: oklch(1 0 0);
+  --color-surface-2: oklch(0.985 0.003 90);
+  --color-surface-3: oklch(0.96 0.004 260);
+  --color-active: oklch(0.95 0.006 260);
+  --color-paper-hover: oklch(0.92 0.005 90);
+  --color-sage: oklch(0.72 0.08 150);
+  --color-sage-ink: oklch(0.42 0.08 150);
+  --color-sage-soft: oklch(0.95 0.04 150);
+  --color-sage-border: oklch(0.86 0.06 150);
+  --color-danger: oklch(0.62 0.18 25);
+  --color-danger-soft: oklch(0.96 0.04 25);
+  --color-danger-border: oklch(0.86 0.08 25);
+  --color-warn: oklch(0.75 0.14 75);
+  --color-warn-ink: oklch(0.45 0.12 75);
+  --color-warn-soft: oklch(0.97 0.04 75);
+  --color-warn-border: oklch(0.88 0.08 75);
+
+  /* Chart palette: slot 1 is the brand hue (the icon blue, stepped into the
+     readable band); slots are assigned in fixed order and never cycled.
+     Values validated per the dataviz checks against both surfaces. */
+  --color-chart-1: oklch(0.60 0.13 228);
+  --color-chart-2: oklch(0.62 0.13 75);
+  --color-chart-3: oklch(0.60 0.11 165);
+  --color-chart-4: oklch(0.55 0.13 300);
+  --color-chart-1-soft: oklch(0.95 0.03 228);
+
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-xl: 14px;
+
+  --shadow-sm: 0 1px 2px rgba(17,24,39,0.04), 0 1px 1px rgba(17,24,39,0.02);
+  --shadow-md: 0 4px 10px -2px rgba(17,24,39,0.06), 0 2px 4px -2px rgba(17,24,39,0.04);
+  --shadow-lg: 0 10px 24px -8px rgba(17,24,39,0.12), 0 4px 8px -4px rgba(17,24,39,0.06);
+
+  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, Menlo, monospace;
+
+  --animate-chip-in: chipIn 0.18s ease-out;
+  --animate-autosave-pulse: autosave-pulse 1.4s ease-out infinite;
+  --animate-shake: shake 0.36s cubic-bezier(.36,.07,.19,.97) both;
+  --animate-slide-in-right: slideInRight 0.24s cubic-bezier(0.32, 0.72, 0, 1);
+  --animate-slide-out-right: slideOutRight 0.18s cubic-bezier(0.32, 0, 0.67, 0);
+  --animate-overlay-in: overlayIn 0.2s ease-out;
+  --animate-overlay-out: overlayOut 0.15s ease-in;
+  --animate-dialog-in: dialogIn 0.18s cubic-bezier(0.32, 0.72, 0, 1);
+  --animate-dialog-out: dialogOut 0.14s cubic-bezier(0.32, 0, 0.67, 0);
+  --animate-palette-in: paletteIn 0.18s cubic-bezier(0.32, 0.72, 0, 1);
+  --animate-palette-out: paletteOut 0.13s cubic-bezier(0.32, 0, 0.67, 0);
+}

--- a/packages/panel/src/PanelManager.php
+++ b/packages/panel/src/PanelManager.php
@@ -393,7 +393,7 @@ class PanelManager
      * __buildSourcePath points at the module's compiled build directory on
      * disk so `lunar:panel:link` can symlink it into public/.
      *
-     * @param  array{input?: string|string[], hotFile?: string|null, buildDirectory?: string, __buildSourcePath?: string}|string|string[]  $config
+     * @param  array{input?: string|list<string>, hotFile?: string|null, buildDirectory?: string, __buildSourcePath?: string}|string|list<string>  $config
      */
     public function vite(string $name, array|string $config): static
     {


### PR DESCRIPTION
## The problem

An add-on that needs a Tailwind class the panel's own build never emitted has nowhere to get it.

Its bundle is loaded from `app.blade.php` after the panel's stylesheet, so a plain `@import 'tailwindcss'` in the add-on re-emits preflight, the theme variables and every utility the panel already ships, and wins on document order. The panel gets quietly restyled around the add-on. This came up on Discord recently, where the workaround was a custom Vite plugin to strip anything the panel already shipped back out of the add-on's CSS.

Avoiding it the other way — shipping no add-on stylesheet at all — restricts the add-on to whatever utilities the panel happens to use. Arbitrary values and opacity modifiers can never be among them, because they are generated per source file, so `text-[11px]`, `max-w-[900px]` and `bg-danger/5` silently do nothing. No error, no warning, no missing asset. On the add-on that prompted this, 17 distinct classes across 11 components were dead, one of them used 58 times.

## The change

The `@theme` block moves out of `resources/css/app.css` into `resources/panel-package/theme.css`, which `app.css` then imports. It lives in the npm package so an add-on can import it too, and `package.json` exports it.

An add-on can now reference the panel's tokens without emitting them:

```css
@import 'tailwindcss/theme.css' theme(reference);
@import '@lunarphp/panel/theme.css' theme(reference);
@import 'tailwindcss/utilities.css' source(none);

@source './js';
```

`theme(reference)` registers the tokens so `text-ink-400` and `bg-danger/5` can be generated, and emits no custom properties at all. `source(none)` plus one `@source` keeps the output to the classes that add-on actually uses. The result is a small utilities-only sheet whose rules resolve against the variables the panel has already put on the page, in both colour schemes.

Tailwind refuses a referenced import containing anything but `@theme`, so `@custom-variant dark` and the `.dark` overrides stay in `app.css`. The new file's header says so, and gives the add-on the one line to repeat for `dark:` variants.

`PanelManager::vite()` documented `input` as `string|string[]`, but the union's bare `string[]` arm collapsed the array shape, so PHPStan narrowed the parameter to `array<string>|string` and rejected the documented call:

```
Parameter #2 $config of method Lunar\Panel\PanelManager::vite() expects
array<string>|string, array<string, list<string>|string> given.
```

`list<string>` on both arms keeps the shape intact. That matters here because an add-on whose build cannot code split — the IIFE output every add-on uses, to share the panel's Vue and Inertia instances — receives its stylesheet as a separate `style.css` manifest entry rather than on the script chunk, so it has to be passed as a second entry point.

## Nothing in the panel changes

`app.css` compiles to the same file it did before the split: `app-DrcNYi_n.css`, same content hash, and `git status` reports the built CSS unmodified after a rebuild.

## Verified

On a real add-on (11 components, 98 distinct classes) building against this branch:

- the add-on sheet is 5.8 kB and emits **no** theme custom properties, no preflight and no base layer
- all 17 previously dead classes now resolve, arbitrary values and opacity modifiers included
- `text-ink-600` still produces nothing, correctly — it is not in the panel's ink scale, so the add-on was simply wrong
- in the browser, the add-on sheet loads last and `capitalize`, `object-contain` and `max-w-[1400px]` all compute, while every panel-owned style is untouched

94 of the add-on's 106 emitted classes also appear in the panel's sheet. They are byte-identical rules from the same Tailwind version and the same theme, so they cost ~5 kB and cannot conflict; the 12 that differ are the ones the add-on could not have had before.
